### PR TITLE
fix(deploy): preserve tracked container during orphan cleanup + add install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -e
+
+# Gordon installer script
+# Usage: curl -fsSL https://gordon.bnema.dev/install | bash
+
+REPO="bnema/gordon"
+INSTALL_DIR="/usr/local/bin"
+
+echo "Installing Gordon..."
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+    linux)
+        OS="linux"
+        ;;
+    darwin)
+        OS="darwin"
+        ;;
+    *)
+        echo "Error: Unsupported operating system: $OS"
+        exit 1
+        ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64|amd64)
+        ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        ARCH="arm64"
+        ;;
+    *)
+        echo "Error: Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+echo "Detected: ${OS}/${ARCH}"
+
+# Construct download URL
+TARBALL="gordon_${OS}_${ARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${TARBALL}"
+
+# Create temporary directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading ${TARBALL}..."
+curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/$TARBALL"
+
+echo "Extracting..."
+tar -xzf "$TMP_DIR/$TARBALL" -C "$TMP_DIR"
+
+echo "Installing to ${INSTALL_DIR}..."
+if [ -w "$INSTALL_DIR" ]; then
+    mv "$TMP_DIR/gordon" "$INSTALL_DIR/gordon"
+else
+    echo "sudo required to install to ${INSTALL_DIR}"
+    sudo mv "$TMP_DIR/gordon" "$INSTALL_DIR/gordon"
+fi
+
+# Verify installation
+if command -v gordon >/dev/null 2>&1; then
+    echo ""
+    echo "Gordon installed successfully!"
+    gordon version
+else
+    echo ""
+    echo "Installation complete. You may need to add ${INSTALL_DIR} to your PATH."
+fi


### PR DESCRIPTION
## Summary

- Fix zero-downtime deployment bug where the old container was stopped before the new one was ready
- Modified `cleanupOrphanedContainers()` to accept a `skipContainerID` parameter to preserve tracked containers
- Added two unit tests to verify orphan cleanup correctly skips tracked containers while still removing true orphans
- Added `install.sh` script for quick installation via curl

## Problem

During deployments, users experienced ~9 seconds of 503 errors because the orphan cleanup was removing containers by name only, without checking if they were already tracked by the service. This caused the running container to be stopped before the new one was ready.

## Install Script

Added a quick install script that:
- Detects OS (linux/darwin) and architecture (amd64/arm64)
- Downloads the latest release from GitHub
- Installs gordon to `/usr/local/bin`

Usage:
```bash
curl -fsSL https://gordon.bnema.dev/install | bash
```

## Test plan

- [x] All existing tests pass (57 tests)
- [x] Added `TestService_Deploy_OrphanCleanupSkipsTrackedContainer` - verifies tracked containers are preserved
- [x] Added `TestService_Deploy_OrphanCleanupRemovesTrueOrphans` - verifies true orphans are still cleaned up
- [ ] Deploy to production and verify no 503 errors during deployment
- [ ] Check journalctl logs for proper zero-downtime sequence
- [ ] Test install script on linux/darwin