### PR TITLE
docs(wiki): cleanup broken links and add secure-vps-setup guide

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -25,7 +25,7 @@ Commands are organized by where they run:
 | `gordon deploy` | Manually deploy or redeploy a route | [serve](./serve.md#gordon-deploy) |
 | `gordon reload` | Reload configuration and sync containers | [serve](./serve.md#gordon-reload) |
 | `gordon logs` | Display Gordon process or container logs | [serve](./serve.md#gordon-logs) |
-| `gordon status` | Show Gordon server status | - |
+| `gordon status` | Show Gordon server status | [status](./status.md) |
 
 ## Client Commands
 

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -1,0 +1,105 @@
+# Status Command
+
+Show Gordon server status and container health.
+
+## gordon status
+
+Display server configuration and container status for all routes.
+
+```bash
+gordon status --remote https://gordon.mydomain.com --token $TOKEN
+```
+
+> **Note:** The status command requires remote mode. Use `--remote` flag or set `GORDON_REMOTE` environment variable.
+
+### Output
+
+```
+Gordon Status
+
+Domain: registry.example.com
+Registry Port: 5000
+Server Port: 8080
+Routes: 3
+Auto-Route: true
+Network Isolation: false
+
+Container Status:
+  app.example.com: running
+  api.example.com: running
+  worker.example.com: stopped
+```
+
+### Information Displayed
+
+| Field | Description |
+|-------|-------------|
+| Domain | Registry domain from configuration |
+| Registry Port | Docker registry port |
+| Server Port | Gordon admin API port |
+| Routes | Total configured routes |
+| Auto-Route | Whether auto-routing is enabled |
+| Network Isolation | Whether network isolation is enabled |
+| Container Status | Status of each route's container |
+
+### Container States
+
+| State | Description |
+|-------|-------------|
+| running | Container is running and healthy |
+| stopped | Container was stopped |
+| exited | Container exited (check logs for errors) |
+| paused | Container is paused |
+| unknown | Unable to determine container state |
+
+## Flags
+
+The status command uses global flags for remote access:
+
+| Flag | Description |
+|------|-------------|
+| `--remote` | Remote Gordon URL |
+| `--token` | Authentication token |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `GORDON_REMOTE` | Remote Gordon URL |
+| `GORDON_TOKEN` | Authentication token |
+
+## Examples
+
+### Check Remote Server Status
+
+```bash
+# Using flags
+gordon status --remote https://gordon.mydomain.com --token $TOKEN
+
+# Using environment variables
+export GORDON_REMOTE=https://gordon.mydomain.com
+export GORDON_TOKEN=your-token
+gordon status
+```
+
+### Quick Health Check
+
+```bash
+# Check if all containers are running
+gordon status --remote https://gordon.mydomain.com --token $TOKEN | grep -E "(running|stopped|exited)"
+```
+
+## Required Permissions
+
+The status endpoint requires `admin:status:read` scope in the authentication token.
+
+```bash
+# Generate token with required scope
+gordon auth token generate --subject admin --scopes admin:status:read
+```
+
+## Related
+
+- [Serve Command](./serve.md)
+- [Routes Command](./routes.md)
+- [Remote CLI Management](/wiki/guides/remote-cli.md)

--- a/wiki/examples/index.md
+++ b/wiki/examples/index.md
@@ -6,7 +6,6 @@ Annotated Gordon configuration examples for common scenarios.
 
 - [Minimal Configuration](./minimal.md) - Simplest working setup
 - [Production Configuration](./production.md) - Full production setup
-- [Development Configuration](./development.md) - Local development setup
 
 ## Quick Reference
 
@@ -15,23 +14,6 @@ Annotated Gordon configuration examples for common scenarios.
 ```toml
 [server]
 gordon_domain = "gordon.local"
-
-[routes]
-"app.local" = "myapp:latest"
-```
-
-### Development
-
-```toml
-[server]
-port = 8080
-gordon_domain = "gordon.local"
-
-[auth]
-enabled = false
-
-[auto_route]
-enabled = true
 
 [routes]
 "app.local" = "myapp:latest"

--- a/wiki/guides/index.md
+++ b/wiki/guides/index.md
@@ -4,12 +4,12 @@ In-depth guides for specific Gordon setups and integrations.
 
 ## Server Setup
 
+- [Secure VPS Setup](./secure-vps-setup.md) - Tailscale SSH, firewalld, and CrowdSec
 - [Running Gordon in a Container](./running-in-container.md) - Deploy Gordon itself in Docker or Podman
 - [Podman Rootless Setup](./podman-rootless.md) - Enhanced security with rootless containers
 
 ## TLS & Load Balancing
 
-- [Cloudflare DNS & Proxy Setup](./cloudflare-setup.md) - HTTPS termination with Cloudflare (recommended)
 - [AWS Application Load Balancer](./aws-alb.md) - Deploy behind AWS ALB
 - [Kubernetes Ingress](./kubernetes-ingress.md) - Deploy behind Kubernetes ingress controller
 

--- a/wiki/guides/secure-vps-setup.md
+++ b/wiki/guides/secure-vps-setup.md
@@ -1,0 +1,301 @@
+# Secure VPS Setup
+
+A production-ready VPS security configuration with Tailscale-only SSH access and CrowdSec intrusion prevention.
+
+## Overview
+
+This guide configures three security layers:
+
+| Layer | Protection |
+|-------|------------|
+| SSH | Tailscale only (invisible to internet) |
+| Firewall | firewalld with DROP policy |
+| IPS | CrowdSec with community blocklists |
+
+## Prerequisites
+
+- Fresh Ubuntu 24.04 VPS
+- Tailscale account
+- Initial SSH access via public IP (temporary)
+- Cloudflare account for HTTPS termination
+
+---
+
+## Step 1: Initial System Hardening
+
+Before anything else, enable automatic security updates and time sync:
+
+```bash
+# Automatic security updates
+apt update && apt install -y unattended-upgrades
+dpkg-reconfigure -plow unattended-upgrades
+
+# Verify time sync (enabled by default on Ubuntu 24.04)
+timedatectl set-ntp true
+timedatectl status
+
+# Basic kernel hardening
+cat > /etc/sysctl.d/99-security.conf << 'EOF'
+# SYN flood protection
+net.ipv4.tcp_syncookies = 1
+
+# Reverse path filtering (anti-spoofing)
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+
+# Disable ICMP redirects
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+
+# Ignore ICMP broadcasts
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+EOF
+
+sysctl --system
+```
+
+## Step 2: Install Tailscale
+
+> **Important**: Use the official repository, NOT the Snap package (has AppArmor issues with Tailscale SSH on Ubuntu 24.04).
+
+```bash
+# Add official Tailscale repository
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | \
+  tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | \
+  tee /etc/apt/sources.list.d/tailscale.list
+
+# Install
+apt update
+apt install -y tailscale
+```
+
+## Step 3: Connect Tailscale with SSH
+
+```bash
+tailscale up --ssh
+```
+
+This outputs an authentication URL. Open it and authenticate with your Tailscale account.
+
+**Important**: After connecting, go to https://login.tailscale.com/admin/machines and **disable key expiry** for this server to prevent lockouts.
+
+## Step 4: Configure firewalld
+
+```bash
+# Install firewalld
+apt install -y firewalld
+
+# Enable and start
+systemctl enable --now firewalld
+
+# Trust Tailscale interface (allows all traffic from your tailnet)
+firewall-cmd --permanent --zone=trusted --add-interface=tailscale0
+
+# Allow Tailscale UDP port (WireGuard)
+firewall-cmd --permanent --add-port=41641/udp
+
+# Allow web traffic (for Gordon reverse proxy)
+firewall-cmd --permanent --add-service=http
+firewall-cmd --permanent --add-service=https
+
+# Apply changes
+firewall-cmd --reload
+```
+
+> **Note**: Gordon's registry is proxied through port 80/443 via `gordon_domain`. Port 5000 does NOT need to be exposed publicly.
+
+## Step 5: Verify Tailscale SSH Works
+
+From another machine on your tailnet:
+
+```bash
+# Get the server's Tailscale hostname
+tailscale status
+
+# Connect from your local machine
+ssh root@<tailscale-hostname>
+# or
+tailscale ssh root@<tailscale-hostname>
+```
+
+## Step 6: Block Public SSH
+
+**Only proceed once Tailscale SSH is confirmed working.**
+
+```bash
+# Remove SSH from public zone
+firewall-cmd --permanent --remove-service=ssh
+
+# Set default policy to DROP all unmatched traffic
+firewall-cmd --permanent --zone=public --set-target=DROP
+
+# Apply changes
+firewall-cmd --reload
+```
+
+Verify public SSH is blocked:
+
+```bash
+# From another machine (not on tailnet)
+ssh -o ConnectTimeout=5 root@<public-ip>  # Should timeout
+```
+
+---
+
+## Step 7: Install CrowdSec
+
+```bash
+# Add CrowdSec repo (NOT Ubuntu's outdated version)
+curl -s https://install.crowdsec.net | bash
+
+# Install CrowdSec
+apt update
+apt install -y crowdsec
+```
+
+## Step 8: Install nftables Bouncer
+
+Ubuntu 24.04 uses nftables by default:
+
+```bash
+apt install -y crowdsec-firewall-bouncer-nftables
+systemctl enable --now crowdsec-firewall-bouncer
+```
+
+## Step 9: Install Security Collections
+
+```bash
+# HTTP protection
+cscli collections install crowdsecurity/http-cve
+cscli collections install crowdsecurity/base-http-scenarios
+
+# Reload to apply
+systemctl reload crowdsec
+```
+
+## Step 10: Whitelist Tailscale IPs
+
+Prevent CrowdSec from blocking Tailscale traffic:
+
+```bash
+cat > /etc/crowdsec/parsers/s02-enrich/tailscale-whitelist.yaml << 'EOF'
+name: tailscale-whitelist
+description: "Whitelist Tailscale CGNAT range"
+whitelist:
+  reason: "Tailscale internal traffic"
+  cidr:
+    - "100.64.0.0/10"
+EOF
+
+systemctl reload crowdsec
+```
+
+## Step 11: Enroll in CrowdSec Console
+
+This enables community blocklists - IPs blocked across all CrowdSec users globally (15,000+ malicious IPs).
+
+1. Create account at https://app.crowdsec.net
+2. Go to **Security Engines** → **Add Security Engine**
+3. Copy enrollment key and run:
+
+```bash
+cscli console enroll <your-enrollment-key>
+```
+
+4. Accept the enrollment in the CrowdSec console
+5. Enable console management:
+
+```bash
+systemctl restart crowdsec
+cscli console enable console_management
+systemctl reload crowdsec
+```
+
+---
+
+## Verification
+
+```bash
+# Firewall status
+firewall-cmd --state
+firewall-cmd --list-all
+firewall-cmd --list-all --zone=trusted
+
+# CrowdSec status
+cscli metrics
+cscli bouncers list
+cscli console status
+
+# Verify nftables has CrowdSec rules
+nft list ruleset | grep -A5 'crowdsec'
+
+# View blocked IPs count
+cscli decisions list | wc -l
+```
+
+---
+
+## Port Summary
+
+| Port | Protocol | Status | Purpose |
+|------|----------|--------|---------|
+| 22 | TCP | Closed | SSH (use Tailscale instead) |
+| 80 | TCP | Open | HTTP (Gordon proxy) |
+| 443 | TCP | Open | HTTPS (Gordon proxy via Cloudflare) |
+| 5000 | TCP | Closed | Registry (proxied through 80/443) |
+| 41641 | UDP | Open | Tailscale WireGuard |
+
+---
+
+## Troubleshooting
+
+### Can't SSH via Tailscale
+
+Check for ACL issues:
+
+```bash
+journalctl -u tailscaled --since "10 minutes ago" | grep -i "rejected\|acl"
+```
+
+If you see `rejected due to acl`, check your Tailscale ACLs at https://login.tailscale.com/admin/acls
+
+### Locked out completely
+
+Use your VPS provider's console access (e.g., Hetzner Cloud Console):
+
+```bash
+firewall-cmd --add-service=ssh  # Temporarily re-enable public SSH
+```
+
+### CrowdSec not blocking
+
+Verify bouncer is running:
+
+```bash
+systemctl status crowdsec-firewall-bouncer
+cscli bouncers list  # Should show "Valid"
+```
+
+### Check what's being blocked
+
+```bash
+cscli decisions list
+cscli alerts list
+```
+
+---
+
+## Next Steps
+
+- [Install Gordon](/docs/getting-started.md)
+- [Podman Rootless Setup](./podman-rootless.md) - Enhanced container isolation
+- [Cloudflare DNS & Proxy Setup](#) - HTTPS termination (coming soon)
+
+## References
+
+- [Tailscale SSH Documentation](https://tailscale.com/kb/1193/tailscale-ssh)
+- [firewalld Documentation](https://firewalld.org/documentation/)
+- [CrowdSec Documentation](https://docs.crowdsec.net/)
+- [CrowdSec Console](https://app.crowdsec.net)

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -6,18 +6,19 @@ Community tutorials, guides, and examples for Gordon.
 
 Step-by-step guides for common tasks:
 
-- [Deploy Your First App](./tutorials/first-deploy.md) - Get started with Gordon
-- [Deploy a Next.js App](./tutorials/nextjs-deploy.md) - Full-stack JavaScript deployment
+- [Deploy Your First App](./tutorials/first-deploy.md) - Deploy a simple web app in minutes
 - [Add PostgreSQL to Your App](./tutorials/postgres-service.md) - Database attachments
-- [Deploy Multi-Service Applications](./tutorials/multi-service-app.md) - Microservices setup
+
+> **New to Gordon?** Start with the [Getting Started guide](/docs/getting-started.md) in the official docs.
 
 ## Guides
 
 In-depth guides for specific setups:
 
+- [Secure VPS Setup](./guides/secure-vps-setup.md) - Tailscale SSH, firewalld, and CrowdSec
 - [Running Gordon in a Container](./guides/running-in-container.md) - Deploy Gordon itself in Docker or Podman
 - [Podman Rootless Setup](./guides/podman-rootless.md) - Enhanced security with rootless containers
-- [Cloudflare DNS & Proxy Setup](./guides/cloudflare-setup.md) - HTTPS termination with Cloudflare
+- [Remote CLI Management](./guides/remote-cli.md) - Manage Gordon instances remotely
 - [Using Pass for Secrets](./guides/secrets-pass.md) - Unix password manager integration
 - [Using SOPS for Secrets](./guides/secrets-sops.md) - Encrypted secrets with SOPS
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -34,7 +34,6 @@ Configuration examples explained:
 
 - [Minimal Configuration](./examples/minimal.md) - Simplest working setup
 - [Production Configuration](./examples/production.md) - Full production setup
-- [Development Configuration](./examples/development.md) - Local development setup
 
 ## Quick Links
 

--- a/wiki/tutorials/index.md
+++ b/wiki/tutorials/index.md
@@ -1,8 +1,8 @@
 # Tutorials
 
-Step-by-step guides to help you get started with Gordon.
+Step-by-step guides for common Gordon tasks.
 
-## Getting Started
+> **New to Gordon?** Start with the [Getting Started guide](/docs/getting-started.md) in the official docs.
 
 - [Deploy Your First App](./first-deploy.md) - Deploy a simple web app in minutes
 


### PR DESCRIPTION
## Summary

- Remove broken wiki links (files that don't exist)
- Fix getting-started confusion in wiki tutorials (now points to docs)
- Add `status` command documentation
- Add secure-vps-setup guide (Tailscale SSH, firewalld, CrowdSec)

## Changes

### Broken links removed
- `tutorials/nextjs-deploy.md`
- `tutorials/multi-service-app.md`
- `guides/cloudflare-setup.md`
- `examples/development.md`

### New content
- `docs/cli/status.md` - Status command reference
- `wiki/guides/secure-vps-setup.md` - VPS security guide

### Fixes
- Wiki "Getting Started" section renamed, now points to docs/getting-started.md
- CLI index updated with status doc link

## Test plan
- [ ] Verify all wiki links resolve correctly
- [ ] Check status doc renders properly
- [ ] Check secure-vps-setup guide renders properly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR cleans up broken documentation links and adds valuable new content for Gordon users. The changes remove references to non-existent files and add two important documentation pieces: a `status` command reference and a comprehensive VPS security guide.

**Major changes:**
- Added `docs/cli/status.md` - complete documentation for the status command with examples and permission details
- Added `wiki/guides/secure-vps-setup.md` - detailed 11-step security hardening guide covering Tailscale SSH, firewalld, and CrowdSec
- Removed broken links from wiki (nextjs-deploy, multi-service-app, cloudflare-setup, development config)
- Updated wiki to direct new users to official Getting Started guide

**Issue found:**
- `wiki/index.md:37` still contains a broken reference to `./examples/development.md` that should be removed

<h3>Confidence Score: 4/5</h3>


- Safe to merge after removing the broken link on `wiki/index.md:37`
- Score of 4 due to one remaining broken link that needs removal. The PR successfully removes most broken documentation references and adds high-quality new content. The secure-vps-setup guide is comprehensive and well-structured with proper security practices. The status command documentation is complete with examples and proper cross-references. All other documentation changes are clean and improve navigation.
- `wiki/index.md` needs the broken development.md link removed from line 37

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/cli/status.md | Added comprehensive documentation for the status command with examples and references |
| wiki/guides/secure-vps-setup.md | Added comprehensive VPS security guide covering Tailscale, firewalld, and CrowdSec setup |
| wiki/index.md | Updated tutorials and guides sections, but contains broken link to development.md on line 37 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Wiki
    participant Docs
    participant Files
    
    User->>Wiki: Navigate to tutorials/guides
    Wiki->>User: Show updated index with secure-vps-setup
    
    User->>Wiki: Click "Secure VPS Setup"
    Wiki->>User: Display comprehensive security guide
    
    User->>Docs: Check CLI reference
    Docs->>User: Show updated index with status link
    
    User->>Docs: Click status command link
    Docs->>User: Display status.md documentation
    
    User->>Wiki: Try to access removed guides
    Note over Wiki,Files: Broken links removed:<br/>- nextjs-deploy.md<br/>- multi-service-app.md<br/>- cloudflare-setup.md<br/>- development.md
    Wiki--xFiles: 404 - Files removed
    
    User->>Wiki: Follow "Getting Started"
    Wiki->>Docs: Redirect to /docs/getting-started.md
    Docs->>User: Show official getting started guide
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->