### PR TITLE
feat: expose route network and attachments in API

### DIFF
--- a/internal/adapters/dto/route.go
+++ b/internal/adapters/dto/route.go
@@ -1,0 +1,20 @@
+// Package dto provides shared data transfer objects for API responses.
+package dto
+
+// RouteInfo represents route details in API responses.
+type RouteInfo struct {
+	Domain          string       `json:"domain"`
+	Image           string       `json:"image"`
+	ContainerID     string       `json:"container_id"`
+	ContainerStatus string       `json:"container_status"`
+	Network         string       `json:"network"`
+	Attachments     []Attachment `json:"attachments"`
+}
+
+// Attachment represents an attached service in API responses.
+type Attachment struct {
+	Name        string `json:"name"`
+	Image       string `json:"image"`
+	ContainerID string `json:"container_id"`
+	Status      string `json:"status"`
+}

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -119,6 +119,22 @@ func parseResponse(resp *http.Response, target any) error {
 
 // Routes API
 
+type RouteInfo struct {
+	Domain          string       `json:"domain"`
+	Image           string       `json:"image"`
+	ContainerID     string       `json:"container_id"`
+	ContainerStatus string       `json:"container_status"`
+	Network         string       `json:"network"`
+	Attachments     []Attachment `json:"attachments"`
+}
+
+type Attachment struct {
+	Name        string `json:"name"`
+	Image       string `json:"image"`
+	ContainerID string `json:"container_id"`
+	Status      string `json:"status"`
+}
+
 // ListRoutes returns all configured routes.
 func (c *Client) ListRoutes(ctx context.Context) ([]domain.Route, error) {
 	resp, err := c.request(ctx, http.MethodGet, "/routes", nil)
@@ -134,6 +150,58 @@ func (c *Client) ListRoutes(ctx context.Context) ([]domain.Route, error) {
 	}
 
 	return result.Routes, nil
+}
+
+// ListRoutesWithDetails returns routes with network and attachment info.
+func (c *Client) ListRoutesWithDetails(ctx context.Context) ([]RouteInfo, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/routes?detailed=true", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Routes []RouteInfo `json:"routes"`
+	}
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Routes, nil
+}
+
+// ListNetworks returns Gordon-managed networks.
+func (c *Client) ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/networks", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Networks []*domain.NetworkInfo `json:"networks"`
+	}
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Networks, nil
+}
+
+// ListAttachments returns attachments for a domain.
+func (c *Client) ListAttachments(ctx context.Context, routeDomain string) ([]Attachment, error) {
+	path := "/routes/" + url.PathEscape(routeDomain) + "/attachments"
+	resp, err := c.request(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Attachments []Attachment `json:"attachments"`
+	}
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Attachments, nil
 }
 
 // GetRoute returns a specific route by domain.

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"gordon/internal/adapters/dto"
 	"gordon/internal/domain"
 )
 
@@ -119,21 +120,9 @@ func parseResponse(resp *http.Response, target any) error {
 
 // Routes API
 
-type RouteInfo struct {
-	Domain          string       `json:"domain"`
-	Image           string       `json:"image"`
-	ContainerID     string       `json:"container_id"`
-	ContainerStatus string       `json:"container_status"`
-	Network         string       `json:"network"`
-	Attachments     []Attachment `json:"attachments"`
-}
-
-type Attachment struct {
-	Name        string `json:"name"`
-	Image       string `json:"image"`
-	ContainerID string `json:"container_id"`
-	Status      string `json:"status"`
-}
+// Type aliases for API types using shared DTO package.
+type RouteInfo = dto.RouteInfo
+type Attachment = dto.Attachment
 
 // ListRoutes returns all configured routes.
 func (c *Client) ListRoutes(ctx context.Context) ([]domain.Route, error) {
@@ -188,6 +177,9 @@ func (c *Client) ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error
 
 // ListAttachments returns attachments for a domain.
 func (c *Client) ListAttachments(ctx context.Context, routeDomain string) ([]Attachment, error) {
+	if routeDomain == "" {
+		return nil, fmt.Errorf("domain is required")
+	}
 	path := "/routes/" + url.PathEscape(routeDomain) + "/attachments"
 	resp, err := c.request(ctx, http.MethodGet, path, nil)
 	if err != nil {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -31,15 +31,11 @@ func truncateImage(image string, maxLen int) string {
 		}
 		short := fmt.Sprintf("%s@sha256:%s", name, digest)
 		if len(short) > maxLen {
-			// Truncate name if still too long
-			available := maxLen - len("@sha256:") - len(digest) - 3 // 3 for ellipsis
-			if available > 0 {
-				if len(name) > available {
-					name = name[:available]
-				}
-				name = name + "..."
-				short = fmt.Sprintf("%s@sha256:%s", name, digest)
+			// Truncate from the end to maintain valid reference format
+			if maxLen <= 3 {
+				return short[:maxLen]
 			}
+			return short[:maxLen-3] + "..."
 		}
 		return short
 	}

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -29,23 +29,42 @@ func truncateImage(image string, maxLen int) string {
 		if len(digest) > 12 {
 			digest = digest[:12]
 		}
-		short := fmt.Sprintf("%s@sha256:%s…", name, digest)
+		short := fmt.Sprintf("%s@sha256:%s", name, digest)
 		if len(short) > maxLen {
 			// Truncate name if still too long
-			available := maxLen - len("@sha256:") - 12 - 1 // 1 for ellipsis
-			if available > 3 {
-				name = name[:available-1] + "…"
+			available := maxLen - len("@sha256:") - len(digest) - 3 // 3 for ellipsis
+			if available > 0 {
+				if len(name) > available {
+					name = name[:available]
+				}
+				name = name + "..."
+				short = fmt.Sprintf("%s@sha256:%s", name, digest)
 			}
-			short = fmt.Sprintf("%s@sha256:%s…", name, digest)
 		}
 		return short
 	}
 
 	// Regular tag: truncate if needed
 	if len(image) > maxLen {
-		return image[:maxLen-1] + "…"
+		if maxLen <= 3 {
+			return image[:maxLen]
+		}
+		return image[:maxLen-3] + "..."
 	}
 	return image
+}
+
+func truncateNetwork(network string, maxLen int) string {
+	if network == "" || network == "-" {
+		return "-"
+	}
+	if len(network) > maxLen {
+		if maxLen <= 3 {
+			return network[:maxLen]
+		}
+		return network[:maxLen-3] + "..."
+	}
+	return network
 }
 
 // newRoutesCmd creates the routes command group.
@@ -107,7 +126,7 @@ func newRoutesListCmd() *cobra.Command {
 
 // runRoutesListRemote lists routes from a remote Gordon instance.
 func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
-	routes, err := client.ListRoutes(ctx)
+	routes, err := client.ListRoutesWithDetails(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list routes: %w", err)
 	}
@@ -123,16 +142,20 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		health = make(map[string]*remote.RouteHealth)
 	}
 
-	// Build table rows
 	const imageColWidth = 35
-	rows := make([][]string, len(routes))
-	for i, route := range routes {
+	const networkColWidth = 22
+	rows := make([][]string, 0, len(routes))
+	for _, route := range routes {
 		routeHealth := health[route.Domain]
 
 		// Container status column
-		containerStatus := "unknown"
-		if routeHealth != nil {
-			containerStatus = routeHealth.ContainerStatus
+		containerStatus := route.ContainerStatus
+		if containerStatus == "" {
+			if routeHealth != nil {
+				containerStatus = routeHealth.ContainerStatus
+			} else {
+				containerStatus = "unknown"
+			}
 		}
 		containerBadge := components.ContainerStatusBadge(containerStatus)
 
@@ -140,7 +163,22 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		httpStatus := formatHTTPStatus(routeHealth)
 
 		displayImage := truncateImage(route.Image, imageColWidth)
-		rows[i] = []string{route.Domain, displayImage, containerBadge, httpStatus}
+		displayNetwork := truncateNetwork(route.Network, networkColWidth)
+		rows = append(rows, []string{route.Domain, displayImage, displayNetwork, containerBadge, httpStatus})
+
+		for i, attachment := range route.Attachments {
+			prefix := "|-"
+			if i == len(route.Attachments)-1 {
+				prefix = "`-"
+			}
+			attachmentName := prefix + " " + attachment.Name
+			if len(attachmentName) > 25 {
+				attachmentName = attachmentName[:22] + "..."
+			}
+			attachmentStatus := components.ContainerStatusBadge(attachment.Status)
+			attachmentImage := truncateImage(attachment.Image, imageColWidth)
+			rows = append(rows, []string{attachmentName, attachmentImage, "-", attachmentStatus, "-"})
+		}
 	}
 
 	// Render table
@@ -148,6 +186,7 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		components.WithColumns([]components.TableColumn{
 			{Title: "Domain", Width: 25},
 			{Title: "Image", Width: imageColWidth},
+			{Title: "Network", Width: networkColWidth},
 			{Title: "Container", Width: 12},
 			{Title: "HTTP", Width: 14},
 		}),

--- a/internal/adapters/out/docker/network_test.go
+++ b/internal/adapters/out/docker/network_test.go
@@ -1,0 +1,70 @@
+package docker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuntime_GetContainerNetwork(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1.41/containers/abc123/json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"NetworkSettings": {
+				"Networks": {
+					"bridge": {"IPAddress": "172.17.0.2"},
+					"gordon-app": {"IPAddress": "172.18.0.2"}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	runtime := NewRuntimeWithClient(cli)
+	network, err := runtime.GetContainerNetwork(context.Background(), "abc123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "gordon-app", network)
+}
+
+func TestRuntime_GetContainerNetwork_Fallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1.41/containers/abc123/json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"NetworkSettings": {
+				"Networks": {
+					"bridge": {"IPAddress": "172.17.0.2"},
+					"custom": {"IPAddress": "172.18.0.2"}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	runtime := NewRuntimeWithClient(cli)
+	network, err := runtime.GetContainerNetwork(context.Background(), "abc123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bridge", network)
+}

--- a/internal/adapters/out/docker/network_test.go
+++ b/internal/adapters/out/docker/network_test.go
@@ -68,3 +68,51 @@ func TestRuntime_GetContainerNetwork_Fallback(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "bridge", network)
 }
+
+func TestRuntime_GetContainerNetwork_EmptyNetworks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1.41/containers/abc123/json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"NetworkSettings": {
+				"Networks": {}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	runtime := NewRuntimeWithClient(cli)
+	network, err := runtime.GetContainerNetwork(context.Background(), "abc123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bridge", network)
+}
+
+func TestRuntime_GetContainerNetwork_NilNetworkSettings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1.41/containers/abc123/json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("failed to create docker client: %v", err)
+	}
+
+	runtime := NewRuntimeWithClient(cli)
+	network, err := runtime.GetContainerNetwork(context.Background(), "abc123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bridge", network)
+}

--- a/internal/boundaries/in/container.go
+++ b/internal/boundaries/in/container.go
@@ -26,6 +26,15 @@ type ContainerService interface {
 	// List returns all managed containers.
 	List(ctx context.Context) map[string]*domain.Container
 
+	// ListRoutesWithDetails returns routes with network and attachment info.
+	ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo
+
+	// ListAttachments returns attachments for a domain.
+	ListAttachments(ctx context.Context, domain string) []domain.Attachment
+
+	// ListNetworks returns Gordon-managed networks.
+	ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error)
+
 	// HealthCheck performs health checks on all containers.
 	HealthCheck(ctx context.Context) map[string]bool
 

--- a/internal/boundaries/in/mocks/mock_container_service.go
+++ b/internal/boundaries/in/mocks/mock_container_service.go
@@ -337,6 +337,180 @@ func (_c *MockContainerService_List_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// ListAttachments provides a mock function for the type MockContainerService
+func (_mock *MockContainerService) ListAttachments(ctx context.Context, domain1 string) []domain.Attachment {
+	ret := _mock.Called(ctx, domain1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAttachments")
+	}
+
+	var r0 []domain.Attachment
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []domain.Attachment); ok {
+		r0 = returnFunc(ctx, domain1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]domain.Attachment)
+		}
+	}
+	return r0
+}
+
+// MockContainerService_ListAttachments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAttachments'
+type MockContainerService_ListAttachments_Call struct {
+	*mock.Call
+}
+
+// ListAttachments is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain1 string
+func (_e *MockContainerService_Expecter) ListAttachments(ctx interface{}, domain1 interface{}) *MockContainerService_ListAttachments_Call {
+	return &MockContainerService_ListAttachments_Call{Call: _e.mock.On("ListAttachments", ctx, domain1)}
+}
+
+func (_c *MockContainerService_ListAttachments_Call) Run(run func(ctx context.Context, domain1 string)) *MockContainerService_ListAttachments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerService_ListAttachments_Call) Return(attachments []domain.Attachment) *MockContainerService_ListAttachments_Call {
+	_c.Call.Return(attachments)
+	return _c
+}
+
+func (_c *MockContainerService_ListAttachments_Call) RunAndReturn(run func(ctx context.Context, domain1 string) []domain.Attachment) *MockContainerService_ListAttachments_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListNetworks provides a mock function for the type MockContainerService
+func (_mock *MockContainerService) ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListNetworks")
+	}
+
+	var r0 []*domain.NetworkInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]*domain.NetworkInfo, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []*domain.NetworkInfo); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*domain.NetworkInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockContainerService_ListNetworks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListNetworks'
+type MockContainerService_ListNetworks_Call struct {
+	*mock.Call
+}
+
+// ListNetworks is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockContainerService_Expecter) ListNetworks(ctx interface{}) *MockContainerService_ListNetworks_Call {
+	return &MockContainerService_ListNetworks_Call{Call: _e.mock.On("ListNetworks", ctx)}
+}
+
+func (_c *MockContainerService_ListNetworks_Call) Run(run func(ctx context.Context)) *MockContainerService_ListNetworks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerService_ListNetworks_Call) Return(networkInfos []*domain.NetworkInfo, err error) *MockContainerService_ListNetworks_Call {
+	_c.Call.Return(networkInfos, err)
+	return _c
+}
+
+func (_c *MockContainerService_ListNetworks_Call) RunAndReturn(run func(ctx context.Context) ([]*domain.NetworkInfo, error)) *MockContainerService_ListNetworks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListRoutesWithDetails provides a mock function for the type MockContainerService
+func (_mock *MockContainerService) ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListRoutesWithDetails")
+	}
+
+	var r0 []domain.RouteInfo
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []domain.RouteInfo); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]domain.RouteInfo)
+		}
+	}
+	return r0
+}
+
+// MockContainerService_ListRoutesWithDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRoutesWithDetails'
+type MockContainerService_ListRoutesWithDetails_Call struct {
+	*mock.Call
+}
+
+// ListRoutesWithDetails is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockContainerService_Expecter) ListRoutesWithDetails(ctx interface{}) *MockContainerService_ListRoutesWithDetails_Call {
+	return &MockContainerService_ListRoutesWithDetails_Call{Call: _e.mock.On("ListRoutesWithDetails", ctx)}
+}
+
+func (_c *MockContainerService_ListRoutesWithDetails_Call) Run(run func(ctx context.Context)) *MockContainerService_ListRoutesWithDetails_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerService_ListRoutesWithDetails_Call) Return(routeInfos []domain.RouteInfo) *MockContainerService_ListRoutesWithDetails_Call {
+	_c.Call.Return(routeInfos)
+	return _c
+}
+
+func (_c *MockContainerService_ListRoutesWithDetails_Call) RunAndReturn(run func(ctx context.Context) []domain.RouteInfo) *MockContainerService_ListRoutesWithDetails_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Remove provides a mock function for the type MockContainerService
 func (_mock *MockContainerService) Remove(ctx context.Context, containerID string, force bool) error {
 	ret := _mock.Called(ctx, containerID, force)

--- a/internal/boundaries/out/mocks/mock_container_runtime.go
+++ b/internal/boundaries/out/mocks/mock_container_runtime.go
@@ -495,6 +495,72 @@ func (_c *MockContainerRuntime_GetContainerLogs_Call) RunAndReturn(run func(ctx 
 	return _c
 }
 
+// GetContainerNetwork provides a mock function for the type MockContainerRuntime
+func (_mock *MockContainerRuntime) GetContainerNetwork(ctx context.Context, containerID string) (string, error) {
+	ret := _mock.Called(ctx, containerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetContainerNetwork")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return returnFunc(ctx, containerID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = returnFunc(ctx, containerID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, containerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockContainerRuntime_GetContainerNetwork_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetContainerNetwork'
+type MockContainerRuntime_GetContainerNetwork_Call struct {
+	*mock.Call
+}
+
+// GetContainerNetwork is a helper method to define mock.On call
+//   - ctx context.Context
+//   - containerID string
+func (_e *MockContainerRuntime_Expecter) GetContainerNetwork(ctx interface{}, containerID interface{}) *MockContainerRuntime_GetContainerNetwork_Call {
+	return &MockContainerRuntime_GetContainerNetwork_Call{Call: _e.mock.On("GetContainerNetwork", ctx, containerID)}
+}
+
+func (_c *MockContainerRuntime_GetContainerNetwork_Call) Run(run func(ctx context.Context, containerID string)) *MockContainerRuntime_GetContainerNetwork_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerRuntime_GetContainerNetwork_Call) Return(s string, err error) *MockContainerRuntime_GetContainerNetwork_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockContainerRuntime_GetContainerNetwork_Call) RunAndReturn(run func(ctx context.Context, containerID string) (string, error)) *MockContainerRuntime_GetContainerNetwork_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetContainerNetworkInfo provides a mock function for the type MockContainerRuntime
 func (_mock *MockContainerRuntime) GetContainerNetworkInfo(ctx context.Context, containerID string) (string, int, error) {
 	ret := _mock.Called(ctx, containerID)

--- a/internal/boundaries/out/runtime.go
+++ b/internal/boundaries/out/runtime.go
@@ -46,6 +46,7 @@ type ContainerRuntime interface {
 	GetImageExposedPorts(ctx context.Context, imageRef string) ([]int, error)
 	GetContainerExposedPorts(ctx context.Context, containerID string) ([]int, error)
 	GetContainerNetworkInfo(ctx context.Context, containerID string) (string, int, error)
+	GetContainerNetwork(ctx context.Context, containerID string) (string, error)
 
 	// Volume management
 	InspectImageVolumes(ctx context.Context, imageRef string) ([]string, error)

--- a/internal/domain/container.go
+++ b/internal/domain/container.go
@@ -21,6 +21,24 @@ type NetworkInfo struct {
 	Labels     map[string]string
 }
 
+// Attachment represents an attached service container.
+type Attachment struct {
+	Name        string
+	Image       string
+	ContainerID string
+	Status      string
+}
+
+// RouteInfo combines route configuration with runtime state.
+type RouteInfo struct {
+	Domain          string
+	Image           string
+	ContainerID     string
+	ContainerStatus string
+	Network         string
+	Attachments     []Attachment
+}
+
 // ContainerConfig holds configuration for creating a container.
 type ContainerConfig struct {
 	Image       string

--- a/internal/usecase/container/routes_test.go
+++ b/internal/usecase/container/routes_test.go
@@ -1,0 +1,162 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"gordon/internal/boundaries/out/mocks"
+	"gordon/internal/domain"
+)
+
+func TestService_ListRoutesWithDetails(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{NetworkPrefix: "gordon"})
+	ctx := testContext()
+
+	svc.containers["app.example.com"] = &domain.Container{
+		ID:     "container-1",
+		Image:  "registry/app:latest",
+		Status: "running",
+		Labels: map[string]string{
+			domain.LabelImage: "app:latest",
+		},
+	}
+
+	runtime.EXPECT().GetContainerNetwork(mock.Anything, "container-1").Return("gordon-app-example-com", nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		{
+			ID:     "attach-1",
+			Name:   "gordon-app-example-com-postgres",
+			Image:  "postgres:15",
+			Status: "running",
+			Labels: map[string]string{
+				domain.LabelAttachment: "true",
+				domain.LabelAttachedTo: "app.example.com",
+				domain.LabelImage:      "postgres:15",
+			},
+		},
+		{
+			ID:     "attach-2",
+			Name:   "gordon-other-redis",
+			Image:  "redis:7",
+			Status: "running",
+			Labels: map[string]string{
+				domain.LabelAttachment: "true",
+				domain.LabelAttachedTo: "other.example.com",
+				domain.LabelImage:      "redis:7",
+			},
+		},
+		{
+			ID:     "other",
+			Name:   "gordon-other",
+			Image:  "busybox",
+			Status: "running",
+			Labels: map[string]string{
+				domain.LabelAttachment: "false",
+			},
+		},
+	}, nil)
+
+	results := svc.ListRoutesWithDetails(ctx)
+
+	assert.Len(t, results, 1)
+	assert.Equal(t, "app.example.com", results[0].Domain)
+	assert.Equal(t, "app:latest", results[0].Image)
+	assert.Equal(t, "container-1", results[0].ContainerID)
+	assert.Equal(t, "running", results[0].ContainerStatus)
+	assert.Equal(t, "gordon-app-example-com", results[0].Network)
+	if assert.Len(t, results[0].Attachments, 1) {
+		assert.Equal(t, "postgres", results[0].Attachments[0].Name)
+		assert.Equal(t, "postgres:15", results[0].Attachments[0].Image)
+		assert.Equal(t, "attach-1", results[0].Attachments[0].ContainerID)
+	}
+}
+
+func TestService_ListRoutesWithDetails_Empty(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{NetworkPrefix: "gordon"})
+	ctx := testContext()
+
+	results := svc.ListRoutesWithDetails(ctx)
+
+	assert.Empty(t, results)
+}
+
+func TestService_ListRoutesWithDetails_NetworkError(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{NetworkPrefix: "gordon"})
+	ctx := testContext()
+
+	svc.containers["app.example.com"] = &domain.Container{
+		ID:     "container-1",
+		Image:  "app:latest",
+		Status: "running",
+	}
+
+	runtime.EXPECT().GetContainerNetwork(mock.Anything, "container-1").Return("", assert.AnError)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+
+	results := svc.ListRoutesWithDetails(ctx)
+
+	assert.Len(t, results, 1)
+	assert.Equal(t, "", results[0].Network)
+}
+
+func TestService_ListAttachments(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{})
+	ctx := testContext()
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		{
+			ID:     "attach-1",
+			Name:   "gordon-app-example-com-postgres",
+			Image:  "postgres:15",
+			Status: "running",
+			Labels: map[string]string{
+				domain.LabelAttachment: "true",
+				domain.LabelAttachedTo: "app.example.com",
+				domain.LabelImage:      "postgres:15",
+			},
+		},
+		{
+			ID:     "attach-2",
+			Name:   "gordon-other-redis",
+			Image:  "redis:7",
+			Status: "running",
+			Labels: map[string]string{
+				domain.LabelAttachment: "true",
+				domain.LabelAttachedTo: "other.example.com",
+				domain.LabelImage:      "redis:7",
+			},
+		},
+	}, nil)
+
+	attachments := svc.ListAttachments(ctx, "app.example.com")
+
+	assert.Len(t, attachments, 1)
+	assert.Equal(t, "postgres", attachments[0].Name)
+	assert.Equal(t, "postgres:15", attachments[0].Image)
+	assert.Equal(t, "attach-1", attachments[0].ContainerID)
+}
+
+func TestService_ListNetworks(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{NetworkPrefix: "gordon"})
+	ctx := testContext()
+
+	runtime.EXPECT().ListNetworks(mock.Anything).Return([]*domain.NetworkInfo{
+		{Name: "gordon-app"},
+		{Name: "bridge"},
+		{Name: "gordon-shared"},
+	}, nil)
+
+	networks, err := svc.ListNetworks(ctx)
+
+	assert.NoError(t, err)
+	assert.Len(t, networks, 2)
+	assert.Equal(t, "gordon-app", networks[0].Name)
+	assert.Equal(t, "gordon-shared", networks[1].Name)
+}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -317,6 +317,9 @@ func (s *Service) List(_ context.Context) map[string]*domain.Container {
 }
 
 // ListRoutesWithDetails returns routes with network and attachment info.
+// Note: Container map is copied under lock, then external calls are made without lock.
+// If containers are removed between copy and runtime calls, errors are handled gracefully
+// (network becomes empty string). This trade-off avoids holding locks during I/O.
 func (s *Service) ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo {
 	s.mu.RLock()
 	containers := make(map[string]*domain.Container, len(s.containers))

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -316,6 +316,68 @@ func (s *Service) List(_ context.Context) map[string]*domain.Container {
 	return result
 }
 
+// ListRoutesWithDetails returns routes with network and attachment info.
+func (s *Service) ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo {
+	s.mu.RLock()
+	containers := make(map[string]*domain.Container, len(s.containers))
+	maps.Copy(containers, s.containers)
+	s.mu.RUnlock()
+
+	results := make([]domain.RouteInfo, 0, len(containers))
+	for domainName, container := range containers {
+		network := ""
+		image := ""
+		containerID := ""
+		status := ""
+		if container != nil {
+			containerID = container.ID
+			status = container.Status
+			image = container.Image
+			if container.Labels != nil {
+				if labelImage, ok := container.Labels[domain.LabelImage]; ok && labelImage != "" {
+					image = labelImage
+				}
+			}
+			if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
+				network = networkName
+			}
+		}
+
+		results = append(results, domain.RouteInfo{
+			Domain:          domainName,
+			Image:           image,
+			ContainerID:     containerID,
+			ContainerStatus: status,
+			Network:         network,
+			Attachments:     s.getAttachmentsForDomain(ctx, domainName),
+		})
+	}
+
+	return results
+}
+
+// ListAttachments returns attachments for a domain.
+func (s *Service) ListAttachments(ctx context.Context, domainName string) []domain.Attachment {
+	return s.getAttachmentsForDomain(ctx, domainName)
+}
+
+// ListNetworks returns Gordon-managed networks.
+func (s *Service) ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error) {
+	networks, err := s.runtime.ListNetworks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []*domain.NetworkInfo
+	for _, network := range networks {
+		if strings.HasPrefix(network.Name, s.config.NetworkPrefix+"-") {
+			filtered = append(filtered, network)
+		}
+	}
+
+	return filtered, nil
+}
+
 // HealthCheck performs health checks on all containers.
 func (s *Service) HealthCheck(ctx context.Context) map[string]bool {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
@@ -867,6 +929,41 @@ func (s *Service) deployAttachments(ctx context.Context, domainName, networkName
 	}
 
 	return nil
+}
+
+func (s *Service) getAttachmentsForDomain(ctx context.Context, domainName string) []domain.Attachment {
+	containers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		return nil
+	}
+
+	attachments := make([]domain.Attachment, 0)
+	for _, container := range containers {
+		if container.Labels == nil {
+			continue
+		}
+		if container.Labels[domain.LabelAttachment] != "true" {
+			continue
+		}
+		if container.Labels[domain.LabelAttachedTo] != domainName {
+			continue
+		}
+		image := container.Image
+		serviceName := container.Name
+		if labelImage, ok := container.Labels[domain.LabelImage]; ok && labelImage != "" {
+			image = labelImage
+			serviceName = extractServiceName(labelImage)
+		}
+		attachment := domain.Attachment{
+			Name:        serviceName,
+			Image:       image,
+			ContainerID: container.ID,
+			Status:      container.Status,
+		}
+		attachments = append(attachments, attachment)
+	}
+
+	return attachments
 }
 
 func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, serviceImage, networkName string) error {

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestService_Deploy_Success(t *testing.T) {
 	config := Config{
 		NetworkIsolation: false,
 		VolumeAutoCreate: false,
-		ReadinessDelay:   0, // No delay for tests
+		ReadinessDelay:   time.Millisecond, // Minimal delay for tests
 	}
 
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
@@ -124,7 +125,7 @@ func TestService_Deploy_ReplacesExistingContainer(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		ReadinessDelay: 0, // No delay for tests
+		ReadinessDelay: time.Millisecond, // Minimal delay for tests
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -199,7 +200,7 @@ func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 	config := Config{
 		NetworkIsolation: true,
 		NetworkPrefix:    "gordon",
-		ReadinessDelay:   0, // No delay for tests
+		ReadinessDelay:   time.Millisecond, // Minimal delay for tests
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -250,7 +251,7 @@ func TestService_Deploy_WithVolumeAutoCreate(t *testing.T) {
 	config := Config{
 		VolumeAutoCreate: true,
 		VolumePrefix:     "gordon",
-		ReadinessDelay:   0, // No delay for tests
+		ReadinessDelay:   time.Millisecond, // Minimal delay for tests
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -723,7 +724,7 @@ func TestService_Deploy_InternalDeployForcesPull(t *testing.T) {
 		RegistryPort:             5000,
 		InternalRegistryUsername: "internal",
 		InternalRegistryPassword: "secret",
-		ReadinessDelay:           0,
+		ReadinessDelay:           time.Millisecond,
 	}
 
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
@@ -791,7 +792,7 @@ func TestService_AutoStart_StartsNewContainers(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		ReadinessDelay: 0,
+		ReadinessDelay: time.Millisecond,
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -834,7 +835,7 @@ func TestService_AutoStart_SkipsExistingContainers(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		ReadinessDelay: 0,
+		ReadinessDelay: time.Millisecond,
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -906,7 +907,7 @@ func TestService_Deploy_OrphanCleanupSkipsTrackedContainer(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		ReadinessDelay: 0, // No delay for tests
+		ReadinessDelay: time.Millisecond, // Minimal delay for tests
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
@@ -990,7 +991,7 @@ func TestService_Deploy_OrphanCleanupRemovesTrueOrphans(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		ReadinessDelay: 0, // No delay for tests
+		ReadinessDelay: time.Millisecond, // Minimal delay for tests
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()


### PR DESCRIPTION
## Summary

- Add network and attachment information to route listing API
- Introduce `?detailed=true` query parameter for extended route info
- Add `/admin/routes/{domain}/attachments` endpoint
- Add `/admin/networks` endpoint for Gordon-managed networks
- Create shared DTO package for API response types
- Improve HTTP handler consistency and add input validation

## Changes

### Features
- **Route details**: `GET /admin/routes?detailed=true` returns network and attachment info
- **Attachments endpoint**: `GET /admin/routes/{domain}/attachments` lists attached services
- **Networks endpoint**: `GET /admin/networks` lists Gordon-managed networks
- **CLI support**: `gordon routes` now shows network and attachment columns

### Refactoring
- Extract `dto.RouteInfo` and `dto.Attachment` to shared package
- Add helper functions for response mapping
- Use `h.sendError` consistently for JSON error responses
- Add input validation in `ListAttachments` client method

### Documentation
- Document race condition design choice in `ListRoutesWithDetails`

### Tests
- Add tests for route details and networks functionality
- Add error path tests for network detection (empty/nil networks)
- Fix `ReadinessDelay` in tests to avoid 5s default (tests now run in 0.018s)

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] Manual verification of new endpoints