### PR TITLE
chore: update module path and bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
           go-version: stable
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-go-mod-
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -53,14 +53,14 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
           go-version: stable
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-go-mod-
 
       - name: Cache Go build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for optimized container image
 
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -46,7 +46,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Deploy to Gordon
         uses: bnema/gordon/.github/actions/deploy@main
@@ -103,7 +103,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Deploy to Gordon
         uses: bnema/gordon/.github/actions/deploy@main
@@ -129,7 +129,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Deploy to Gordon
         uses: bnema/gordon/.github/actions/deploy@main
@@ -158,7 +158,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -187,7 +187,7 @@ jobs:
   deploy-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bnema/gordon/.github/actions/deploy@main
         with:
           registry: ${{ secrets.GORDON_REGISTRY }}
@@ -200,7 +200,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bnema/gordon/.github/actions/deploy@main
         with:
           registry: ${{ secrets.GORDON_REGISTRY }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module gordon
+module github.com/bnema/gordon
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/bnema/zerowrap v1.3.0

--- a/internal/adapters/in/cli/attachments.go
+++ b/internal/adapters/in/cli/attachments.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"sort"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/adapters/in/cli/ui/components"
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -13,14 +13,14 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/adapters/in/cli/ui/styles"
-	"gordon/internal/adapters/out/secrets"
-	"gordon/internal/adapters/out/tokenstore"
-	"gordon/internal/app"
-	"gordon/internal/domain"
-	"gordon/internal/usecase/auth"
-	"gordon/pkg/duration"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/out/secrets"
+	"github.com/bnema/gordon/internal/adapters/out/tokenstore"
+	"github.com/bnema/gordon/internal/app"
+	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/auth"
+	"github.com/bnema/gordon/pkg/duration"
 )
 
 // newAuthCmd creates the auth command group.
@@ -344,7 +344,7 @@ The hash can be stored in your secrets backend and referenced in the config:
 
   [auth]
   type = "password"
-  password_hash = "gordon/auth/password_hash"`,
+  password_hash = "github.com/bnema/gordon/auth/password_hash"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPasswordHash()
 		},
@@ -564,7 +564,7 @@ func runPasswordHash() error {
 	fmt.Println("Then reference the path in your config:")
 	fmt.Println("  [auth]")
 	fmt.Println("  type = \"password\"")
-	fmt.Println("  password_hash = \"gordon/auth/password_hash\"")
+	fmt.Println("  password_hash = \"github.com/bnema/gordon/auth/password_hash\"")
 
 	return nil
 }

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"gordon/internal/adapters/in/cli/ui/styles"
-	"gordon/internal/app"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/app"
 )
 
 // newDeployCmd creates the deploy command.

--- a/internal/adapters/in/cli/local.go
+++ b/internal/adapters/in/cli/local.go
@@ -9,11 +9,11 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/spf13/viper"
 
-	"gordon/internal/adapters/out/domainsecrets"
-	"gordon/internal/app"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/usecase/config"
-	secretsSvc "gordon/internal/usecase/secrets"
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+	"github.com/bnema/gordon/internal/app"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/usecase/config"
+	secretsSvc "github.com/bnema/gordon/internal/usecase/secrets"
 )
 
 // LocalServices provides direct access to local services for CLI operations.

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Client is an HTTP client for the Gordon admin API.

--- a/internal/adapters/in/cli/remotes.go
+++ b/internal/adapters/in/cli/remotes.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/adapters/in/cli/ui/components"
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/app"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/app"
 )
 
 var (

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/adapters/in/cli/ui/components"
-	"gordon/internal/adapters/in/cli/ui/styles"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/domain"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"gordon/internal/adapters/in/cli/remote"
-	"gordon/internal/adapters/in/cli/ui/components"
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/adapters/in/cli/serve.go
+++ b/internal/adapters/in/cli/serve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"gordon/internal/app"
+	"github.com/bnema/gordon/internal/app"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/adapters/in/cli/ui/components/confirm.go
+++ b/internal/adapters/in/cli/ui/components/confirm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"

--- a/internal/adapters/in/cli/ui/components/form.go
+++ b/internal/adapters/in/cli/ui/components/form.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/adapters/in/cli/ui/components/spinner.go
+++ b/internal/adapters/in/cli/ui/components/spinner.go
@@ -2,7 +2,7 @@
 package components
 
 import (
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/adapters/in/cli/ui/components/status.go
+++ b/internal/adapters/in/cli/ui/components/status.go
@@ -3,7 +3,7 @@ package components
 import (
 	"strings"
 
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/charmbracelet/lipgloss"
 )

--- a/internal/adapters/in/cli/ui/components/table.go
+++ b/internal/adapters/in/cli/ui/components/table.go
@@ -1,7 +1,7 @@
 package components
 
 import (
-	"gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // maxAdminRequestSize is the maximum allowed size for admin API request bodies.

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	inmocks "gordon/internal/boundaries/in/mocks"
-	"gordon/internal/domain"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/adapters/in/http/admin/middleware.go
+++ b/internal/adapters/in/http/admin/middleware.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/adapters/in/http/middleware"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // contextKey is a custom type for context keys to avoid collisions.

--- a/internal/adapters/in/http/admin/middleware_test.go
+++ b/internal/adapters/in/http/admin/middleware_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/adapters/in/http/middleware"
-	inmocks "gordon/internal/boundaries/in/mocks"
-	outmocks "gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func adminTestLogger() zerowrap.Logger {

--- a/internal/adapters/in/http/auth/handler.go
+++ b/internal/adapters/in/http/auth/handler.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // InternalAuth holds credentials for internal loopback registry access.

--- a/internal/adapters/in/http/auth/handler_test.go
+++ b/internal/adapters/in/http/auth/handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/in/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/adapters/in/http/middleware/auth.go
+++ b/internal/adapters/in/http/middleware/auth.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // contextKey is a type for context keys used by this package.

--- a/internal/adapters/in/http/middleware/auth_test.go
+++ b/internal/adapters/in/http/middleware/auth_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/adapters/in/http/middleware/logging.go
+++ b/internal/adapters/in/http/middleware/logging.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/dto"
 )
 
 // ResponseWriter wraps http.ResponseWriter to capture status code and bytes written.

--- a/internal/adapters/in/http/proxy/handler.go
+++ b/internal/adapters/in/http/proxy/handler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/in"
 )
 
 // Handler wraps the proxy service for HTTP.

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/boundaries/in"
-	"gordon/internal/domain"
-	"gordon/pkg/manifest"
-	"gordon/pkg/validation"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/pkg/manifest"
+	"github.com/bnema/gordon/pkg/validation"
 )
 
 const (

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	inmocks "gordon/internal/boundaries/in/mocks"
-	"gordon/internal/domain"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/adapters/in/http/registry/ratelimit.go
+++ b/internal/adapters/in/http/registry/ratelimit.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/adapters/dto"
-	"gordon/internal/adapters/in/http/middleware"
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // RateLimitMiddleware creates rate limiting middleware for the registry API.

--- a/internal/adapters/in/http/registry/ratelimit_test.go
+++ b/internal/adapters/in/http/registry/ratelimit_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"gordon/internal/adapters/in/http/middleware"
-	"gordon/internal/adapters/out/ratelimit"
-	outmocks "gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/adapters/out/ratelimit"
+	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
 )
 
 func TestRateLimitMiddleware_Disabled(t *testing.T) {

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Runtime implements the ContainerRuntime interface using Docker API.

--- a/internal/adapters/out/domainsecrets/store.go
+++ b/internal/adapters/out/domainsecrets/store.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // FileStore implements the DomainSecretStore interface using filesystem-based env files.

--- a/internal/adapters/out/domainsecrets/store_test.go
+++ b/internal/adapters/out/domainsecrets/store_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/adapters/out/envloader/file.go
+++ b/internal/adapters/out/envloader/file.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // FileLoader implements the EnvLoader interface using filesystem-based env files.

--- a/internal/adapters/out/envloader/file_test.go
+++ b/internal/adapters/out/envloader/file_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
 )
 
 func TestFileLoader_ResolveSecrets(t *testing.T) {

--- a/internal/adapters/out/eventbus/inmemory.go
+++ b/internal/adapters/out/eventbus/inmemory.go
@@ -10,8 +10,8 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/google/uuid"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // InMemory implements the EventBus interface using in-memory channels.

--- a/internal/adapters/out/filesystem/blob.go
+++ b/internal/adapters/out/filesystem/blob.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/pkg/validation"
+	"github.com/bnema/gordon/pkg/validation"
 )
 
 // BlobStorage implements the BlobStorage interface using the local filesystem.

--- a/internal/adapters/out/filesystem/manifest.go
+++ b/internal/adapters/out/filesystem/manifest.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/pkg/validation"
+	"github.com/bnema/gordon/pkg/validation"
 )
 
 // ManifestStorage implements the ManifestStorage interface using the local filesystem.

--- a/internal/adapters/out/ratelimit/memory.go
+++ b/internal/adapters/out/ratelimit/memory.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"golang.org/x/time/rate"
 
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // Ensure MemoryStore implements out.RateLimiter.

--- a/internal/adapters/out/ratelimit/store.go
+++ b/internal/adapters/out/ratelimit/store.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // NewStore creates a RateLimiter based on the configured backend.

--- a/internal/adapters/out/secrets/pass.go
+++ b/internal/adapters/out/secrets/pass.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // passPathRegex validates pass paths.

--- a/internal/adapters/out/secrets/pass_test.go
+++ b/internal/adapters/out/secrets/pass_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestValidatePath(t *testing.T) {
@@ -22,7 +22,7 @@ func TestValidatePath(t *testing.T) {
 		// Valid paths
 		{
 			name:    "simple path",
-			path:    "gordon/registry/secret",
+			path:    "github.com/bnema/gordon/registry/secret",
 			wantErr: false,
 		},
 		{
@@ -168,7 +168,7 @@ func TestPassProvider_GetSecret_PathValidation(t *testing.T) {
 	}{
 		{
 			name:    "valid path rejected due to pass not installed",
-			path:    "gordon/test/secret",
+			path:    "github.com/bnema/gordon/test/secret",
 			wantErr: true, // Will fail because pass command doesn't exist in test, but path is valid
 		},
 		{

--- a/internal/adapters/out/tokenstore/pass.go
+++ b/internal/adapters/out/tokenstore/pass.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ansiRegex matches ANSI escape sequences for stripping from pass output.
@@ -21,9 +21,9 @@ var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 const (
 	// passTokenPath is the base path for tokens in pass.
-	passTokenPath = "gordon/registry/tokens"
+	passTokenPath = "gordon/registry/tokens" //nolint:gosec // Not a credential, this is a pass store path
 	// passRevokedPath is the path for the revocation list in pass.
-	passRevokedPath = "gordon/registry/revoked"
+	passRevokedPath = "gordon/registry/revoked" //nolint:gosec // Not a credential, this is a pass store path
 )
 
 // cachedToken holds a token and its JWT in memory.

--- a/internal/adapters/out/tokenstore/pass_test.go
+++ b/internal/adapters/out/tokenstore/pass_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // These tests verify the in-memory caching behavior of PassStore.

--- a/internal/adapters/out/tokenstore/store.go
+++ b/internal/adapters/out/tokenstore/store.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // NewStore creates a TokenStore based on the configured backend.

--- a/internal/adapters/out/tokenstore/unsafe.go
+++ b/internal/adapters/out/tokenstore/unsafe.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // sanitizeSubject creates a safe filename from a subject by hashing it.

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -21,41 +21,41 @@ import (
 	"github.com/spf13/viper"
 
 	// Adapters - Output
-	"gordon/internal/adapters/out/docker"
-	"gordon/internal/adapters/out/domainsecrets"
-	"gordon/internal/adapters/out/envloader"
-	"gordon/internal/adapters/out/eventbus"
-	"gordon/internal/adapters/out/filesystem"
-	"gordon/internal/adapters/out/httpprober"
-	"gordon/internal/adapters/out/logwriter"
-	"gordon/internal/adapters/out/ratelimit"
-	"gordon/internal/adapters/out/secrets"
-	"gordon/internal/adapters/out/tokenstore"
+	"github.com/bnema/gordon/internal/adapters/out/docker"
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+	"github.com/bnema/gordon/internal/adapters/out/envloader"
+	"github.com/bnema/gordon/internal/adapters/out/eventbus"
+	"github.com/bnema/gordon/internal/adapters/out/filesystem"
+	"github.com/bnema/gordon/internal/adapters/out/httpprober"
+	"github.com/bnema/gordon/internal/adapters/out/logwriter"
+	"github.com/bnema/gordon/internal/adapters/out/ratelimit"
+	"github.com/bnema/gordon/internal/adapters/out/secrets"
+	"github.com/bnema/gordon/internal/adapters/out/tokenstore"
 
 	// Adapters - Input
-	"gordon/internal/adapters/in/http/admin"
-	authhandler "gordon/internal/adapters/in/http/auth"
-	"gordon/internal/adapters/in/http/middleware"
-	"gordon/internal/adapters/in/http/registry"
+	"github.com/bnema/gordon/internal/adapters/in/http/admin"
+	authhandler "github.com/bnema/gordon/internal/adapters/in/http/auth"
+	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/adapters/in/http/registry"
 
 	// Boundaries
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 
 	// Domain
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	// Use cases
-	"gordon/internal/usecase/auth"
-	"gordon/internal/usecase/config"
-	"gordon/internal/usecase/container"
-	"gordon/internal/usecase/health"
-	"gordon/internal/usecase/logs"
-	"gordon/internal/usecase/proxy"
-	registrySvc "gordon/internal/usecase/registry"
-	secretsSvc "gordon/internal/usecase/secrets"
+	"github.com/bnema/gordon/internal/usecase/auth"
+	"github.com/bnema/gordon/internal/usecase/config"
+	"github.com/bnema/gordon/internal/usecase/container"
+	"github.com/bnema/gordon/internal/usecase/health"
+	"github.com/bnema/gordon/internal/usecase/logs"
+	"github.com/bnema/gordon/internal/usecase/proxy"
+	registrySvc "github.com/bnema/gordon/internal/usecase/registry"
+	secretsSvc "github.com/bnema/gordon/internal/usecase/secrets"
 
 	// Pkg
-	"gordon/pkg/duration"
+	"github.com/bnema/gordon/pkg/duration"
 )
 
 // Config holds the application configuration.

--- a/internal/boundaries/in/auth.go
+++ b/internal/boundaries/in/auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // AuthService defines the contract for registry authentication operations.

--- a/internal/boundaries/in/config.go
+++ b/internal/boundaries/in/config.go
@@ -3,7 +3,7 @@ package in
 import (
 	"context"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ConfigService defines the contract for configuration management.

--- a/internal/boundaries/in/container.go
+++ b/internal/boundaries/in/container.go
@@ -6,7 +6,7 @@ package in
 import (
 	"context"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ContainerService defines the contract for container management operations.

--- a/internal/boundaries/in/health.go
+++ b/internal/boundaries/in/health.go
@@ -6,7 +6,7 @@ package in
 import (
 	"context"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // HealthService defines the contract for route health checking operations.

--- a/internal/boundaries/in/mocks/mock_auth_service.go
+++ b/internal/boundaries/in/mocks/mock_auth_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 	"time"
 
 	mock "github.com/stretchr/testify/mock"

--- a/internal/boundaries/in/mocks/mock_config_service.go
+++ b/internal/boundaries/in/mocks/mock_config_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/in/mocks/mock_container_service.go
+++ b/internal/boundaries/in/mocks/mock_container_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/in/mocks/mock_health_service.go
+++ b/internal/boundaries/in/mocks/mock_health_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/in/mocks/mock_proxy_service.go
+++ b/internal/boundaries/in/mocks/mock_proxy_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 	"net/http"
 
 	mock "github.com/stretchr/testify/mock"

--- a/internal/boundaries/in/mocks/mock_registry_service.go
+++ b/internal/boundaries/in/mocks/mock_registry_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 	"io"
 
 	mock "github.com/stretchr/testify/mock"

--- a/internal/boundaries/in/mocks/mock_secret_service.go
+++ b/internal/boundaries/in/mocks/mock_secret_service.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/in/proxy.go
+++ b/internal/boundaries/in/proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ProxyService defines the contract for reverse proxy operations.

--- a/internal/boundaries/in/registry.go
+++ b/internal/boundaries/in/registry.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // RegistryService defines the contract for container registry operations.

--- a/internal/boundaries/in/secrets.go
+++ b/internal/boundaries/in/secrets.go
@@ -3,7 +3,7 @@ package in
 import (
 	"context"
 
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // SecretService defines the contract for managing domain-scoped secrets.

--- a/internal/boundaries/out/eventbus.go
+++ b/internal/boundaries/out/eventbus.go
@@ -1,7 +1,7 @@
 package out
 
 import (
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // EventHandler defines the contract for handling events.

--- a/internal/boundaries/out/mocks/mock_container_runtime.go
+++ b/internal/boundaries/out/mocks/mock_container_runtime.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 	"io"
 
 	mock "github.com/stretchr/testify/mock"

--- a/internal/boundaries/out/mocks/mock_domain_secret_store.go
+++ b/internal/boundaries/out/mocks/mock_domain_secret_store.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/mocks/mock_event_bus.go
+++ b/internal/boundaries/out/mocks/mock_event_bus.go
@@ -5,8 +5,8 @@
 package mocks
 
 import (
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/mocks/mock_event_handler.go
+++ b/internal/boundaries/out/mocks/mock_event_handler.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/mocks/mock_event_publisher.go
+++ b/internal/boundaries/out/mocks/mock_event_publisher.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/mocks/mock_event_subscriber.go
+++ b/internal/boundaries/out/mocks/mock_event_subscriber.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/mocks/mock_token_store.go
+++ b/internal/boundaries/out/mocks/mock_token_store.go
@@ -6,7 +6,7 @@ package mocks
 
 import (
 	"context"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 
 	mock "github.com/stretchr/testify/mock"
 )

--- a/internal/boundaries/out/runtime.go
+++ b/internal/boundaries/out/runtime.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"io"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ContainerRuntime defines the contract for container runtime operations.

--- a/internal/boundaries/out/token_store.go
+++ b/internal/boundaries/out/token_store.go
@@ -3,7 +3,7 @@ package out
 import (
 	"context"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // TokenStore defines the contract for storing and managing authentication tokens.

--- a/internal/testutils/mocks/runtime_gen.go
+++ b/internal/testutils/mocks/runtime_gen.go
@@ -11,7 +11,7 @@ package mocks
 
 import (
 	context "context"
-	runtime "gordon/pkg/runtime"
+	runtime "github.com/bnema/gordon/pkg/runtime"
 	io "io"
 	reflect "reflect"
 

--- a/internal/usecase/auth/service.go
+++ b/internal/usecase/auth/service.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 const (

--- a/internal/usecase/auth/service_test.go
+++ b/internal/usecase/auth/service_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testContext() context.Context {

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -12,8 +12,8 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Config holds the loaded configuration.

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testContext() context.Context {

--- a/internal/usecase/container/autoroute.go
+++ b/internal/usecase/container/autoroute.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // EnvFileExtractor defines the interface for extracting env files from images.

--- a/internal/usecase/container/autoroute_test.go
+++ b/internal/usecase/container/autoroute_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	inmocks "gordon/internal/boundaries/in/mocks"
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // domainToEnvFileName tests

--- a/internal/usecase/container/events.go
+++ b/internal/usecase/container/events.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // ImagePushedHandler handles image.pushed events.

--- a/internal/usecase/container/events_test.go
+++ b/internal/usecase/container/events_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	inmocks "gordon/internal/boundaries/in/mocks"
-	"gordon/internal/domain"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testCtx() context.Context {

--- a/internal/usecase/container/routes_test.go
+++ b/internal/usecase/container/routes_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestService_ListRoutesWithDetails(t *testing.T) {

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Config holds configuration needed by the container service.

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testContext() context.Context {

--- a/internal/usecase/health/service.go
+++ b/internal/usecase/health/service.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // maxConcurrentProbes limits the number of concurrent health probes to prevent resource exhaustion.

--- a/internal/usecase/health/service_test.go
+++ b/internal/usecase/health/service_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/in/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {

--- a/internal/usecase/logs/service.go
+++ b/internal/usecase/logs/service.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // Service implements the LogService interface.

--- a/internal/usecase/logs/service_test.go
+++ b/internal/usecase/logs/service_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/boundaries/in/mocks"
-	outMocks "gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in/mocks"
+	outMocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestService_GetProcessLogs(t *testing.T) {

--- a/internal/usecase/proxy/events.go
+++ b/internal/usecase/proxy/events.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // TargetInvalidator defines the interface for invalidating proxy targets.

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/in"
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // proxyTransport is a shared HTTP transport with proper timeouts.

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	inmocks "gordon/internal/boundaries/in/mocks"
-	outmocks "gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testContext() context.Context {

--- a/internal/usecase/proxy/ssrf.go
+++ b/internal/usecase/proxy/ssrf.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"sync"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // blockedCIDRStrings contains CIDR blocks that should never be proxied to.

--- a/internal/usecase/proxy/ssrf_test.go
+++ b/internal/usecase/proxy/ssrf_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestIsBlockedTarget_IPAddresses(t *testing.T) {

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Service implements the RegistryService interface.

--- a/internal/usecase/registry/service_test.go
+++ b/internal/usecase/registry/service_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/out/mocks"
-	"gordon/internal/domain"
+	"github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testContext() context.Context {

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/boundaries/out"
 )
 
 // Domain validation errors.

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"gordon/internal/boundaries/out"
-	outmocks "gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
 )
 
 func testLogger() zerowrap.Logger {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"gordon/internal/adapters/in/cli"
+	"github.com/bnema/gordon/internal/adapters/in/cli"
 )
 
 // Build information set by goreleaser via ldflags


### PR DESCRIPTION
## Summary

- Change module path from `gordon` to `github.com/bnema/gordon` for Go Report Card compatibility
- Update Go version from 1.25.5 to 1.25.6
- Bump GitHub Actions and Dockerfile to latest versions

## Changes

| Component | Before | After |
|-----------|--------|-------|
| Module path | `gordon` | `github.com/bnema/gordon` |
| Go version | 1.25.5 | 1.25.6 |
| Dockerfile | `golang:1.24-alpine` | `golang:1.25-alpine` |
| actions/checkout | v4 | v6 |
| actions/cache | v4 | v5 |
| golangci-lint-action | v7 | v9 |

## Why

Go Report Card was showing v0.1.17 instead of current version because the module path didn't match the GitHub repository URL. This change allows Go Report Card to properly identify and analyze the latest code.

## Testing

- [x] `go build .` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes