### PR TITLE
docs(external-routes): remove misleading Docker Registry example

### DIFF
--- a/docs/config/external-routes.md
+++ b/docs/config/external-routes.md
@@ -6,7 +6,7 @@ External routes allow proxying to non-containerized services running on the host
 
 ```toml
 [external_routes]
-"service.mydomain.com" = "localhost:5000"
+"service.mydomain.com" = "localhost:3000"
 "cache.mydomain.com" = "192.168.1.100:6379"
 ```
 
@@ -24,15 +24,6 @@ External routes allow proxying to non-containerized services running on the host
 | `port` | Target port number |
 
 ## Use Cases
-
-### Docker Registry
-
-Proxy to a Docker registry running outside of Gordon:
-
-```toml
-[external_routes]
-"registry.mydomain.com" = "localhost:5000"
-```
 
 ### Database Admin Tools
 


### PR DESCRIPTION
## Summary
- Remove the Docker Registry example from external routes documentation

The example was misleading because Gordon's built-in registry is always enabled by default on port 5000. The example showed proxying to `localhost:5000` which would conflict with the default configuration.

## Test plan
- [ ] Verify documentation renders correctly