### PR TITLE
fix(docs): correct logging structure and remove broken link

### DIFF
--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -70,10 +70,8 @@ max_age = 28
 ├── gordon.log              # Main application logs
 ├── gordon.log.1            # Rotated log
 ├── gordon.log.2.gz         # Compressed old log
-├── proxy.log               # HTTP proxy traffic
 └── containers/
-    ├── abc123def.log       # Container by ID
-    ├── app_mydomain_com.log  # Symlink by domain
+    ├── app_mydomain_com.log  # Container logs by domain
     └── api_mydomain_com.log
 ```
 

--- a/wiki/examples/minimal.md
+++ b/wiki/examples/minimal.md
@@ -93,5 +93,4 @@ enabled = true
 
 ## Related
 
-- [Development Configuration](./development.md)
 - [Production Configuration](./production.md)


### PR DESCRIPTION
## Summary

- Remove non-existent `proxy.log` from log directory structure documentation
- Fix container log file naming (logs are named by domain, not container ID)
- Remove incorrect symlink claim from documentation
- Remove broken link to non-existent `development.md`

## Test plan

- [x] Verified documentation now matches actual code behavior in `logwriter.go`
- [x] Verified linked files exist