### PR TITLE
docs(install): add quick install script and fix logs user service fallback

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,18 +11,10 @@ Deploy your first app with Gordon in under 5 minutes.
 ## 1. Install Gordon
 
 ```bash
-# Download the latest release (choose your architecture)
-# For x86_64:
-wget https://github.com/bnema/gordon/releases/latest/download/gordon_linux_amd64.tar.gz
-tar -xzf gordon_linux_amd64.tar.gz
-
-# For ARM64 (Raspberry Pi 4, AWS Graviton, etc.):
-# wget https://github.com/bnema/gordon/releases/latest/download/gordon_linux_arm64.tar.gz
-# tar -xzf gordon_linux_arm64.tar.gz
-
-chmod +x gordon
-sudo mv gordon /usr/local/bin/
+curl -fsSL https://gordon.bnema.dev/install | bash
 ```
+
+This script automatically detects your OS and architecture, downloads the appropriate binary, and installs it to `/usr/local/bin`.
 
 ## 2. Start Gordon
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,15 @@ Detailed installation guide for production environments.
 
 ## Download Gordon
 
-### From GitHub Releases
+### Quick Install (Recommended)
+
+```bash
+curl -fsSL https://gordon.bnema.dev/install | bash
+```
+
+This script automatically detects your OS (Linux/macOS) and architecture (amd64/arm64), downloads the appropriate binary from GitHub releases, and installs it to `/usr/local/bin`.
+
+### Manual Installation
 
 **Linux (x86_64)**
 ```bash


### PR DESCRIPTION
## Summary

- Simplify installation documentation with curl-based quick install script (`curl -fsSL https://gordon.bnema.dev/install | bash`)
- Improve journalctl log retrieval to try user service first, then fall back to system service

## Test plan

- [ ] Verify install script URL is accessible
- [ ] Test `gordon logs` with user systemd service
- [ ] Test `gordon logs` fallback to system service