### PR TITLE
fix(logs): address Copilot review items from PR #11

### DIFF
--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/bnema/zerowrap"
@@ -272,8 +271,8 @@ func runTokenRevoke(tokenID, configPath string) error {
 func runPasswordHash() error {
 	fmt.Print("Enter password: ")
 
-	// Read password without echo
-	passwordBytes, err := term.ReadPassword(syscall.Stdin)
+	// Read password without echo (use os.Stdin.Fd() for better compatibility)
+	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		// Fallback for non-terminal input
 		reader := bufio.NewReader(os.Stdin)

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -910,6 +910,11 @@ func normalizeImageRef(image string) string {
 	//   user/repo:tag -> docker.io/user/repo
 	//   localhost:5000/image:tag -> localhost:5000/image
 	//   registry.example.com/image:tag -> registry.example.com/image
+	//
+	// Note: This function assumes valid Docker image references. Edge cases like
+	// "registry.com:5000" (registry with port but no image name) are not valid
+	// image references per Docker's naming conventions, which require at least
+	// one path component after the registry (e.g., "registry.com:5000/image").
 
 	// Find the tag separator: the last colon that isn't part of a port number.
 	// A colon is part of a port if there's no slash after it until the next colon.


### PR DESCRIPTION
## Summary
- Fix infinite loop in `followFile` - now handles SIGINT/SIGTERM for graceful Ctrl+C cleanup
- Implement ring buffer in `tailFile` for memory-efficient log tailing (no longer loads entire file)
- Replace deprecated `syscall.Stdin` with `os.Stdin.Fd()` for better compatibility
- Add edge case documentation to `normalizeImageRef` explaining Docker image reference requirements
- Add signal cleanup documentation in `runServers`

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] Lint passes (`make lint`)
- [ ] Manual test: `gordon logs -f` and Ctrl+C exits cleanly
- [ ] Manual test: `gordon logs` on large log file doesn't spike memory