### PR TITLE
fix: improve CLI routes list display

### DIFF
--- a/internal/adapters/dto/admin_route.go
+++ b/internal/adapters/dto/admin_route.go
@@ -24,6 +24,7 @@ type Attachment struct {
 	Image       string `json:"image"`
 	ContainerID string `json:"container_id"`
 	Status      string `json:"status"`
+	Network     string `json:"network"`
 }
 
 // RoutesResponse represents a list of routes.

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -172,8 +172,10 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		for _, attachment := range route.Attachments {
 			// Use container icon with indent for attachment tree display
 			attachmentName := "  " + styles.IconContainer + " " + attachment.Name
-			if len(attachmentName) > 25 {
-				attachmentName = attachmentName[:22] + "..."
+			// Use rune count for proper Unicode handling (icons are multi-byte)
+			runes := []rune(attachmentName)
+			if len(runes) > 25 {
+				attachmentName = string(runes[:22]) + "..."
 			}
 			attachmentStatus := components.ContainerStatusBadge(attachment.Status)
 			attachmentImage := truncateImage(attachment.Image, imageColWidth)

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -169,12 +169,9 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		displayNetwork := truncateNetwork(route.Network, networkColWidth)
 		rows = append(rows, []string{route.Domain, displayImage, displayNetwork, containerBadge, httpStatus})
 
-		for i, attachment := range route.Attachments {
-			prefix := "|-"
-			if i == len(route.Attachments)-1 {
-				prefix = "`-"
-			}
-			attachmentName := prefix + " " + attachment.Name
+		for _, attachment := range route.Attachments {
+			// Use container icon with indent for attachment tree display
+			attachmentName := "  " + styles.IconContainer + " " + attachment.Name
 			if len(attachmentName) > 25 {
 				attachmentName = attachmentName[:22] + "..."
 			}

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -181,7 +181,9 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 			}
 			attachmentStatus := components.ContainerStatusBadge(attachment.Status)
 			attachmentImage := truncateImage(attachment.Image, imageColWidth)
-			rows = append(rows, []string{attachmentName, attachmentImage, "-", attachmentStatus, "-"})
+			// Show attachment's actual network for debugging/verification
+			attachmentNetwork := truncateNetwork(attachment.Network, networkColWidth)
+			rows = append(rows, []string{attachmentName, attachmentImage, attachmentNetwork, attachmentStatus, "-"})
 		}
 	}
 

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -170,18 +170,19 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		rows = append(rows, []string{route.Domain, displayImage, displayNetwork, containerBadge, httpStatus})
 
 		for i, attachment := range route.Attachments {
-			// ASCII tree structure for nested attachments
-			prefix := "├─"
+			// Unicode box-drawing tree structure for nested attachments
+			prefix := styles.IconTreeBranch + styles.IconTreeLine
 			if i == len(route.Attachments)-1 {
-				prefix = "└─"
+				prefix = styles.IconTreeLast + styles.IconTreeLine
 			}
 			attachmentName := prefix + " " + attachment.Name
-			if len(attachmentName) > 25 {
-				attachmentName = attachmentName[:22] + "..."
+			runes := []rune(attachmentName)
+			if len(runes) > 25 {
+				attachmentName = string(runes[:22]) + "..."
 			}
 			attachmentStatus := components.ContainerStatusBadge(attachment.Status)
 			attachmentImage := truncateImage(attachment.Image, imageColWidth)
-			// Show attachment's actual network for debugging/verification
+			// Display the attachment's actual network in the routes table
 			attachmentNetwork := truncateNetwork(attachment.Network, networkColWidth)
 			rows = append(rows, []string{attachmentName, attachmentImage, attachmentNetwork, attachmentStatus, "-"})
 		}

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -169,13 +169,15 @@ func runRoutesListRemote(ctx context.Context, client *remote.Client) error {
 		displayNetwork := truncateNetwork(route.Network, networkColWidth)
 		rows = append(rows, []string{route.Domain, displayImage, displayNetwork, containerBadge, httpStatus})
 
-		for _, attachment := range route.Attachments {
-			// Use container icon with indent for attachment tree display
-			attachmentName := "  " + styles.IconContainer + " " + attachment.Name
-			// Use rune count for proper Unicode handling (icons are multi-byte)
-			runes := []rune(attachmentName)
-			if len(runes) > 25 {
-				attachmentName = string(runes[:22]) + "..."
+		for i, attachment := range route.Attachments {
+			// ASCII tree structure for nested attachments
+			prefix := "├─"
+			if i == len(route.Attachments)-1 {
+				prefix = "└─"
+			}
+			attachmentName := prefix + " " + attachment.Name
+			if len(attachmentName) > 25 {
+				attachmentName = attachmentName[:22] + "..."
 			}
 			attachmentStatus := components.ContainerStatusBadge(attachment.Status)
 			attachmentImage := truncateImage(attachment.Image, imageColWidth)

--- a/internal/adapters/in/cli/ui/components/status.go
+++ b/internal/adapters/in/cli/ui/components/status.go
@@ -92,8 +92,9 @@ func RenderStatus(status Status, label string) string {
 	return config.Style.Render(config.Icon + " " + label)
 }
 
-// RenderStatusBadge renders a status as a badge with background and icon.
-func RenderStatusBadge(status Status, _ string) string {
+// RenderStatusBadge renders a status as a compact icon badge with background.
+// It displays only the icon (no label) for minimal width in table columns.
+func RenderStatusBadge(status Status) string {
 	config := DefaultStatusConfigs[status]
 	var badgeStyle lipgloss.Style
 	switch status {
@@ -171,7 +172,7 @@ func NewStatusBadge(status Status, label string) StatusIndicator {
 // View renders the status indicator.
 func (s StatusIndicator) View() string {
 	if s.Badge {
-		return RenderStatusBadge(s.Status, s.Label)
+		return RenderStatusBadge(s.Status)
 	}
 	return RenderStatus(s.Status, s.Label)
 }
@@ -185,5 +186,5 @@ func ContainerStatusIndicator(status string) string {
 // ContainerStatusBadge renders container status as a badge.
 func ContainerStatusBadge(status string) string {
 	parsed := ParseStatus(status)
-	return RenderStatusBadge(parsed, status)
+	return RenderStatusBadge(parsed)
 }

--- a/internal/adapters/in/cli/ui/components/table.go
+++ b/internal/adapters/in/cli/ui/components/table.go
@@ -45,7 +45,7 @@ func NewTable(opts ...TableOption) *TableModel {
 			Foreground(styles.ColorText).
 			Padding(0, 1),
 		evenStyle: lipgloss.NewStyle().
-			Foreground(styles.ColorTextMuted).
+			Foreground(styles.ColorText).
 			Padding(0, 1),
 	}
 

--- a/internal/adapters/in/cli/ui/styles/icons.go
+++ b/internal/adapters/in/cli/ui/styles/icons.go
@@ -2,78 +2,101 @@ package styles
 
 // Nerd Font icons for terminal UI.
 // These icons require a Nerd Font compatible terminal font.
+// All icons are defined using Unicode escape sequences for portability.
 // Fallback ASCII alternatives are provided where practical.
 const (
 	// Status indicators
-	IconSuccess = "" // nf-fa-check (U+F00C)
-	IconError   = "" // nf-fa-times (U+F00D)
-	IconWarning = "" // nf-fa-exclamation_triangle (U+F071)
-	IconInfo    = "" // nf-fa-info_circle (U+F05A)
-	IconPending = "" // nf-fa-clock_o (U+F017)
+	IconSuccess = "\uf00c" // nf-fa-check
+	IconError   = "\uf00d" // nf-fa-times
+	IconWarning = "\uf071" // nf-fa-exclamation_triangle
+	IconInfo    = "\uf05a" // nf-fa-info_circle
+	IconPending = "\uf017" // nf-fa-clock
+
+	// Container status icons
+	IconRunning    = "\uf00c" // nf-fa-check (green)
+	IconStopped    = "\uf04d" // nf-fa-stop
+	IconExited     = "\uf00d" // nf-fa-times
+	IconPaused     = "\uf04c" // nf-fa-pause
+	IconRestarting = "\uf021" // nf-fa-refresh
+	IconUnknown    = "\uf071" // nf-fa-exclamation_triangle
 
 	// Objects
-	IconRoute     = ""  // nf-fa-sitemap (U+F0E8)
-	IconSecret    = ""  // nf-fa-lock (U+F023)
-	IconToken     = ""  // nf-fa-key (U+F084)
-	IconContainer = ""  // nf-oct-container (U+F489)
-	IconServer    = ""  // nf-fa-server (U+F233)
-	IconNetwork   = "󰛳" // nf-md-lan (U+F06F3)
-	IconVolume    = ""  // nf-fa-database (U+F1C0)
-	IconImage     = ""  // nf-fa-archive (U+F187)
+	IconRoute     = "\uf0e8"     // nf-fa-sitemap
+	IconSecret    = "\uf023"     // nf-fa-lock
+	IconToken     = "\uf084"     // nf-fa-key
+	IconContainer = "\uf4b7"     // nf-oct-container
+	IconServer    = "\uf233"     // nf-fa-server
+	IconNetwork   = "\U000f0317" // nf-md-lan
+	IconVolume    = "\uf1c0"     // nf-fa-database
+	IconImage     = "\uf187"     // nf-fa-archive
+	IconDocker    = "\ue7b0"     // nf-dev-docker
 
 	// Actions
-	IconAdd     = "" // nf-fa-plus (U+F067)
-	IconRemove  = "" // nf-fa-minus (U+F068)
-	IconEdit    = "" // nf-fa-pencil (U+F040)
-	IconRefresh = "" // nf-fa-refresh (U+F021)
-	IconUpload  = "" // nf-fa-cloud_upload (U+F0EE)
-	IconDelete  = "" // nf-fa-trash (U+F1F8)
+	IconAdd     = "\uf067" // nf-fa-plus
+	IconRemove  = "\uf068" // nf-fa-minus
+	IconEdit    = "\uf040" // nf-fa-pencil
+	IconRefresh = "\uf021" // nf-fa-refresh
+	IconUpload  = "\uf0ee" // nf-fa-cloud_upload
+	IconDelete  = "\uf1f8" // nf-fa-trash
 
 	// Navigation
-	IconArrowRight = "" // nf-fa-arrow_right (U+F061)
-	IconArrowLeft  = "" // nf-fa-arrow_left (U+F060)
-	IconArrowUp    = "" // nf-fa-arrow_up (U+F062)
-	IconArrowDown  = "" // nf-fa-arrow_down (U+F063)
-	IconChevron    = "" // nf-fa-chevron_right (U+F054)
+	IconArrowRight = "\uf061" // nf-fa-arrow_right
+	IconArrowLeft  = "\uf060" // nf-fa-arrow_left
+	IconArrowUp    = "\uf062" // nf-fa-arrow_up
+	IconArrowDown  = "\uf063" // nf-fa-arrow_down
+	IconChevron    = "\uf054" // nf-fa-chevron_right
 
 	// UI elements
-	IconBullet     = "▸" // Simple triangle bullet
-	IconDot        = "●" // Filled circle
-	IconDotEmpty   = "○" // Empty circle
-	IconCheckbox   = ""  // nf-fa-square_o (U+F096)
-	IconChecked    = ""  // nf-fa-check_square_o (U+F046)
-	IconRadio      = ""  // nf-fa-circle_o (U+F10C)
-	IconRadioCheck = ""  // nf-fa-dot_circle_o (U+F192)
+	IconBullet     = "\u25b8" // ▸ Simple triangle bullet
+	IconDot        = "\u25cf" // ● Filled circle
+	IconDotEmpty   = "\u25cb" // ○ Empty circle
+	IconCheckbox   = "\uf096" // nf-fa-square_o
+	IconChecked    = "\uf046" // nf-fa-check_square_o
+	IconRadio      = "\uf10c" // nf-fa-circle_o
+	IconRadioCheck = "\uf192" // nf-fa-dot_circle_o
+	IconPlay       = "\uf04b" // nf-fa-play
+	IconStop       = "\uf04d" // nf-fa-stop
+	IconPause      = "\uf04c" // nf-fa-pause
+
+	// Tree structure
+	IconTreeBranch = "\u251c" // ├
+	IconTreeLast   = "\u2514" // └
+	IconTreeLine   = "\u2500" // ─
+	IconTreeVert   = "\u2502" // │
 
 	// Spinners (individual frames)
-	SpinnerDot    = "⣾⣽⣻⢿⡿⣟⣯⣷"
+	SpinnerDot    = "\u28fe\u28fd\u28fb\u28bf\u287f\u28df\u28ef\u28f7"
 	SpinnerLine   = "|/-\\"
-	SpinnerCircle = "◐◓◑◒"
-	SpinnerBrail  = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+	SpinnerCircle = "\u25d0\u25d3\u25d1\u25d2"
+	SpinnerBrail  = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"
 
 	// Borders and decorations
-	BorderHorizontal = "─"
-	BorderVertical   = "│"
-	BorderCornerTL   = "┌"
-	BorderCornerTR   = "┐"
-	BorderCornerBL   = "└"
-	BorderCornerBR   = "┘"
-	BorderT          = "┬"
-	BorderB          = "┴"
-	BorderL          = "├"
-	BorderR          = "┤"
-	BorderCross      = "┼"
+	BorderHorizontal = "\u2500" // ─
+	BorderVertical   = "\u2502" // │
+	BorderCornerTL   = "\u250c" // ┌
+	BorderCornerTR   = "\u2510" // ┐
+	BorderCornerBL   = "\u2514" // └
+	BorderCornerBR   = "\u2518" // ┘
+	BorderT          = "\u252c" // ┬
+	BorderB          = "\u2534" // ┴
+	BorderL          = "\u251c" // ├
+	BorderR          = "\u2524" // ┤
+	BorderCross      = "\u253c" // ┼
 
 	// Gordon branding
-	IconGordon = "" // nf-fa-cube (U+F1B2)
+	IconGordon = "\uf1b2" // nf-fa-cube
 )
 
 // ASCII fallback alternatives for terminals without Nerd Fonts.
 const (
-	AsciiSuccess = "[OK]"
-	AsciiError   = "[X]"
-	AsciiWarning = "[!]"
-	AsciiInfo    = "[i]"
-	AsciiBullet  = ">"
-	AsciiDot     = "*"
+	AsciiSuccess    = "[OK]"
+	AsciiError      = "[X]"
+	AsciiWarning    = "[!]"
+	AsciiInfo       = "[i]"
+	AsciiBullet     = ">"
+	AsciiDot        = "*"
+	AsciiRunning    = "[R]"
+	AsciiStopped    = "[S]"
+	AsciiTreeBranch = "|-"
+	AsciiTreeLast   = "`-"
 )

--- a/internal/adapters/in/cli/ui/styles/icons.go
+++ b/internal/adapters/in/cli/ui/styles/icons.go
@@ -24,9 +24,9 @@ const (
 	IconRoute     = "\uf0e8"     // nf-fa-sitemap
 	IconSecret    = "\uf023"     // nf-fa-lock
 	IconToken     = "\uf084"     // nf-fa-key
-	IconContainer = "\uf4b7"     // nf-oct-container
+	IconContainer = "\uf489"     // nf-oct-container (U+F489)
 	IconServer    = "\uf233"     // nf-fa-server
-	IconNetwork   = "\U000f0317" // nf-md-lan
+	IconNetwork   = "\U000f06f3" // nf-md-lan (U+F06F3)
 	IconVolume    = "\uf1c0"     // nf-fa-database
 	IconImage     = "\uf187"     // nf-fa-archive
 	IconDocker    = "\ue7b0"     // nf-dev-docker

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -47,6 +47,7 @@ func toAttachmentResponse(a domain.Attachment) dto.Attachment {
 		Image:       a.Image,
 		ContainerID: a.ContainerID,
 		Status:      a.Status,
+		Network:     a.Network,
 	}
 }
 

--- a/internal/domain/container.go
+++ b/internal/domain/container.go
@@ -27,6 +27,7 @@ type Attachment struct {
 	Image       string
 	ContainerID string
 	Status      string
+	Network     string
 }
 
 // RouteInfo combines route configuration with runtime state.

--- a/internal/usecase/container/routes_test.go
+++ b/internal/usecase/container/routes_test.go
@@ -25,6 +25,9 @@ func TestService_ListRoutesWithDetails(t *testing.T) {
 	}
 
 	runtime.EXPECT().GetContainerNetwork(mock.Anything, "container-1").Return("gordon-app-example-com", nil)
+	// getAllAttachments calls GetContainerNetwork for each attachment
+	runtime.EXPECT().GetContainerNetwork(mock.Anything, "attach-1").Return("gordon-app-example-com", nil)
+	runtime.EXPECT().GetContainerNetwork(mock.Anything, "attach-2").Return("gordon-other-example-com", nil)
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID:     "attach-1",
@@ -71,6 +74,7 @@ func TestService_ListRoutesWithDetails(t *testing.T) {
 		assert.Equal(t, "postgres", results[0].Attachments[0].Name)
 		assert.Equal(t, "postgres:15", results[0].Attachments[0].Image)
 		assert.Equal(t, "attach-1", results[0].Attachments[0].ContainerID)
+		assert.Equal(t, "gordon-app-example-com", results[0].Attachments[0].Network)
 	}
 }
 
@@ -136,6 +140,7 @@ func TestService_ListAttachments(t *testing.T) {
 			},
 		},
 	}, nil)
+	runtime.EXPECT().GetContainerNetwork(mock.Anything, "attach-1").Return("gordon-app-example-com", nil)
 
 	attachments := svc.ListAttachments(ctx, "app.example.com")
 
@@ -143,6 +148,7 @@ func TestService_ListAttachments(t *testing.T) {
 	assert.Equal(t, "postgres", attachments[0].Name)
 	assert.Equal(t, "postgres:15", attachments[0].Image)
 	assert.Equal(t, "attach-1", attachments[0].ContainerID)
+	assert.Equal(t, "gordon-app-example-com", attachments[0].Network)
 }
 
 func TestService_ListNetworks(t *testing.T) {

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -344,6 +344,8 @@ func (s *Service) ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo 
 					image = labelImage
 				}
 			}
+			// Strip registry domain prefix from image for cleaner display
+			image = s.stripRegistryPrefix(image)
 			if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
 				network = networkName
 			}
@@ -360,6 +362,19 @@ func (s *Service) ListRoutesWithDetails(ctx context.Context) []domain.RouteInfo 
 	}
 
 	return results
+}
+
+// stripRegistryPrefix removes the configured registry domain prefix from an image reference.
+// For example, "reg.example.com/myapp:latest" becomes "myapp:latest" if registry domain is "reg.example.com".
+func (s *Service) stripRegistryPrefix(image string) string {
+	if s.config.RegistryDomain == "" {
+		return image
+	}
+	prefix := strings.TrimSuffix(s.config.RegistryDomain, "/") + "/"
+	if strings.HasPrefix(image, prefix) {
+		return strings.TrimPrefix(image, prefix)
+	}
+	return image
 }
 
 // ListAttachments returns attachments for a domain.

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -958,7 +958,7 @@ func (s *Service) getAttachmentsForDomain(ctx context.Context, domainName string
 		return nil
 	}
 
-	return s.filterAttachments(containers, domainName)
+	return s.filterAttachments(ctx, containers, domainName)
 }
 
 // getAllAttachments fetches all containers once and returns attachments grouped by domain.
@@ -987,11 +987,17 @@ func (s *Service) getAllAttachments(ctx context.Context) map[string][]domain.Att
 			image = labelImage
 			serviceName = extractServiceName(labelImage)
 		}
+		// Get the container's network for debugging/verification
+		network := ""
+		if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
+			network = networkName
+		}
 		attachment := domain.Attachment{
 			Name:        serviceName,
 			Image:       image,
 			ContainerID: container.ID,
 			Status:      container.Status,
+			Network:     network,
 		}
 		result[ownerDomain] = append(result[ownerDomain], attachment)
 	}
@@ -1000,7 +1006,7 @@ func (s *Service) getAllAttachments(ctx context.Context) map[string][]domain.Att
 }
 
 // filterAttachments extracts attachments for a specific domain from a container list.
-func (s *Service) filterAttachments(containers []*domain.Container, domainName string) []domain.Attachment {
+func (s *Service) filterAttachments(ctx context.Context, containers []*domain.Container, domainName string) []domain.Attachment {
 	attachments := make([]domain.Attachment, 0)
 	for _, container := range containers {
 		if container.Labels == nil {
@@ -1018,11 +1024,17 @@ func (s *Service) filterAttachments(containers []*domain.Container, domainName s
 			image = labelImage
 			serviceName = extractServiceName(labelImage)
 		}
+		// Get the container's network for debugging/verification
+		network := ""
+		if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
+			network = networkName
+		}
 		attachment := domain.Attachment{
 			Name:        serviceName,
 			Image:       image,
 			ContainerID: container.ID,
 			Status:      container.Status,
+			Network:     network,
 		}
 		attachments = append(attachments, attachment)
 	}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -987,14 +987,14 @@ func (s *Service) getAllAttachments(ctx context.Context) map[string][]domain.Att
 			image = labelImage
 			serviceName = extractServiceName(labelImage)
 		}
-		// Get the container's network for debugging/verification
+		// Get the container's network for display in the routes table
 		network := ""
 		if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
 			network = networkName
 		}
 		attachment := domain.Attachment{
 			Name:        serviceName,
-			Image:       image,
+			Image:       s.stripRegistryPrefix(image),
 			ContainerID: container.ID,
 			Status:      container.Status,
 			Network:     network,
@@ -1024,14 +1024,14 @@ func (s *Service) filterAttachments(ctx context.Context, containers []*domain.Co
 			image = labelImage
 			serviceName = extractServiceName(labelImage)
 		}
-		// Get the container's network for debugging/verification
+		// Get the container's network for display in the routes table
 		network := ""
 		if networkName, err := s.runtime.GetContainerNetwork(ctx, container.ID); err == nil {
 			network = networkName
 		}
 		attachment := domain.Attachment{
 			Name:        serviceName,
-			Image:       image,
+			Image:       s.stripRegistryPrefix(image),
 			ContainerID: container.ID,
 			Status:      container.Status,
 			Network:     network,


### PR DESCRIPTION
## Summary

- Convert all icon constants to Unicode escape sequences (`\uXXXX`) for better portability across editors
- Add new container status icons: running, stopped, paused, restarting, exited, unknown
- Render container status badges with Nerd Font icons instead of text labels
- Fix gray/faded alternating table rows by using consistent text color
- Use container icon (󰆧) prefix for attachment tree display instead of ASCII chars

## Changes

| File | Description |
|------|-------------|
| `styles/icons.go` | Unicode escape sequences, new status icons |
| `components/status.go` | Icon-based status badges, new status types |
| `components/table.go` | Fix alternating row color |
| `cli/routes.go` | Container icon for attachments |