### PR TITLE
fix: use static checksums.txt filename in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,9 @@ builds:
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
+checksum:
+  name_template: "checksums.txt"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary
- Configures goreleaser to use static `checksums.txt` filename instead of versioned `gordon_X.Y.Z_checksums.txt`
- Fixes the installer which expects the file at `/releases/latest/download/checksums.txt`

## Root cause
GoReleaser's default checksum filename includes the version, but the installer uses the `/latest/download/` URL pattern which requires a predictable filename.

## Test plan
- [ ] Create a new release and verify `checksums.txt` is in the assets
- [ ] Run installer: `curl -fsSL https://raw.githubusercontent.com/bnema/gordon/main/install.sh | sh`