### PR TITLE
feat: add human-friendly duration parser for token expiry

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -386,8 +386,23 @@ gordon auth token generate --subject <name> [options]
 |--------|---------|-------------|
 | `--subject` | (required) | Username/subject for the token |
 | `--scopes` | `push,pull` | Comma-separated scopes |
-| `--expiry` | `720h` | Duration until expiry (0 = never) |
+| `--expiry` | `30d` | Duration until expiry (0 = never) |
 | `-c, --config` | Auto | Path to config file |
+
+**Duration format:**
+
+Supports human-friendly duration units:
+
+| Unit | Description | Example |
+|------|-------------|---------|
+| `d` | Days (24 hours) | `30d` |
+| `w` | Weeks (7 days) | `2w` |
+| `M` | Months (30 days) | `6M` |
+| `y` | Years (365 days) | `1y` |
+
+Compound durations are also supported: `1y6M`, `2w3d`, `1d12h`
+
+Standard Go durations also work: `24h`, `30m`, `1h30m`
 
 **Examples:**
 
@@ -395,14 +410,17 @@ gordon auth token generate --subject <name> [options]
 # CI token that never expires
 gordon auth token generate --subject github-actions --expiry 0
 
-# Read-only token
-gordon auth token generate --subject reader --scopes pull --expiry 720h
+# Read-only token for 30 days
+gordon auth token generate --subject reader --scopes pull --expiry 30d
 
-# Push-only token for build system
-gordon auth token generate --subject builder --scopes push --expiry 0
+# Push-only token for 1 year
+gordon auth token generate --subject builder --scopes push --expiry 1y
 
 # Temporary token (24 hours)
 gordon auth token generate --subject temp --expiry 24h
+
+# Token for 6 months
+gordon auth token generate --subject deploy --expiry 6M
 ```
 
 **Output:**

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -46,7 +46,7 @@ type = "token"                           # "password" or "token"
 # password_hash = "gordon/registry/password_hash"
 # Token auth:
 token_secret = "gordon/registry/token_secret"
-token_expiry = "720h"                    # Duration or 0 for never
+token_expiry = "30d"                     # Duration (1y, 30d, 2w) or 0 for never
 
 # Deploy behavior
 [deploy]
@@ -134,7 +134,7 @@ enabled = false                          # Auto-create routes from image names
 | `secrets.backend` | `"unsafe"` |
 | `registry_auth.enabled` | `false` |
 | `registry_auth.type` | `"password"` |
-| `registry_auth.token_expiry` | `"720h"` |
+| `registry_auth.token_expiry` | `"30d"` |
 | `deploy.pull_policy` | `"if-tag-changed"` |
 | `logging.level` | `"info"` |
 | `logging.format` | `"console"` |

--- a/docs/config/registry-auth.md
+++ b/docs/config/registry-auth.md
@@ -27,7 +27,7 @@ token_expiry = "720h"                          # Duration or 0 for never
 | `username` | string | - | Username for password auth |
 | `password_hash` | string | - | Path to bcrypt hash in secrets backend |
 | `token_secret` | string | - | Path to JWT signing secret in secrets backend |
-| `token_expiry` | string | `"720h"` | Token validity duration (0 = never expires) |
+| `token_expiry` | string | `"30d"` | Token validity duration (0 = never expires). Supports: d (days), w (weeks), M (months), y (years) |
 
 ## Authentication Types
 
@@ -43,7 +43,7 @@ backend = "pass"
 enabled = true
 type = "token"
 token_secret = "gordon/registry/token_secret"
-token_expiry = "720h"  # 30 days, or "0" for never
+token_expiry = "30d"  # 30 days, or "0" for never. Also: 1y, 2w, 6M
 ```
 
 **Setup:**
@@ -113,7 +113,7 @@ Tokens can have different permission levels:
 
 ```bash
 # Pull-only token (for read-only access)
-gordon auth token generate --subject reader --scopes pull --expiry 720h
+gordon auth token generate --subject reader --scopes pull --expiry 30d
 
 # Push-only token (for CI builds)
 gordon auth token generate --subject builder --scopes push --expiry 0
@@ -121,17 +121,26 @@ gordon auth token generate --subject builder --scopes push --expiry 0
 
 ## Token Expiry
 
-Control how long tokens remain valid:
+Control how long tokens remain valid. Supports human-friendly units:
+- `d` - days (24 hours)
+- `w` - weeks (7 days)
+- `M` - months (30 days)
+- `y` - years (365 days)
+
+Compound durations work too: `1y6M`, `2w3d`
 
 ```bash
 # Never expires (for CI/CD)
 gordon auth token generate --subject ci --expiry 0
 
-# Expires in 30 days
-gordon auth token generate --subject temp --expiry 720h
+# Expires in 1 year
+gordon auth token generate --subject deploy --expiry 1y
 
-# Expires in 24 hours
-gordon auth token generate --subject short --expiry 24h
+# Expires in 30 days
+gordon auth token generate --subject temp --expiry 30d
+
+# Expires in 2 weeks
+gordon auth token generate --subject short --expiry 2w
 ```
 
 ## Instance-Specific Tokens

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -52,6 +52,9 @@ import (
 	"gordon/internal/usecase/proxy"
 	registrySvc "gordon/internal/usecase/registry"
 	secretsSvc "gordon/internal/usecase/secrets"
+
+	// Pkg
+	"gordon/pkg/duration"
 )
 
 // Config holds the application configuration.
@@ -640,7 +643,7 @@ func parseTokenExpiry(expiry string) (time.Duration, error) {
 		return 0, nil
 	}
 
-	parsed, err := time.ParseDuration(expiry)
+	parsed, err := duration.Parse(expiry)
 	if err != nil {
 		return 0, fmt.Errorf("invalid token_expiry: %w", err)
 	}

--- a/pkg/duration/parse.go
+++ b/pkg/duration/parse.go
@@ -1,0 +1,127 @@
+// Package duration provides human-friendly duration parsing.
+package duration
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Common duration constants for human-friendly units.
+const (
+	Day   = 24 * time.Hour
+	Week  = 7 * Day
+	Month = 30 * Day  // Approximate
+	Year  = 365 * Day // Approximate
+)
+
+// unitMultipliers maps human-friendly unit suffixes to their duration values.
+var unitMultipliers = map[string]time.Duration{
+	"d": Day,
+	"w": Week,
+	"M": Month, // Capital M for months to distinguish from minutes
+	"y": Year,
+}
+
+// durationPattern matches duration components like "1y", "6M", "2w", "3d".
+var durationPattern = regexp.MustCompile(`(\d+)([ywMd])`)
+
+// Parse extends time.ParseDuration to support human-friendly units:
+//   - d (days) = 24h
+//   - w (weeks) = 7d
+//   - M (months) = 30d (approximate)
+//   - y (years) = 365d (approximate)
+//
+// Standard Go duration units (ns, us, ms, s, m, h) are also supported.
+// Compound durations like "1y6M" or "2w3d" or "1d12h" work as expected.
+//
+// Special case: "0" returns 0 duration (useful for never-expiring tokens).
+//
+// Examples:
+//
+//	Parse("1d")      // 24 hours
+//	Parse("2w")      // 14 days
+//	Parse("1M")      // 30 days
+//	Parse("1y")      // 365 days
+//	Parse("1y6M")    // 1 year and 6 months
+//	Parse("2w3d")    // 2 weeks and 3 days
+//	Parse("1d12h")   // 1 day and 12 hours
+//	Parse("24h")     // standard Go duration
+//	Parse("0")       // zero duration
+func Parse(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+
+	if s == "" {
+		return 0, fmt.Errorf("empty duration string")
+	}
+
+	// Special case: "0" means no expiry
+	if s == "0" {
+		return 0, nil
+	}
+
+	// Check if the string contains any human-friendly units
+	if !containsHumanUnits(s) {
+		// Fall back to standard Go parsing
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w (supported units: ns, us, ms, s, m, h, d, w, M, y)", s, err)
+		}
+		return d, nil
+	}
+
+	// Parse human-friendly units
+	return parseHumanDuration(s)
+}
+
+// containsHumanUnits checks if the string contains any human-friendly unit suffixes.
+func containsHumanUnits(s string) bool {
+	for unit := range unitMultipliers {
+		if strings.Contains(s, unit) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseHumanDuration parses a duration string containing human-friendly units.
+func parseHumanDuration(s string) (time.Duration, error) {
+	var total time.Duration
+	remaining := s
+
+	// First, extract all human-friendly units (y, M, w, d)
+	matches := durationPattern.FindAllStringSubmatch(remaining, -1)
+	if len(matches) > 0 {
+		for _, match := range matches {
+			value, err := strconv.ParseInt(match[1], 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid duration value %q in %q", match[1], s)
+			}
+
+			unit := match[2]
+			multiplier, ok := unitMultipliers[unit]
+			if !ok {
+				return 0, fmt.Errorf("unknown duration unit %q in %q", unit, s)
+			}
+
+			total += time.Duration(value) * multiplier
+		}
+
+		// Remove the matched human-friendly parts
+		remaining = durationPattern.ReplaceAllString(remaining, "")
+	}
+
+	// If there's remaining content, try to parse it as standard Go duration
+	remaining = strings.TrimSpace(remaining)
+	if remaining != "" {
+		d, err := time.ParseDuration(remaining)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w (supported units: ns, us, ms, s, m, h, d, w, M, y)", s, err)
+		}
+		total += d
+	}
+
+	return total, nil
+}

--- a/pkg/duration/parse_test.go
+++ b/pkg/duration/parse_test.go
@@ -1,0 +1,132 @@
+package duration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		// Single human-friendly units
+		{name: "1 day", input: "1d", want: Day},
+		{name: "2 days", input: "2d", want: 2 * Day},
+		{name: "1 week", input: "1w", want: Week},
+		{name: "2 weeks", input: "2w", want: 2 * Week},
+		{name: "1 month", input: "1M", want: Month},
+		{name: "3 months", input: "3M", want: 3 * Month},
+		{name: "1 year", input: "1y", want: Year},
+		{name: "2 years", input: "2y", want: 2 * Year},
+
+		// Compound human-friendly units
+		{name: "1 year 6 months", input: "1y6M", want: Year + 6*Month},
+		{name: "2 weeks 3 days", input: "2w3d", want: 2*Week + 3*Day},
+		{name: "1 year 2 months 1 week", input: "1y2M1w", want: Year + 2*Month + Week},
+
+		// Mixed with standard Go units
+		{name: "1 day 12 hours", input: "1d12h", want: Day + 12*time.Hour},
+		{name: "2 weeks 6 hours", input: "2w6h", want: 2*Week + 6*time.Hour},
+		{name: "1 month 1 day 1 hour", input: "1M1d1h", want: Month + Day + time.Hour},
+		{name: "1 year 30 minutes", input: "1y30m", want: Year + 30*time.Minute},
+
+		// Standard Go duration units (fallback)
+		{name: "24 hours", input: "24h", want: 24 * time.Hour},
+		{name: "30 minutes", input: "30m", want: 30 * time.Minute},
+		{name: "1 hour 30 minutes", input: "1h30m", want: time.Hour + 30*time.Minute},
+		{name: "1 second", input: "1s", want: time.Second},
+		{name: "500 milliseconds", input: "500ms", want: 500 * time.Millisecond},
+		{name: "1000 microseconds", input: "1000us", want: 1000 * time.Microsecond},
+		{name: "1000000 nanoseconds", input: "1000000ns", want: 1000000 * time.Nanosecond},
+
+		// Special cases
+		{name: "zero duration", input: "0", want: 0},
+		{name: "zero with unit", input: "0d", want: 0},
+		{name: "zero hours", input: "0h", want: 0},
+
+		// Large values
+		{name: "10 years", input: "10y", want: 10 * Year},
+		{name: "52 weeks", input: "52w", want: 52 * Week},
+		{name: "365 days", input: "365d", want: 365 * Day},
+
+		// Edge cases with whitespace (should be trimmed)
+		{name: "whitespace around", input: "  1d  ", want: Day},
+
+		// Error cases
+		{name: "empty string", input: "", wantErr: true},
+		{name: "invalid format", input: "abc", wantErr: true},
+		{name: "invalid unit", input: "1x", wantErr: true},
+		{name: "missing value", input: "d", wantErr: true},
+		{name: "negative not supported by Go", input: "-1d", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Parse(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConstants(t *testing.T) {
+	// Verify our constants are correct
+	if Day != 24*time.Hour {
+		t.Errorf("Day = %v, want %v", Day, 24*time.Hour)
+	}
+	if Week != 7*24*time.Hour {
+		t.Errorf("Week = %v, want %v", Week, 7*24*time.Hour)
+	}
+	if Month != 30*24*time.Hour {
+		t.Errorf("Month = %v, want %v", Month, 30*24*time.Hour)
+	}
+	if Year != 365*24*time.Hour {
+		t.Errorf("Year = %v, want %v", Year, 365*24*time.Hour)
+	}
+}
+
+func TestParseEquivalences(t *testing.T) {
+	// Test that our human-friendly units produce expected equivalences
+	tests := []struct {
+		name  string
+		human string
+		goStd string
+		hours int
+	}{
+		{name: "1 day = 24 hours", human: "1d", goStd: "24h", hours: 24},
+		{name: "1 week = 168 hours", human: "1w", goStd: "168h", hours: 168},
+		{name: "1 month = 720 hours", human: "1M", goStd: "720h", hours: 720},
+		{name: "1 year = 8760 hours", human: "1y", goStd: "8760h", hours: 8760},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			humanDur, err := Parse(tt.human)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.human, err)
+			}
+
+			goDur, err := time.ParseDuration(tt.goStd)
+			if err != nil {
+				t.Fatalf("time.ParseDuration(%q) error = %v", tt.goStd, err)
+			}
+
+			if humanDur != goDur {
+				t.Errorf("Parse(%q) = %v, want %v (from %q)", tt.human, humanDur, goDur, tt.goStd)
+			}
+
+			expectedHours := time.Duration(tt.hours) * time.Hour
+			if humanDur != expectedHours {
+				t.Errorf("Parse(%q) = %v, want %d hours", tt.human, humanDur, tt.hours)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add new `pkg/duration` package that extends Go's `time.ParseDuration` to support human-friendly units
- Support for days (`d`), weeks (`w`), months (`M`), and years (`y`)
- Compound durations work: `1y6M`, `2w3d`, `1d12h`
- Update CLI and config to use the new parser
- Change default token expiry from `720h` to `30d` for readability

## Test plan

- [x] Run `go test ./pkg/duration/... -v` - all tests pass
- [x] Run `make lint` - no issues
- [x] Build succeeds
- [ ] Deploy to VPS and test: `gordon auth token generate --subject test --expiry 1y`