### PR TITLE
fix: minor QA issues from v2.6.0 testing

### DIFF
--- a/internal/adapters/dto/admin_secrets.go
+++ b/internal/adapters/dto/admin_secrets.go
@@ -1,9 +1,16 @@
 package dto
 
+// AttachmentSecretsResponse represents secrets for an attachment container.
+type AttachmentSecretsResponse struct {
+	Service string   `json:"service"`
+	Keys    []string `json:"keys"`
+}
+
 // SecretsListResponse represents a list of secret keys for a domain.
 type SecretsListResponse struct {
-	Domain string   `json:"domain"`
-	Keys   []string `json:"keys"`
+	Domain      string                      `json:"domain"`
+	Keys        []string                    `json:"keys"`
+	Attachments []AttachmentSecretsResponse `json:"attachments,omitempty"`
 }
 
 // SecretsStatusResponse represents a secrets write response.

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -180,12 +180,19 @@ func extractServiceName(containerName string) string {
 
 	serviceName := parts[1]
 	allParts := strings.Split(serviceName, "-")
-	if len(allParts) > 2 {
-		// Take last 2 parts as service name (e.g., "gitea-postgres")
-		return strings.Join(allParts[len(allParts)-2:], "-")
+
+	// Handle service names based on the number of segments explicitly
+	if len(allParts) < 2 {
+		// No additional segments; use the service name as-is.
+		return serviceName
+	}
+	if len(allParts) == 2 {
+		// Exactly two segments; the service name is already in the desired form.
+		return strings.Join(allParts, "-")
 	}
 
-	return serviceName
+	// More than two segments: take the last two as the short service name (e.g., "gitea-postgres").
+	return strings.Join(allParts[len(allParts)-2:], "-")
 }
 
 // getKeyPrefix returns the tree prefix for a key based on its position.

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"gordon/internal/adapters/in/cli/remote"
 	"gordon/internal/adapters/in/cli/ui/components"
 	"gordon/internal/adapters/in/cli/ui/styles"
 
@@ -39,65 +40,168 @@ func newSecretsListCmd() *cobra.Command {
 		Long: `List all secret keys configured for a domain.
 
 Note: Only secret keys are shown, not values (for security).
+Attachment secrets (for services like databases) are also displayed.
 
 Examples:
   gordon secrets list app.mydomain.com
   gordon --remote https://gordon.mydomain.com secrets list api.mydomain.com`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			secretDomain := args[0]
-
-			var keys []string
-			var err error
-
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				keys, err = client.ListSecrets(ctx, secretDomain)
-			} else {
-				local, localErr := GetLocalServices(configPath)
-				if localErr != nil {
-					return fmt.Errorf("failed to initialize local services: %w", localErr)
-				}
-				keys, err = local.GetSecretService().ListKeys(ctx, secretDomain)
-			}
-
-			if err != nil {
-				return fmt.Errorf("failed to list secrets: %w", err)
-			}
-
-			if len(keys) == 0 {
-				fmt.Println(styles.Theme.Muted.Render(fmt.Sprintf("No secrets configured for %s", secretDomain)))
-				return nil
-			}
-
-			title := fmt.Sprintf("Secrets for %s", secretDomain)
-			if !isRemote {
-				title = fmt.Sprintf("Secrets for %s (local)", secretDomain)
-			}
-			fmt.Println(styles.Theme.Title.Render(title))
-			fmt.Println()
-
-			// Build table rows
-			rows := make([][]string, len(keys))
-			for i, key := range keys {
-				rows[i] = []string{key, styles.Theme.Muted.Render("(hidden)")}
-			}
-
-			// Render table
-			table := components.NewTable(
-				components.WithColumns([]components.TableColumn{
-					{Title: "Key", Width: 30},
-					{Title: "Value", Width: 20},
-				}),
-				components.WithRows(rows),
-			)
-
-			fmt.Println(table.View())
-
-			return nil
-		},
+		RunE: runSecretsListCmd,
 	}
+}
+
+// runSecretsListCmd executes the secrets list command.
+func runSecretsListCmd(_ *cobra.Command, args []string) error {
+	ctx := context.Background()
+	secretDomain := args[0]
+
+	keys, attachments, isRemote, err := fetchSecretsWithAttachments(ctx, secretDomain)
+	if err != nil {
+		return err
+	}
+
+	totalSecrets := len(keys)
+	for _, att := range attachments {
+		totalSecrets += len(att.Keys)
+	}
+
+	if totalSecrets == 0 {
+		fmt.Println(styles.Theme.Muted.Render(fmt.Sprintf("No secrets configured for %s", secretDomain)))
+		return nil
+	}
+
+	title := fmt.Sprintf("Secrets for %s", secretDomain)
+	if !isRemote {
+		title = fmt.Sprintf("Secrets for %s (local)", secretDomain)
+	}
+	fmt.Println(styles.Theme.Title.Render(title))
+	fmt.Println()
+
+	rows := buildSecretsTableRows(keys, attachments)
+
+	table := components.NewTable(
+		components.WithColumns([]components.TableColumn{
+			{Title: "Key", Width: 45},
+			{Title: "Value", Width: 10},
+		}),
+		components.WithRows(rows),
+	)
+
+	fmt.Println(table.View())
+	return nil
+}
+
+// fetchSecretsWithAttachments retrieves secrets from remote or local source.
+func fetchSecretsWithAttachments(ctx context.Context, secretDomain string) ([]string, []remote.AttachmentSecrets, bool, error) {
+	client, isRemote := GetRemoteClient()
+	if isRemote {
+		result, err := client.ListSecretsWithAttachments(ctx, secretDomain)
+		if err != nil {
+			return nil, nil, isRemote, fmt.Errorf("failed to list secrets: %w", err)
+		}
+		return result.Keys, result.Attachments, isRemote, nil
+	}
+
+	local, err := GetLocalServices(configPath)
+	if err != nil {
+		return nil, nil, isRemote, fmt.Errorf("failed to initialize local services: %w", err)
+	}
+
+	keys, domainAttachments, err := local.GetSecretService().ListKeysWithAttachments(ctx, secretDomain)
+	if err != nil {
+		return nil, nil, isRemote, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	// Convert to remote.AttachmentSecrets format
+	var attachments []remote.AttachmentSecrets
+	for _, att := range domainAttachments {
+		attachments = append(attachments, remote.AttachmentSecrets{
+			Service: att.Service,
+			Keys:    att.Keys,
+		})
+	}
+
+	return keys, attachments, isRemote, nil
+}
+
+// buildSecretsTableRows builds table rows with tree structure for attachments.
+func buildSecretsTableRows(keys []string, attachments []remote.AttachmentSecrets) [][]string {
+	var rows [][]string
+
+	// Domain secrets first
+	for _, key := range keys {
+		rows = append(rows, []string{key, styles.Theme.Muted.Render("(hidden)")})
+	}
+
+	// Attachment secrets with tree structure
+	for i, att := range attachments {
+		isLastAttachment := i == len(attachments)-1
+		rows = append(rows, buildAttachmentRows(att, isLastAttachment)...)
+	}
+
+	return rows
+}
+
+// buildAttachmentRows builds table rows for a single attachment with tree structure.
+func buildAttachmentRows(att remote.AttachmentSecrets, isLastAttachment bool) [][]string {
+	var rows [][]string
+
+	// Attachment header with tree prefix
+	prefix := styles.IconTreeBranch + styles.IconTreeLine
+	if isLastAttachment {
+		prefix = styles.IconTreeLast + styles.IconTreeLine
+	}
+
+	serviceName := extractServiceName(att.Service)
+	attachmentHeader := fmt.Sprintf("%s %s", prefix, styles.Theme.Muted.Render(fmt.Sprintf("[%s]", serviceName)))
+	rows = append(rows, []string{attachmentHeader, ""})
+
+	// Keys for this attachment with nested tree structure
+	for j, key := range att.Keys {
+		isLastKey := j == len(att.Keys)-1
+		keyPrefix := getKeyPrefix(isLastAttachment, isLastKey)
+		rows = append(rows, []string{keyPrefix + " " + key, styles.Theme.Muted.Render("(hidden)")})
+	}
+
+	return rows
+}
+
+// extractServiceName extracts a short service name from a container name.
+// e.g., "gordon-git-bnema-dev-gitea-postgres" → "gitea-postgres"
+func extractServiceName(containerName string) string {
+	if !strings.HasPrefix(containerName, "gordon-") {
+		return containerName
+	}
+
+	parts := strings.SplitN(containerName, "-", 2)
+	if len(parts) <= 1 {
+		return containerName
+	}
+
+	serviceName := parts[1]
+	allParts := strings.Split(serviceName, "-")
+	if len(allParts) > 2 {
+		// Take last 2 parts as service name (e.g., "gitea-postgres")
+		return strings.Join(allParts[len(allParts)-2:], "-")
+	}
+
+	return serviceName
+}
+
+// getKeyPrefix returns the tree prefix for a key based on its position.
+func getKeyPrefix(isLastAttachment, isLastKey bool) string {
+	if isLastAttachment {
+		// Parent is last, use space continuation
+		if isLastKey {
+			return "   " + styles.IconTreeLast + styles.IconTreeLine
+		}
+		return "   " + styles.IconTreeBranch + styles.IconTreeLine
+	}
+	// Parent has siblings, use vertical line continuation
+	if isLastKey {
+		return styles.IconTreeVert + "  " + styles.IconTreeLast + styles.IconTreeLine
+	}
+	return styles.IconTreeVert + "  " + styles.IconTreeBranch + styles.IconTreeLine
 }
 
 // newSecretsSetCmd creates the secrets set command.

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -279,7 +279,7 @@ func TestHandler_SecretsGet_RequiresReadScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.wantStatus == http.StatusOK {
-				secretSvc.EXPECT().ListKeys(mock.Anything, "app.example.com").Return([]string{}, nil).Maybe()
+				secretSvc.EXPECT().ListKeysWithAttachments(mock.Anything, "app.example.com").Return([]string{}, nil, nil).Maybe()
 			}
 
 			req := httptest.NewRequest("GET", "/admin/secrets/app.example.com", nil)
@@ -535,7 +535,7 @@ func TestHandler_Reload_RequiresWriteScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.wantStatus == http.StatusOK {
-				configSvc.EXPECT().Load(mock.Anything).Return(nil).Maybe()
+				configSvc.EXPECT().Reload(mock.Anything).Return(nil).Maybe()
 			}
 
 			req := httptest.NewRequest("POST", "/admin/reload", nil)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1281,7 +1281,8 @@ func loadConfig(v *viper.Viper, configPath string) error {
 	v.SetDefault("logging.container_logs.max_age", 28)
 	v.SetDefault("env.dir", "") // defaults to {data_dir}/env when empty
 	v.SetDefault("auth.enabled", true)
-	v.SetDefault("auth.type", "password")
+	// Note: auth.type is intentionally not set - it's inferred from config
+	// If password_hash is set -> password mode, otherwise -> token mode
 	v.SetDefault("auth.secrets_backend", "unsafe")
 	v.SetDefault("auth.token_expiry", "720h")
 	v.SetDefault("api.rate_limit.enabled", true)

--- a/internal/boundaries/in/config.go
+++ b/internal/boundaries/in/config.go
@@ -11,6 +11,10 @@ type ConfigService interface {
 	// Load loads the configuration from the configured source.
 	Load(ctx context.Context) error
 
+	// Reload re-reads the configuration file from disk and loads it into memory.
+	// This is different from Load() which only loads from the cached viper values.
+	Reload(ctx context.Context) error
+
 	// GetRoutes returns all configured routes.
 	GetRoutes(ctx context.Context) []domain.Route
 

--- a/internal/boundaries/in/mocks/mock_config_service.go
+++ b/internal/boundaries/in/mocks/mock_config_service.go
@@ -805,6 +805,57 @@ func (_c *MockConfigService_Load_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// Reload provides a mock function for the type MockConfigService
+func (_mock *MockConfigService) Reload(ctx context.Context) error {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reload")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockConfigService_Reload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Reload'
+type MockConfigService_Reload_Call struct {
+	*mock.Call
+}
+
+// Reload is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockConfigService_Expecter) Reload(ctx interface{}) *MockConfigService_Reload_Call {
+	return &MockConfigService_Reload_Call{Call: _e.mock.On("Reload", ctx)}
+}
+
+func (_c *MockConfigService_Reload_Call) Run(run func(ctx context.Context)) *MockConfigService_Reload_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockConfigService_Reload_Call) Return(err error) *MockConfigService_Reload_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockConfigService_Reload_Call) RunAndReturn(run func(ctx context.Context) error) *MockConfigService_Reload_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveAttachment provides a mock function for the type MockConfigService
 func (_mock *MockConfigService) RemoveAttachment(ctx context.Context, domainOrGroup string, image string) error {
 	ret := _mock.Called(ctx, domainOrGroup, image)

--- a/internal/boundaries/in/mocks/mock_secret_service.go
+++ b/internal/boundaries/in/mocks/mock_secret_service.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	"context"
+	"gordon/internal/boundaries/out"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -232,6 +233,82 @@ func (_c *MockSecretService_ListKeys_Call) Return(strings []string, err error) *
 }
 
 func (_c *MockSecretService_ListKeys_Call) RunAndReturn(run func(ctx context.Context, domain string) ([]string, error)) *MockSecretService_ListKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListKeysWithAttachments provides a mock function for the type MockSecretService
+func (_mock *MockSecretService) ListKeysWithAttachments(ctx context.Context, domain string) ([]string, []out.AttachmentSecrets, error) {
+	ret := _mock.Called(ctx, domain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListKeysWithAttachments")
+	}
+
+	var r0 []string
+	var r1 []out.AttachmentSecrets
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, []out.AttachmentSecrets, error)); ok {
+		return returnFunc(ctx, domain)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) []out.AttachmentSecrets); ok {
+		r1 = returnFunc(ctx, domain)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]out.AttachmentSecrets)
+		}
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) error); ok {
+		r2 = returnFunc(ctx, domain)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockSecretService_ListKeysWithAttachments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListKeysWithAttachments'
+type MockSecretService_ListKeysWithAttachments_Call struct {
+	*mock.Call
+}
+
+// ListKeysWithAttachments is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+func (_e *MockSecretService_Expecter) ListKeysWithAttachments(ctx interface{}, domain interface{}) *MockSecretService_ListKeysWithAttachments_Call {
+	return &MockSecretService_ListKeysWithAttachments_Call{Call: _e.mock.On("ListKeysWithAttachments", ctx, domain)}
+}
+
+func (_c *MockSecretService_ListKeysWithAttachments_Call) Run(run func(ctx context.Context, domain string)) *MockSecretService_ListKeysWithAttachments_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSecretService_ListKeysWithAttachments_Call) Return(strings []string, attachmentSecretss []out.AttachmentSecrets, err error) *MockSecretService_ListKeysWithAttachments_Call {
+	_c.Call.Return(strings, attachmentSecretss, err)
+	return _c
+}
+
+func (_c *MockSecretService_ListKeysWithAttachments_Call) RunAndReturn(run func(ctx context.Context, domain string) ([]string, []out.AttachmentSecrets, error)) *MockSecretService_ListKeysWithAttachments_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/in/secrets.go
+++ b/internal/boundaries/in/secrets.go
@@ -1,6 +1,10 @@
 package in
 
-import "context"
+import (
+	"context"
+
+	"gordon/internal/boundaries/out"
+)
 
 // SecretService defines the contract for managing domain-scoped secrets.
 // These are environment variables stored per-domain for container injection.
@@ -8,6 +12,10 @@ type SecretService interface {
 	// ListKeys returns the list of secret keys for a domain (not values).
 	// Returns an error if the domain is invalid.
 	ListKeys(ctx context.Context, domain string) ([]string, error)
+
+	// ListKeysWithAttachments returns the list of secret keys for a domain
+	// along with any attachment secrets for containers associated with the domain.
+	ListKeysWithAttachments(ctx context.Context, domain string) ([]string, []out.AttachmentSecrets, error)
 
 	// GetAll returns all secrets for a domain as a key-value map.
 	// Returns an error if the domain is invalid.

--- a/internal/boundaries/out/domain_secrets.go
+++ b/internal/boundaries/out/domain_secrets.go
@@ -1,5 +1,13 @@
 package out
 
+// AttachmentSecrets represents secrets for an attachment container.
+type AttachmentSecrets struct {
+	// Service is the attachment service name (e.g., "gitea-postgres")
+	Service string
+	// Keys is the list of secret keys for this attachment
+	Keys []string
+}
+
 // DomainSecretStore defines the contract for managing domain-scoped secrets.
 // These are environment variables stored per-domain for container injection.
 type DomainSecretStore interface {
@@ -14,4 +22,9 @@ type DomainSecretStore interface {
 
 	// Delete removes a specific secret key from a domain.
 	Delete(domain, key string) error
+
+	// ListAttachmentKeys finds and returns secret keys for attachment containers
+	// associated with the given domain. Returns a list of AttachmentSecrets, one
+	// for each attachment that has secrets configured.
+	ListAttachmentKeys(domain string) ([]AttachmentSecrets, error)
 }

--- a/internal/boundaries/out/mocks/mock_domain_secret_store.go
+++ b/internal/boundaries/out/mocks/mock_domain_secret_store.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"gordon/internal/boundaries/out"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -150,6 +152,68 @@ func (_c *MockDomainSecretStore_GetAll_Call) Return(stringToString map[string]st
 }
 
 func (_c *MockDomainSecretStore_GetAll_Call) RunAndReturn(run func(domain string) (map[string]string, error)) *MockDomainSecretStore_GetAll_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListAttachmentKeys provides a mock function for the type MockDomainSecretStore
+func (_mock *MockDomainSecretStore) ListAttachmentKeys(domain string) ([]out.AttachmentSecrets, error) {
+	ret := _mock.Called(domain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAttachmentKeys")
+	}
+
+	var r0 []out.AttachmentSecrets
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]out.AttachmentSecrets, error)); ok {
+		return returnFunc(domain)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []out.AttachmentSecrets); ok {
+		r0 = returnFunc(domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]out.AttachmentSecrets)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(domain)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDomainSecretStore_ListAttachmentKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAttachmentKeys'
+type MockDomainSecretStore_ListAttachmentKeys_Call struct {
+	*mock.Call
+}
+
+// ListAttachmentKeys is a helper method to define mock.On call
+//   - domain string
+func (_e *MockDomainSecretStore_Expecter) ListAttachmentKeys(domain interface{}) *MockDomainSecretStore_ListAttachmentKeys_Call {
+	return &MockDomainSecretStore_ListAttachmentKeys_Call{Call: _e.mock.On("ListAttachmentKeys", domain)}
+}
+
+func (_c *MockDomainSecretStore_ListAttachmentKeys_Call) Run(run func(domain string)) *MockDomainSecretStore_ListAttachmentKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainSecretStore_ListAttachmentKeys_Call) Return(attachmentSecretss []out.AttachmentSecrets, err error) *MockDomainSecretStore_ListAttachmentKeys_Call {
+	_c.Call.Return(attachmentSecretss, err)
+	return _c
+}
+
+func (_c *MockDomainSecretStore_ListAttachmentKeys_Call) RunAndReturn(run func(domain string) ([]out.AttachmentSecrets, error)) *MockDomainSecretStore_ListAttachmentKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -85,6 +85,25 @@ func (s *Service) Load(ctx context.Context) error {
 	return nil
 }
 
+// Reload re-reads the configuration file from disk and loads it into memory.
+// This should be used when you want to pick up external changes to the config file.
+// It differs from Load() which only loads from cached viper values.
+func (s *Service) Reload(ctx context.Context) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "Reload",
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	// Re-read the config file from disk
+	if err := s.viper.ReadInConfig(); err != nil {
+		return log.WrapErr(err, "failed to read config file")
+	}
+
+	// Load the values into memory
+	return s.Load(ctx)
+}
+
 // loadConfigValues loads simple config values from viper.
 func (s *Service) loadConfigValues() Config {
 	// Prefer gordon_domain over registry_domain

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -352,6 +352,16 @@ func (s *Service) proxyToRegistry(w http.ResponseWriter, r *http.Request) {
 		func(resp *http.Response) error {
 			resp.Header.Set("X-Proxied-By", "Gordon")
 			resp.Header.Set("X-Registry-Backend", "gordon-registry")
+
+			// Remove security headers from registry response to prevent duplicates.
+			// The proxy middleware already adds these headers, so the registry's
+			// copies would create duplicates in the final response.
+			resp.Header.Del("X-Content-Type-Options")
+			resp.Header.Del("X-Frame-Options")
+			resp.Header.Del("X-XSS-Protection")
+			resp.Header.Del("Referrer-Policy")
+			resp.Header.Del("Permissions-Policy")
+
 			return nil
 		},
 	)


### PR DESCRIPTION
## Summary

Fixes 3 minor issues discovered during manual QA testing of v2.6.0+ changes.

### Issue #1: `routes remove` returns 500 for routes in config
**Root Cause:** The `/admin/reload` endpoint was calling `Load()` without first calling `ReadInConfig()`, causing the in-memory config to be out of sync with the file.

**Fixes:**
- Add `Reload()` method to `ConfigService` interface that re-reads config from disk
- Update `handleRoutesDelete` to return 404 for `ErrRouteNotFound` instead of 500

### Issue #2: `secrets list <domain>` doesn't show attachment secrets  
**Root Cause:** Attachment containers use a different env file naming convention (`gordon-{domain}-{service}.env`) that wasn't being searched.

**Fixes:**
- Add `ListAttachmentKeys()` to discover attachment env files
- Update CLI to display attachment secrets with tree structure

### Issue #3: Duplicate security headers on registry/admin endpoints
**Root Cause:** When proxy forwards to registry (localhost:5000), both apply `SecurityHeaders` middleware.

**Fix:** Strip security headers from registry response in `proxyToRegistry()`.

## Testing

All fixes verified on live VPS:
- `routes remove` now works correctly
- `secrets list` shows attachment secrets with tree structure
- No duplicate security headers on registry endpoints

## Commits
- `fix(config): add Reload method to properly re-read config from disk`
- `fix(admin): return 404 for route not found on delete`
- `feat(secrets): auto-discover and display attachment secrets`
- `fix(proxy): remove duplicate security headers on registry proxy`