### PR TITLE
fix(auth): registry push failures with token cache and scope validation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,7 @@ Deploy your first app with Gordon in under 5 minutes.
 - A Linux VPS with Docker or Podman installed
 - A domain pointing to your VPS (DNS A record)
 - Cloudflare account (free tier) for HTTPS termination
+- [pass](https://www.passwordstore.org/) (password manager) with GPG key initialized
 
 ## 1. Install Gordon
 
@@ -16,7 +17,7 @@ curl -fsSL https://gordon.bnema.dev/install | bash
 
 This script automatically detects your OS and architecture, downloads the appropriate binary, and installs it to `/usr/local/bin`.
 
-## 2. Start Gordon
+## 2. Initialize Configuration
 
 ```bash
 # First run creates the default config
@@ -26,7 +27,41 @@ gordon serve
 
 Config is created at `~/.config/gordon/gordon.toml`.
 
-## 3. Configure Your Registry Domain
+## 3. Set Up Authentication
+
+Gordon requires a `token_secret` for JWT authentication. We recommend using `pass` to store secrets securely.
+
+> **Local development?** If you just want to try Gordon locally, you can disable auth temporarily:
+> ```toml
+> [auth]
+> enabled = false
+> ```
+> Skip to [Step 4](#4-configure-your-registry-domain). For production, continue below.
+
+**Initialize pass (if not already done):**
+```bash
+# Generate a GPG key if you don't have one
+gpg --gen-key
+
+# Initialize pass with your GPG key ID
+pass init <your-gpg-key-id>
+```
+
+**Create the JWT token secret:**
+```bash
+# Generate and store a random 32-character secret
+openssl rand -base64 32 | pass insert -m gordon/auth/token_secret
+```
+
+**Update your config** (`~/.config/gordon/gordon.toml`):
+```toml
+[auth]
+enabled = true
+secrets_backend = "pass"
+token_secret = "gordon/auth/token_secret"
+```
+
+## 4. Configure Your Registry Domain
 
 Edit `~/.config/gordon/gordon.toml`:
 
@@ -34,13 +69,13 @@ Edit `~/.config/gordon/gordon.toml`:
 [server]
 port = 8080                              # Proxy port (use with Cloudflare)
 registry_port = 5000                     # Registry port
-gordon_domain = "gordon.mydomain.com"      # Your Gordon domain
+gordon_domain = "gordon.mydomain.com"    # Your Gordon domain
 
 [routes]
 "app.mydomain.com" = "myapp:latest"      # Domain → Image mapping
 ```
 
-## 4. Set Up DNS
+## 5. Set Up DNS
 
 In Cloudflare (or your DNS provider):
 
@@ -51,7 +86,7 @@ In Cloudflare (or your DNS provider):
 
 Enable Cloudflare proxy (orange cloud) for HTTPS.
 
-## 5. Start Gordon as a Service
+## 6. Start Gordon as a Service
 
 ```bash
 # Create systemd user service
@@ -75,11 +110,24 @@ systemctl --user enable --now gordon
 sudo loginctl enable-linger $USER
 ```
 
-## 6. Deploy Your First App
+## 7. Generate a Deploy Token
+
+Create a token for pushing images to your registry (skip if auth is disabled):
+
+```bash
+gordon auth token generate --subject deploy --scopes push,pull --expiry 0
+```
+
+Save this token securely - you'll need it for Docker login.
+
+## 8. Deploy Your First App
 
 On your local machine:
 
 ```bash
+# Log in to your Gordon registry (skip if auth is disabled)
+docker login -u deploy -p <your-token> registry.mydomain.com
+
 # Build your app
 docker build -t myapp .
 
@@ -92,7 +140,7 @@ docker push registry.mydomain.com/myapp:latest
 
 Your app is now live at `https://app.mydomain.com`!
 
-## 7. Update Your App
+## 9. Update Your App
 
 Push a new image to deploy with zero downtime:
 

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -352,6 +352,44 @@ The hash can be stored in your secrets backend and referenced in the config:
 }
 
 // runTokenGenerate generates a new authentication token.
+// parseAndConvertScopes parses a comma-separated scope string and converts
+// simple scopes (push, pull, *) to Docker v2 format (repository:*:action).
+func parseAndConvertScopes(scopesStr string) []string {
+	rawScopes := strings.Split(scopesStr, ",")
+	for i := range rawScopes {
+		rawScopes[i] = strings.TrimSpace(rawScopes[i])
+	}
+
+	// Check if scopes are already in v2 format (contain colons)
+	hasSimpleScope := false
+	for _, s := range rawScopes {
+		if !strings.Contains(s, ":") && (s == "push" || s == "pull" || s == "*") {
+			hasSimpleScope = true
+			break
+		}
+	}
+
+	if !hasSimpleScope {
+		return rawScopes
+	}
+
+	// Convert simple scopes to v2 format: repository:*:push,pull
+	var scopes []string
+	var actions []string
+	for _, s := range rawScopes {
+		if s == "push" || s == "pull" || s == "*" {
+			actions = append(actions, s)
+		} else {
+			// Keep non-simple scopes as-is (e.g., admin scopes)
+			scopes = append(scopes, s)
+		}
+	}
+	if len(actions) > 0 {
+		scopes = append(scopes, "repository:*:"+strings.Join(actions, ","))
+	}
+	return scopes
+}
+
 func runTokenGenerate(subject, scopesStr, expiryStr, configPath string) error {
 	cfg, err := loadAuthConfig(configPath)
 	if err != nil {
@@ -367,41 +405,7 @@ func runTokenGenerate(subject, scopesStr, expiryStr, configPath string) error {
 		}
 	}
 
-	// Parse scopes and convert simple scopes to Docker v2 format
-	// Simple scopes like "push,pull" become "repository:*:push,pull"
-	rawScopes := strings.Split(scopesStr, ",")
-	for i := range rawScopes {
-		rawScopes[i] = strings.TrimSpace(rawScopes[i])
-	}
-
-	// Check if scopes are already in v2 format (contain colons)
-	// or if they're simple scopes that need conversion
-	var scopes []string
-	hasSimpleScope := false
-	for _, s := range rawScopes {
-		if !strings.Contains(s, ":") && (s == "push" || s == "pull" || s == "*") {
-			hasSimpleScope = true
-			break
-		}
-	}
-
-	if hasSimpleScope {
-		// Convert simple scopes to v2 format: repository:*:push,pull
-		var actions []string
-		for _, s := range rawScopes {
-			if s == "push" || s == "pull" || s == "*" {
-				actions = append(actions, s)
-			} else {
-				// Keep non-simple scopes as-is (e.g., admin scopes)
-				scopes = append(scopes, s)
-			}
-		}
-		if len(actions) > 0 {
-			scopes = append(scopes, "repository:*:"+strings.Join(actions, ","))
-		}
-	} else {
-		scopes = rawScopes
-	}
+	scopes := parseAndConvertScopes(scopesStr)
 
 	// Create auth service
 	log := zerowrap.New(zerowrap.Config{Level: "warn"})

--- a/internal/adapters/in/http/middleware/auth.go
+++ b/internal/adapters/in/http/middleware/auth.go
@@ -312,33 +312,28 @@ func isInternalRegistryAuth(r *http.Request, internalAuth InternalRegistryAuth) 
 	return usernameMatch && passwordMatch
 }
 
-// checkScopeAccess verifies the token has permission for the requested operation.
-// Maps HTTP method to registry action and checks if any token scope grants access.
-func checkScopeAccess(r *http.Request, claims *domain.TokenClaims, log zerowrap.Logger) bool {
-	// Determine required action from HTTP method
-	var action string
-	switch r.Method {
+// actionFromMethod returns the registry action for an HTTP method.
+func actionFromMethod(method string) string {
+	switch method {
 	case http.MethodGet, http.MethodHead:
-		action = domain.ScopeActionPull
+		return domain.ScopeActionPull
 	case http.MethodPut, http.MethodPost, http.MethodPatch, http.MethodDelete:
-		action = domain.ScopeActionPush
+		return domain.ScopeActionPush
 	default:
-		action = domain.ScopeActionPull // Default to pull for unknown methods
+		return domain.ScopeActionPull
 	}
+}
 
-	// Extract repository name from URL path
-	// Paths are like /v2/{name}/manifests/{reference} or /v2/{name}/blobs/{digest}
-	path := r.URL.Path
+// extractRepoName extracts the repository name from a registry path.
+// Returns empty string if the path is not a valid registry path or should be allowed.
+func extractRepoName(path string) (repoName string, shouldAllow bool) {
 	if !strings.HasPrefix(path, "/v2/") {
-		// Not a registry path, allow
-		return true
+		return "", true // Not a registry path, allow
 	}
 
-	// Remove /v2/ prefix and find repository name
 	pathParts := strings.Split(strings.TrimPrefix(path, "/v2/"), "/")
 	if len(pathParts) < 2 {
-		// Malformed path or /v2/ root, allow
-		return true
+		return "", true // Malformed path or /v2/ root, allow
 	}
 
 	// Find the boundary between repo name and route (manifests, blobs, tags)
@@ -350,16 +345,25 @@ func checkScopeAccess(r *http.Request, claims *domain.TokenClaims, log zerowrap.
 		}
 	}
 	if len(repoNameParts) == 0 {
-		// Could be a special route like /v2/token, allow
-		return true
+		return "", true // Special route like /v2/token, allow
 	}
 
-	repoName := strings.Join(repoNameParts, "/")
+	return strings.Join(repoNameParts, "/"), false
+}
+
+// checkScopeAccess verifies the token has permission for the requested operation.
+// Maps HTTP method to registry action and checks if any token scope grants access.
+func checkScopeAccess(r *http.Request, claims *domain.TokenClaims, log zerowrap.Logger) bool {
+	action := actionFromMethod(r.Method)
+
+	repoName, shouldAllow := extractRepoName(r.URL.Path)
+	if shouldAllow {
+		return true
+	}
 
 	// Check if any token scope grants access
 	for _, scopeStr := range claims.Scopes {
 		// Handle simple scopes (e.g., "push", "pull") for backwards compatibility
-		// with tokens generated before v2 scope format was enforced
 		if scopeStr == action || scopeStr == "*" {
 			log.Debug().
 				Str("repo", repoName).
@@ -372,7 +376,6 @@ func checkScopeAccess(r *http.Request, claims *domain.TokenClaims, log zerowrap.
 		// Handle Docker v2 format scopes (e.g., "repository:myrepo:push,pull")
 		scope, err := domain.ParseScope(scopeStr)
 		if err != nil {
-			log.Debug().Err(err).Str("scope", scopeStr).Msg("scope not in v2 format, skipping")
 			continue
 		}
 

--- a/internal/adapters/out/tokenstore/pass.go
+++ b/internal/adapters/out/tokenstore/pass.go
@@ -242,7 +242,10 @@ func (s *PassStore) Revoke(ctx context.Context, tokenID string) error {
 	// Update cache
 	s.cacheMu.Lock()
 	s.revokedList = revokedList
-	s.revokedSet[tokenID] = struct{}{}
+	s.revokedSet = make(map[string]struct{}, len(revokedList))
+	for _, id := range revokedList {
+		s.revokedSet[id] = struct{}{}
+	}
 	s.cacheMu.Unlock()
 
 	s.log.Info().
@@ -280,9 +283,9 @@ func (s *PassStore) IsRevoked(ctx context.Context, tokenID string) (bool, error)
 	for _, id := range revokedList {
 		s.revokedSet[id] = struct{}{}
 	}
+	_, revoked := s.revokedSet[tokenID]
 	s.cacheMu.Unlock()
 
-	_, revoked := s.revokedSet[tokenID]
 	return revoked, nil
 }
 

--- a/internal/adapters/out/tokenstore/pass_test.go
+++ b/internal/adapters/out/tokenstore/pass_test.go
@@ -1,0 +1,254 @@
+package tokenstore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gordon/internal/domain"
+)
+
+// These tests verify the in-memory caching behavior of PassStore.
+// They directly manipulate the cache to test cache hit/miss logic
+// without requiring the actual pass binary.
+
+func newTestPassStore() *PassStore {
+	return &PassStore{
+		timeout:    10 * time.Second,
+		tokenCache: make(map[string]*cachedToken),
+		revokedSet: make(map[string]struct{}),
+	}
+}
+
+func TestPassStore_GetToken_CacheHit(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate cache
+	expectedToken := &domain.Token{
+		ID:        "test-id",
+		Subject:   "test-subject",
+		Scopes:    []string{"push", "pull"},
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	expectedJWT := "cached-jwt-token"
+
+	store.cacheMu.Lock()
+	store.tokenCache["test-subject"] = &cachedToken{
+		jwt:   expectedJWT,
+		token: expectedToken,
+	}
+	store.cacheMu.Unlock()
+
+	// Should return cached value without calling pass
+	jwt, token, err := store.GetToken(context.Background(), "test-subject")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedJWT, jwt)
+	assert.Equal(t, expectedToken.ID, token.ID)
+	assert.Equal(t, expectedToken.Subject, token.Subject)
+	assert.Equal(t, expectedToken.Scopes, token.Scopes)
+}
+
+func TestPassStore_GetToken_CacheMiss_ReturnsNotFound(t *testing.T) {
+	store := newTestPassStore()
+
+	// Cache miss should try to call pass (which will fail in test env)
+	_, _, err := store.GetToken(context.Background(), "nonexistent")
+
+	// Should return ErrTokenNotFound since pass won't have this token
+	assert.ErrorIs(t, err, domain.ErrTokenNotFound)
+}
+
+func TestPassStore_IsRevoked_CacheHit_Revoked(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate revocation cache
+	store.cacheMu.Lock()
+	store.revokedList = []string{"revoked-token-1", "revoked-token-2"}
+	store.revokedSet = map[string]struct{}{
+		"revoked-token-1": {},
+		"revoked-token-2": {},
+	}
+	store.cacheMu.Unlock()
+
+	// Check revoked token
+	revoked, err := store.IsRevoked(context.Background(), "revoked-token-1")
+	require.NoError(t, err)
+	assert.True(t, revoked)
+}
+
+func TestPassStore_IsRevoked_CacheHit_NotRevoked(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate revocation cache with some revoked tokens
+	store.cacheMu.Lock()
+	store.revokedList = []string{"revoked-token-1"}
+	store.revokedSet = map[string]struct{}{
+		"revoked-token-1": {},
+	}
+	store.cacheMu.Unlock()
+
+	// Check non-revoked token (cache is populated, so no pass call)
+	revoked, err := store.IsRevoked(context.Background(), "valid-token")
+	require.NoError(t, err)
+	assert.False(t, revoked)
+}
+
+func TestPassStore_CacheUpdate_OnSave(t *testing.T) {
+	store := newTestPassStore()
+
+	token := &domain.Token{
+		ID:        "new-token-id",
+		Subject:   "new-subject",
+		Scopes:    []string{"push"},
+		IssuedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	jwt := "new-jwt-token"
+
+	// Simulate what SaveToken does to the cache
+	store.cacheMu.Lock()
+	store.tokenCache[token.Subject] = &cachedToken{jwt: jwt, token: token}
+	store.cacheMu.Unlock()
+
+	// Verify cache was updated - subsequent GetToken should hit cache
+	gotJWT, gotToken, err := store.GetToken(context.Background(), "new-subject")
+
+	require.NoError(t, err)
+	assert.Equal(t, jwt, gotJWT)
+	assert.Equal(t, token.ID, gotToken.ID)
+}
+
+func TestPassStore_CacheClear_OnDelete(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate cache
+	store.cacheMu.Lock()
+	store.tokenCache["to-delete"] = &cachedToken{
+		jwt:   "some-jwt",
+		token: &domain.Token{ID: "id", Subject: "to-delete"},
+	}
+	store.cacheMu.Unlock()
+
+	// Simulate what DeleteToken does to the cache
+	store.cacheMu.Lock()
+	delete(store.tokenCache, "to-delete")
+	store.cacheMu.Unlock()
+
+	// Verify cache entry was removed
+	store.cacheMu.RLock()
+	_, ok := store.tokenCache["to-delete"]
+	store.cacheMu.RUnlock()
+
+	assert.False(t, ok)
+}
+
+func TestPassStore_GetToken_ConcurrentAccess(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate cache
+	expectedToken := &domain.Token{
+		ID:      "concurrent-id",
+		Subject: "concurrent-subject",
+		Scopes:  []string{"push", "pull"},
+	}
+	expectedJWT := "concurrent-jwt"
+
+	store.cacheMu.Lock()
+	store.tokenCache["concurrent-subject"] = &cachedToken{
+		jwt:   expectedJWT,
+		token: expectedToken,
+	}
+	store.cacheMu.Unlock()
+
+	// Simulate concurrent access (like Docker buildx parallel requests)
+	var wg sync.WaitGroup
+	errors := make([]error, 0)
+	var errMu sync.Mutex
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			jwt, token, err := store.GetToken(context.Background(), "concurrent-subject")
+			if err != nil {
+				errMu.Lock()
+				errors = append(errors, err)
+				errMu.Unlock()
+				return
+			}
+			if jwt != expectedJWT || token.ID != expectedToken.ID {
+				errMu.Lock()
+				errors = append(errors, assert.AnError)
+				errMu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Empty(t, errors, "concurrent access should not produce errors")
+}
+
+func TestPassStore_IsRevoked_ConcurrentAccess(t *testing.T) {
+	store := newTestPassStore()
+
+	// Pre-populate revocation cache
+	store.cacheMu.Lock()
+	store.revokedList = []string{"revoked-1"}
+	store.revokedSet = map[string]struct{}{"revoked-1": {}}
+	store.cacheMu.Unlock()
+
+	// Simulate concurrent access
+	var wg sync.WaitGroup
+	errors := make([]error, 0)
+	var errMu sync.Mutex
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			revoked, err := store.IsRevoked(context.Background(), "revoked-1")
+			if err != nil {
+				errMu.Lock()
+				errors = append(errors, err)
+				errMu.Unlock()
+				return
+			}
+			if !revoked {
+				errMu.Lock()
+				errors = append(errors, assert.AnError)
+				errMu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Empty(t, errors, "concurrent access should not produce errors")
+}
+
+func TestPassStore_RevokeUpdatesCache(t *testing.T) {
+	store := newTestPassStore()
+
+	// Initialize empty revocation cache
+	store.cacheMu.Lock()
+	store.revokedList = []string{}
+	store.revokedSet = make(map[string]struct{})
+	store.cacheMu.Unlock()
+
+	// Simulate what Revoke does to the cache
+	tokenID := "newly-revoked"
+	store.cacheMu.Lock()
+	store.revokedList = append(store.revokedList, tokenID)
+	store.revokedSet[tokenID] = struct{}{}
+	store.cacheMu.Unlock()
+
+	// Verify IsRevoked now returns true from cache
+	revoked, err := store.IsRevoked(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+}


### PR DESCRIPTION
## Summary

Fixes registry push failures (403 Forbidden) caused by two issues:

1. **GPG agent overload**: Docker buildx makes many concurrent requests, each triggering multiple `pass show` calls for token validation. GPG agent gets overwhelmed and kills processes with `signal: killed`.

2. **Scope format mismatch**: CLI-generated tokens stored simple scopes (`["push", "pull"]`) but the auth middleware expected Docker v2 format (`repository:*:push,pull`).

## Changes

### Token Cache (`internal/adapters/out/tokenstore/pass.go`)
- Add in-memory cache for tokens and revocation list
- First lookup populates cache, subsequent requests use cached values
- Thread-safe with `sync.RWMutex`
- Cache invalidated on save/delete/revoke operations

### Scope Validation (`internal/adapters/in/http/middleware/auth.go`)
- Add backwards compatibility for simple scopes (`push`, `pull`, `*`)
- Existing tokens with simple scopes continue to work

### CLI Token Generation (`internal/adapters/in/cli/auth.go`)
- Convert simple scopes to Docker v2 format when generating tokens
- `--scopes push,pull` now stores as `repository:*:push,pull`

### Documentation (`docs/getting-started.md`)
- Add authentication setup instructions with pass
- Include token generation and docker login steps

## Testing

- Added unit tests for cache behavior in `pass_test.go`
- Tested concurrent access patterns
- Verified docker buildx push works after fix