### PR TITLE
fix(auth): prevent access tokens from overwriting CLI tokens

### DIFF
--- a/internal/adapters/in/http/middleware/auth_test.go
+++ b/internal/adapters/in/http/middleware/auth_test.go
@@ -481,6 +481,10 @@ func (s stubAuthService) GenerateToken(context.Context, string, []string, time.D
 	return "", errors.New("not implemented")
 }
 
+func (s stubAuthService) GenerateAccessToken(context.Context, string, []string, time.Duration) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (s stubAuthService) RevokeToken(context.Context, string) error {
 	return errors.New("not implemented")
 }

--- a/internal/adapters/in/http/registry/token.go
+++ b/internal/adapters/in/http/registry/token.go
@@ -111,8 +111,8 @@ func (h *TokenHandler) handleToken(w http.ResponseWriter, r *http.Request) {
 	// Format: scope=repository:name:action1,action2 (can appear multiple times)
 	requestedScopes := h.parseRequestedScopes(r, log)
 
-	// Generate a short-lived access token (5 minutes)
-	accessToken, err := h.authSvc.GenerateToken(ctx, username, requestedScopes, 5*time.Minute)
+	// Generate a short-lived access token (5 minutes) - not stored
+	accessToken, err := h.authSvc.GenerateAccessToken(ctx, username, requestedScopes, 5*time.Minute)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to generate access token")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/internal/boundaries/in/auth.go
+++ b/internal/boundaries/in/auth.go
@@ -23,9 +23,13 @@ type AuthService interface {
 	// ValidateToken validates a JWT token and returns its claims.
 	ValidateToken(ctx context.Context, tokenString string) (*domain.TokenClaims, error)
 
-	// GenerateToken creates a new JWT token for the given subject.
+	// GenerateToken creates a new JWT token for the given subject and stores it.
 	// If expiry is 0, the token never expires.
 	GenerateToken(ctx context.Context, subject string, scopes []string, expiry time.Duration) (string, error)
+
+	// GenerateAccessToken creates a short-lived JWT for registry access without storing it.
+	// Used by /v2/token endpoint for Docker client sessions.
+	GenerateAccessToken(ctx context.Context, subject string, scopes []string, expiry time.Duration) (string, error)
 
 	// RevokeToken revokes a token by its ID.
 	RevokeToken(ctx context.Context, tokenID string) error

--- a/internal/boundaries/in/mocks/mock_auth_service.go
+++ b/internal/boundaries/in/mocks/mock_auth_service.go
@@ -39,6 +39,84 @@ func (_m *MockAuthService) EXPECT() *MockAuthService_Expecter {
 	return &MockAuthService_Expecter{mock: &_m.Mock}
 }
 
+// GenerateAccessToken provides a mock function for the type MockAuthService
+func (_mock *MockAuthService) GenerateAccessToken(ctx context.Context, subject string, scopes []string, expiry time.Duration) (string, error) {
+	ret := _mock.Called(ctx, subject, scopes, expiry)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GenerateAccessToken")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, time.Duration) (string, error)); ok {
+		return returnFunc(ctx, subject, scopes, expiry)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []string, time.Duration) string); ok {
+		r0 = returnFunc(ctx, subject, scopes, expiry)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []string, time.Duration) error); ok {
+		r1 = returnFunc(ctx, subject, scopes, expiry)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAuthService_GenerateAccessToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GenerateAccessToken'
+type MockAuthService_GenerateAccessToken_Call struct {
+	*mock.Call
+}
+
+// GenerateAccessToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subject string
+//   - scopes []string
+//   - expiry time.Duration
+func (_e *MockAuthService_Expecter) GenerateAccessToken(ctx interface{}, subject interface{}, scopes interface{}, expiry interface{}) *MockAuthService_GenerateAccessToken_Call {
+	return &MockAuthService_GenerateAccessToken_Call{Call: _e.mock.On("GenerateAccessToken", ctx, subject, scopes, expiry)}
+}
+
+func (_c *MockAuthService_GenerateAccessToken_Call) Run(run func(ctx context.Context, subject string, scopes []string, expiry time.Duration)) *MockAuthService_GenerateAccessToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []string
+		if args[2] != nil {
+			arg2 = args[2].([]string)
+		}
+		var arg3 time.Duration
+		if args[3] != nil {
+			arg3 = args[3].(time.Duration)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAuthService_GenerateAccessToken_Call) Return(s string, err error) *MockAuthService_GenerateAccessToken_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockAuthService_GenerateAccessToken_Call) RunAndReturn(run func(ctx context.Context, subject string, scopes []string, expiry time.Duration) (string, error)) *MockAuthService_GenerateAccessToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GeneratePasswordHash provides a mock function for the type MockAuthService
 func (_mock *MockAuthService) GeneratePasswordHash(password string) (string, error) {
 	ret := _mock.Called(password)

--- a/internal/usecase/auth/service_test.go
+++ b/internal/usecase/auth/service_test.go
@@ -201,8 +201,110 @@ func TestService_GenerateAccessToken_NoStorage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "testuser", claims.Subject)
 	assert.Contains(t, claims.Scopes, "repository:myrepo:push,pull")
-	// Access token should have short expiry (5 min = 300 seconds)
-	assert.True(t, claims.ExpiresAt-claims.IssuedAt <= 300)
+	// Access token should have exactly 5 min expiry (allow 2 sec tolerance for test execution)
+	assert.InDelta(t, 300, claims.ExpiresAt-claims.IssuedAt, 2)
+}
+
+func TestService_GenerateAccessToken_RejectsInvalidExpiry(t *testing.T) {
+	tokenStore := mocks.NewMockTokenStore(t)
+
+	svc := NewService(Config{
+		Enabled:     true,
+		AuthType:    domain.AuthTypeToken,
+		TokenSecret: []byte("test-secret-key-for-jwt-signing"),
+	}, tokenStore, zerowrap.Default())
+
+	ctx := testContext()
+
+	// Zero expiry should be rejected
+	_, err := svc.GenerateAccessToken(ctx, "testuser", []string{"repository:myrepo:pull"}, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expiry must be positive")
+
+	// Negative expiry should be rejected
+	_, err = svc.GenerateAccessToken(ctx, "testuser", []string{"repository:myrepo:pull"}, -time.Minute)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expiry must be positive")
+
+	// Expiry exceeding max should be rejected
+	_, err = svc.GenerateAccessToken(ctx, "testuser", []string{"repository:myrepo:pull"}, 10*time.Minute)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestService_ValidateToken_LongLivedRequiresStore(t *testing.T) {
+	// Tokens with expiry > 5 minutes must exist in store
+	tokenStore := mocks.NewMockTokenStore(t)
+
+	svc := NewService(Config{
+		Enabled:     true,
+		AuthType:    domain.AuthTypeToken,
+		TokenSecret: []byte("test-secret-key-for-jwt-signing"),
+	}, tokenStore, zerowrap.Default())
+
+	ctx := testContext()
+
+	// Generate a long-lived token (stored)
+	var capturedToken *domain.Token
+	tokenStore.EXPECT().
+		SaveToken(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, t *domain.Token, _ string) {
+			capturedToken = t
+		}).
+		Return(nil)
+
+	token, err := svc.GenerateToken(ctx, "testuser", []string{"push", "pull"}, time.Hour)
+	assert.NoError(t, err)
+
+	// Validation should call GetToken and IsRevoked
+	tokenStore.EXPECT().
+		GetToken(mock.Anything, "testuser").
+		Return(token, capturedToken, nil)
+	tokenStore.EXPECT().
+		IsRevoked(mock.Anything, capturedToken.ID).
+		Return(false, nil)
+
+	claims, err := svc.ValidateToken(ctx, token)
+	assert.NoError(t, err)
+	assert.Equal(t, "testuser", claims.Subject)
+}
+
+func TestService_ValidateToken_NeverExpiringRequiresStore(t *testing.T) {
+	// Tokens with ExpiresAt = 0 (never expires) must exist in store
+	tokenStore := mocks.NewMockTokenStore(t)
+
+	svc := NewService(Config{
+		Enabled:     true,
+		AuthType:    domain.AuthTypeToken,
+		TokenSecret: []byte("test-secret-key-for-jwt-signing"),
+	}, tokenStore, zerowrap.Default())
+
+	ctx := testContext()
+
+	// Generate a never-expiring token (stored)
+	var capturedToken *domain.Token
+	tokenStore.EXPECT().
+		SaveToken(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, t *domain.Token, _ string) {
+			capturedToken = t
+		}).
+		Return(nil)
+
+	token, err := svc.GenerateToken(ctx, "ci-bot", []string{"push", "pull"}, 0)
+	assert.NoError(t, err)
+
+	// Validation should call GetToken and IsRevoked (not bypass store)
+	tokenStore.EXPECT().
+		GetToken(mock.Anything, "ci-bot").
+		Return(token, capturedToken, nil)
+	tokenStore.EXPECT().
+		IsRevoked(mock.Anything, capturedToken.ID).
+		Return(false, nil)
+
+	claims, err := svc.ValidateToken(ctx, token)
+	assert.NoError(t, err)
+	assert.Equal(t, "ci-bot", claims.Subject)
+	assert.Equal(t, int64(0), claims.ExpiresAt) // Never expires
 }
 
 func TestService_ValidateToken_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes 401 Unauthorized error after successful `docker login`
- Root cause: `/v2/token` endpoint stored short-lived access tokens, overwriting CLI-generated tokens (both keyed by subject)
- When Docker sent the original CLI token on subsequent requests, the token ID mismatch caused 401

## Changes

- Add `GenerateAccessToken` method that signs JWT without storing
- Skip store validation for short-lived access tokens (≤5min expiry)
- Update `/v2/token` endpoint to use `GenerateAccessToken`
- Add unit test for ephemeral access token generation

## Test plan

- [x] All existing tests pass
- [x] New unit test for `GenerateAccessToken` confirms no storage
- [ ] Manual test: `docker login` followed by `docker push` should succeed