### PR TITLE
Add pass-backed secrets, registry token auth, and CLI token login

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,12 @@ version: 2
 before:
   hooks:
 
+git:
+  prerelease_suffix: "-"
+
 release:
   draft: true
+  prerelease: auto
 
 builds:
   - id: "gordon"

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -19,7 +19,7 @@ Manage Gordon server authentication tokens and passwords.
 
 ## gordon auth login
 
-Authenticate with a remote Gordon server using password authentication.
+Authenticate with a remote Gordon server using password authentication or a pre-generated token.
 
 ```bash
 gordon auth login [options]
@@ -31,14 +31,18 @@ gordon auth login [options]
 |--------|-------------|
 | `-r, --remote` | Remote to authenticate with (defaults to active remote) |
 | `-u, --username` | Username for authentication |
+| `-p, --password` | Password for authentication |
+| `-t, --token` | Authentication token to store for the remote |
 
 ### Description
 
 This command prompts for your username and password, authenticates with the remote server's `/auth/password` endpoint, and stores the returned token in your remotes configuration.
 
+If you provide `--token`, the token is stored directly and verified against `/admin/status` on a best-effort basis.
+
 The token is a long-lived JWT (7 days) that's used for subsequent CLI operations against the remote.
 
-> **Note:** This command only works with servers that have password authentication configured (`username` + `password_hash`). For token-only servers, use `gordon remotes set-token` instead.
+> **Note:** For token-only servers, you can pass `--token` here or use `gordon remotes set-token`.
 
 ### Examples
 
@@ -51,6 +55,9 @@ gordon auth login --remote prod
 
 # Pre-fill username
 gordon auth login --username admin
+
+# Store a pre-generated token
+gordon auth login --token <token>
 ```
 
 ### Output
@@ -212,7 +219,9 @@ Display the auto-generated internal registry credentials.
 gordon auth internal
 ```
 
-Gordon generates temporary credentials for internal communication with its local registry. These credentials are useful for manual recovery when debugging deployment issues.
+Gordon generates temporary credentials for loopback-only communication with its local registry. These credentials are useful for manual recovery when debugging deployment issues.
+
+When registry auth is enabled, Gordon also generates a separate service token for its own registry-domain pulls. That token is not exposed via the CLI.
 
 ### Output
 
@@ -231,6 +240,7 @@ Usage:
 - Credentials are regenerated each time Gordon starts
 - Only available while Gordon is running
 - Used for manual `docker pull` from the local registry during debugging
+- Separate from the service token used by Gordon core for registry-domain pulls
 
 ### Use Cases
 

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -2,6 +2,10 @@
 
 Manage secrets on local or remote Gordon instances.
 
+Storage depends on the secrets backend:
+- `pass`: secrets are stored in pass under `gordon/env/<domain>/<KEY>`
+- `sops` or `unsafe`: secrets are stored in domain `.env` files
+
 ## gordon secrets
 
 ### Subcommands

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -45,7 +45,7 @@ Token auth always works. Adding `username` + `password_hash` enables interactive
 `token_secret` and `password_hash` are read through the configured backend:
 
 | Backend | Description |
-|---------|-------------|
+| --------- | ------------- |
 | `pass` | Unix password manager (GPG-encrypted) |
 | `sops` | Mozilla SOPS encrypted files |
 | `unsafe` | Plain text files (development only) |
@@ -112,7 +112,7 @@ gordon remotes set-token prod <token>
 Registry scopes:
 
 | Scope | Permission |
-|-------|------------|
+| ------- | ------------ |
 | `push` | Push images to registry |
 | `pull` | Pull images from registry |
 | `push,pull` | Both push and pull (default) |

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -313,6 +313,8 @@ token_secret = "gordon/auth/token_secret"
 
 Gordon generates internal credentials automatically when auth is enabled. These are used for loopback pulls when deploying containers and are regenerated on each restart.
 
+Gordon also generates a separate service token for its own registry-domain pulls. This token is managed internally and is not exposed via configuration or CLI.
+
 To view internal credentials (for troubleshooting):
 ```bash
 gordon auth internal

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -54,7 +54,7 @@ See [Secret Providers](./secrets.md) for setup details.
 
 ## Environment Variable
 
-`GORDON_AUTH_TOKEN_SECRET` overrides `token_secret` in the config.
+`GORDON_AUTH_TOKEN_SECRET` overrides `token_secret` in the config. If you don’t set the env var, `token_secret` is loaded from the configured secrets backend (including `pass`).
 
 ```bash
 export GORDON_AUTH_TOKEN_SECRET="your-32-character-secret-here"

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -34,6 +34,21 @@ Gordon loads environment variables from files named after the domain:
 | `api.company.io` | `api_company_io.env` |
 | `staging.app.dev` | `staging_app_dev.env` |
 
+## Backend Behavior
+
+The `auth.secrets_backend` setting changes where route secrets live:
+
+### Pass Backend
+
+- Env files are not used for route secrets.
+- Use `gordon secrets set` to store per-domain secrets in pass.
+- Existing `.env` files are migrated on startup and renamed to `.env.migrated`.
+
+### SOPS or Unsafe Backend
+
+- Env files remain the source of truth.
+- Use `${sops:...}` syntax for encrypted values when `secrets_backend = "sops"`.
+
 ## File Format
 
 Standard `.env` file format:

--- a/docs/config/secrets.md
+++ b/docs/config/secrets.md
@@ -54,6 +54,10 @@ token_secret = "gordon/auth/token_secret"
 - Standard Unix tooling
 - Works with team GPG keys
 
+**Route secrets storage:**
+- `gordon secrets set` stores per-domain secrets in pass under `gordon/env/<domain>/<KEY>`
+- Existing `.env` files are auto-migrated on startup and renamed to `.env.migrated`
+
 ### SOPS
 
 Uses Mozilla SOPS for encrypted file-based secrets:
@@ -84,6 +88,10 @@ DB_PASSWORD=${sops:secrets.yaml:database.password}
 - Multiple encryption backends (AWS KMS, GCP KMS, Azure Key Vault, PGP)
 - YAML/JSON file encryption
 - Git-friendly (encrypted files in repo)
+
+**Route secrets storage:**
+- Domain secrets stay in `.env` files
+- Use `${sops:...}` syntax to resolve encrypted values
 
 ### Unsafe (Development Only)
 

--- a/docs/config/secrets.md
+++ b/docs/config/secrets.md
@@ -55,7 +55,7 @@ token_secret = "gordon/auth/token_secret"
 - Works with team GPG keys
 
 **Route secrets storage:**
-- `gordon secrets set` stores per-domain secrets in pass under `gordon/env/<domain>/<KEY>`
+- `gordon secrets set` stores per-domain secrets in pass under `gordon/env/<sanitized-domain>/<KEY>` (dots/colons/slashes → underscores)
 - Existing `.env` files are auto-migrated on startup and renamed to `.env.migrated`
 
 ### SOPS

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ Config is created at `~/.config/gordon/gordon.toml`.
 
 ## 3. Set Up Authentication
 
-Gordon requires a `token_secret` for JWT authentication. We recommend using `pass` to store secrets securely.
+Gordon requires a `token_secret` for JWT authentication. You can store it in `pass` or provide it via the `GORDON_AUTH_TOKEN_SECRET` environment variable. We recommend using `pass` to store secrets securely.
 
 > **Local development?** If you just want to try Gordon locally, you can disable auth temporarily:
 > ```toml
@@ -51,6 +51,11 @@ pass init <your-gpg-key-id>
 ```bash
 # Generate and store a random 32-character secret
 openssl rand -base64 32 | pass insert -m gordon/auth/token_secret
+```
+
+**Or set it via environment variable:**
+```bash
+export GORDON_AUTH_TOKEN_SECRET="your-32-character-secret-here"
 ```
 
 **Update your config** (`~/.config/gordon/gordon.toml`):

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,7 @@ openssl rand -base64 32 | pass insert -m gordon/auth/token_secret
 ```
 
 **Or set it via environment variable:**
+
 ```bash
 export GORDON_AUTH_TOKEN_SECRET="your-32-character-secret-here"
 ```

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,11 @@ set -e
 
 # Gordon installer script
 # Usage: curl -fsSL https://gordon.bnema.dev/install | bash
+# Usage with pre-release: curl -fsSL https://gordon.bnema.dev/install | GORDON_PRERELEASE=1 bash
 
 REPO="bnema/gordon"
 INSTALL_DIR="/usr/local/bin"
+VERSION="${GORDON_VERSION:-latest}"
 
 echo "Installing Gordon..."
 
@@ -43,14 +45,37 @@ echo "Detected: ${OS}/${ARCH}"
 
 # Construct download URL
 TARBALL="gordon_${OS}_${ARCH}.tar.gz"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${TARBALL}"
+
+# Determine version to download
+if [ "$VERSION" = "latest" ] && [ -n "$GORDON_PRERELEASE" ]; then
+    echo "Finding latest pre-release..."
+    # Get latest release (including pre-releases) from GitHub API
+    RELEASE_DATA=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null || echo "")
+    if [ -z "$RELEASE_DATA" ]; then
+        echo "Error: Failed to fetch release information from GitHub API"
+        exit 1
+    fi
+    VERSION=$(echo "$RELEASE_DATA" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+    if [ -z "$VERSION" ]; then
+        echo "Error: Could not determine latest pre-release version"
+        exit 1
+    fi
+    echo "Using pre-release version: ${VERSION}"
+elif [ "$VERSION" = "latest" ]; then
+    VERSION="latest"
+    echo "Using latest stable release"
+else
+    echo "Using version: ${VERSION}"
+fi
+
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
 
 # Create temporary directory
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Download checksums file
-CHECKSUMS_URL="https://github.com/${REPO}/releases/latest/download/checksums.txt"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
 echo "Downloading checksums..."
 if ! curl -fsSL "$CHECKSUMS_URL" -o "$TMP_DIR/checksums.txt"; then
     echo "Error: Failed to download checksums file"

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -240,8 +240,11 @@ Examples:
 
 	cmd.Flags().StringVarP(&remoteName, "remote", "r", "", "Remote to authenticate with (defaults to active remote)")
 	cmd.Flags().StringVarP(&username, "username", "u", "", "Username for authentication")
-	cmd.Flags().StringVarP(&password, "password", "p", "", "Password for authentication")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password (visible in process listings; prefer interactive prompt)")
 	cmd.Flags().StringVarP(&token, "token", "t", "", "Authentication token to store for the remote")
+
+	cmd.MarkFlagsMutuallyExclusive("token", "password")
+	cmd.MarkFlagsMutuallyExclusive("token", "username")
 
 	return cmd
 }

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -271,7 +271,6 @@ func runAuthLogin(remoteName, username, password string) error {
 		return fmt.Errorf("username cannot be empty")
 	}
 
-	password = strings.TrimSpace(password)
 	if password == "" {
 		// Prompt for password (hidden input)
 		fmt.Print("Password: ")
@@ -283,10 +282,14 @@ func runAuthLogin(remoteName, username, password string) error {
 			if readErr != nil {
 				return fmt.Errorf("failed to read password: %w", readErr)
 			}
-			passwordBytes = []byte(strings.TrimSpace(passwordInput))
+			// Only trim trailing newline from fallback input
+			passwordBytes = []byte(strings.TrimRight(passwordInput, "\r\n"))
 		}
 		fmt.Println()
-		password = strings.TrimSpace(string(passwordBytes))
+		password = string(passwordBytes)
+	} else {
+		// Only trim trailing newline from flag-provided password
+		password = strings.TrimRight(password, "\r\n")
 	}
 
 	if password == "" {

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -207,12 +207,14 @@ func newAuthLoginCmd() *cobra.Command {
 	var (
 		remoteName string
 		username   string
+		token      string
+		password   string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with a Gordon server",
-		Long: `Authenticate with a Gordon server using password authentication.
+		Long: `Authenticate with a Gordon server using password authentication or a pre-generated token.
 
 This command prompts for your username and password, authenticates with the
 remote server's /auth/password endpoint, and stores the returned token.
@@ -220,43 +222,35 @@ remote server's /auth/password endpoint, and stores the returned token.
 The token is stored in your remote configuration and used for subsequent
 CLI operations.
 
-Note: This command only works with servers configured for password authentication.
-For servers using token-based auth, use 'gordon remote set-token' instead.
+If --token is provided, the token is stored for the remote and verified
+against /admin/status on a best-effort basis.
 
 Examples:
-  gordon auth login                    Login using active remote
-  gordon auth login --remote prod      Login to specific remote
-  gordon auth login --username admin   Pre-fill username`,
+	gordon auth login                    Login using active remote
+	gordon auth login --remote prod      Login to specific remote
+	gordon auth login --username admin   Pre-fill username
+	gordon auth login --token <token>    Store a token for token-only servers`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAuthLogin(remoteName, username)
+			if token != "" {
+				return runAuthLoginWithToken(remoteName, token)
+			}
+			return runAuthLogin(remoteName, username, password)
 		},
 	}
 
 	cmd.Flags().StringVarP(&remoteName, "remote", "r", "", "Remote to authenticate with (defaults to active remote)")
 	cmd.Flags().StringVarP(&username, "username", "u", "", "Username for authentication")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password for authentication")
+	cmd.Flags().StringVarP(&token, "token", "t", "", "Authentication token to store for the remote")
 
 	return cmd
 }
 
 // runAuthLogin authenticates with a remote Gordon server.
-func runAuthLogin(remoteName, username string) error {
-	// Load remotes config
-	config, err := remote.LoadRemotes("")
+func runAuthLogin(remoteName, username, password string) error {
+	resolvedName, remoteConfig, err := resolveRemoteEntry(remoteName)
 	if err != nil {
-		return fmt.Errorf("failed to load remotes: %w", err)
-	}
-
-	// Determine which remote to use
-	if remoteName == "" {
-		remoteName = config.Active
-	}
-	if remoteName == "" {
-		return fmt.Errorf("no remote specified and no active remote set. Use --remote or 'gordon remote use <name>'")
-	}
-
-	remoteConfig, ok := config.Remotes[remoteName]
-	if !ok {
-		return fmt.Errorf("remote '%s' not found", remoteName)
+		return err
 	}
 
 	// Prompt for username if not provided
@@ -274,21 +268,25 @@ func runAuthLogin(remoteName, username string) error {
 		return fmt.Errorf("username cannot be empty")
 	}
 
-	// Prompt for password (hidden input)
-	fmt.Print("Password: ")
-	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		// Fallback for non-terminal input
-		reader := bufio.NewReader(os.Stdin)
-		password, readErr := reader.ReadString('\n')
-		if readErr != nil {
-			return fmt.Errorf("failed to read password: %w", readErr)
+	password = strings.TrimSpace(password)
+	if password == "" {
+		// Prompt for password (hidden input)
+		fmt.Print("Password: ")
+		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			// Fallback for non-terminal input
+			reader := bufio.NewReader(os.Stdin)
+			passwordInput, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				return fmt.Errorf("failed to read password: %w", readErr)
+			}
+			passwordBytes = []byte(strings.TrimSpace(passwordInput))
 		}
-		passwordBytes = []byte(strings.TrimSpace(password))
+		fmt.Println()
+		password = strings.TrimSpace(string(passwordBytes))
 	}
-	fmt.Println() // newline after hidden password input
 
-	if len(passwordBytes) == 0 {
+	if password == "" {
 		return fmt.Errorf("password cannot be empty")
 	}
 
@@ -297,24 +295,75 @@ func runAuthLogin(remoteName, username string) error {
 
 	// Authenticate
 	ctx := context.Background()
-	fmt.Printf("Authenticating with %s...\n", remoteName)
+	fmt.Printf("Authenticating with %s...\n", resolvedName)
 
-	resp, err := client.Authenticate(ctx, username, string(passwordBytes))
+	resp, err := client.Authenticate(ctx, username, password)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
 
 	// Update remote config with new token
-	if err := remote.UpdateRemoteToken(remoteName, resp.Token); err != nil {
+	if err := remote.UpdateRemoteToken(resolvedName, resp.Token); err != nil {
 		return fmt.Errorf("failed to save token: %w", err)
 	}
 
 	fmt.Println()
 	fmt.Println(styles.RenderSuccess("Authentication successful!"))
-	fmt.Printf("Token stored for remote '%s'\n", remoteName)
+	fmt.Printf("Token stored for remote '%s'\n", resolvedName)
 	fmt.Printf("Expires in: %d seconds\n", resp.ExpiresIn)
 
 	return nil
+}
+
+func runAuthLoginWithToken(remoteName, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("token cannot be empty")
+	}
+
+	resolvedName, remoteConfig, err := resolveRemoteEntry(remoteName)
+	if err != nil {
+		return err
+	}
+
+	if err := remote.UpdateRemoteToken(resolvedName, token); err != nil {
+		return fmt.Errorf("failed to save token: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println(styles.RenderSuccess(fmt.Sprintf("Token stored for remote '%s'", resolvedName)))
+
+	client := remote.NewClient(remoteConfig.URL, remote.WithToken(token))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := client.GetStatus(ctx); err != nil {
+		fmt.Println(styles.RenderWarning(fmt.Sprintf("Token verification failed: %v", err)))
+		return nil
+	}
+
+	fmt.Println(styles.RenderSuccess("Token verified with remote status endpoint"))
+	return nil
+}
+
+func resolveRemoteEntry(remoteName string) (string, remote.RemoteEntry, error) {
+	config, err := remote.LoadRemotes("")
+	if err != nil {
+		return "", remote.RemoteEntry{}, fmt.Errorf("failed to load remotes: %w", err)
+	}
+
+	if remoteName == "" {
+		remoteName = config.Active
+	}
+	if remoteName == "" {
+		return "", remote.RemoteEntry{}, fmt.Errorf("no remote specified and no active remote set. Use --remote or 'gordon remote use <name>'")
+	}
+
+	remoteConfig, ok := config.Remotes[remoteName]
+	if !ok {
+		return "", remote.RemoteEntry{}, fmt.Errorf("remote '%s' not found", remoteName)
+	}
+
+	return remoteName, remoteConfig, nil
 }
 
 // runShowInternalAuth displays the internal registry credentials.

--- a/internal/adapters/in/cli/auth_test.go
+++ b/internal/adapters/in/cli/auth_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+)
+
+func TestRunAuthLoginWithToken_VerifiesAndStores(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/status" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		receivedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"routes":0,"registry_domain":"","registry_port":0,"server_port":0,"auto_route":false,"network_isolation":false,"container_status":{}}`))
+	}))
+	defer server.Close()
+
+	config := &remote.ClientConfig{
+		Active: "prod",
+		Remotes: map[string]remote.RemoteEntry{
+			"prod": {URL: server.URL},
+		},
+	}
+	assert.NoError(t, remote.SaveRemotes(remote.DefaultRemotesPath(), config))
+
+	err := runAuthLoginWithToken("", "token123")
+	assert.NoError(t, err)
+
+	loaded, err := remote.LoadRemotes("")
+	assert.NoError(t, err)
+	assert.Equal(t, "token123", loaded.Remotes["prod"].Token)
+	assert.Equal(t, "Bearer token123", receivedAuth)
+}
+
+func TestRunAuthLoginWithToken_StoresTokenOnVerificationFailure(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/status" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	config := &remote.ClientConfig{
+		Active: "prod",
+		Remotes: map[string]remote.RemoteEntry{
+			"prod": {URL: server.URL},
+		},
+	}
+	assert.NoError(t, remote.SaveRemotes(remote.DefaultRemotesPath(), config))
+
+	err := runAuthLoginWithToken("", "token123")
+	assert.NoError(t, err)
+
+	loaded, err := remote.LoadRemotes("")
+	assert.NoError(t, err)
+	assert.Equal(t, "token123", loaded.Remotes["prod"].Token)
+}

--- a/internal/adapters/out/domainsecrets/helpers_test.go
+++ b/internal/adapters/out/domainsecrets/helpers_test.go
@@ -1,7 +1,25 @@
 package domainsecrets
 
-import "github.com/bnema/zerowrap"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bnema/zerowrap"
+)
 
 func testLogger() zerowrap.Logger {
 	return zerowrap.Default()
+}
+
+// CleanupPassAttachment removes attachment secrets from pass for testing.
+// It's a test helper that should be called with defer to ensure cleanup.
+// This function is exported to be shared across test packages.
+func CleanupPassAttachment(_ *testing.T, containerName string, keys []string) {
+	for _, key := range keys {
+		path := fmt.Sprintf("%s/%s/%s", PassAttachmentPath, containerName, key)
+		_ = passCmd("rm", "-f", path)
+	}
+
+	manifestPath := fmt.Sprintf("%s/%s/.keys", PassAttachmentPath, containerName)
+	_ = passCmd("rm", "-f", manifestPath)
 }

--- a/internal/adapters/out/domainsecrets/helpers_test.go
+++ b/internal/adapters/out/domainsecrets/helpers_test.go
@@ -1,0 +1,7 @@
+package domainsecrets
+
+import "github.com/bnema/zerowrap"
+
+func testLogger() zerowrap.Logger {
+	return zerowrap.Default()
+}

--- a/internal/adapters/out/domainsecrets/pass_store.go
+++ b/internal/adapters/out/domainsecrets/pass_store.go
@@ -1,0 +1,459 @@
+// Package domainsecrets implements the DomainSecretStore adapter using pass.
+package domainsecrets
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/bnema/zerowrap"
+
+	"github.com/bnema/gordon/internal/adapters/out/secrets"
+	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// ansiRegex matches ANSI escape sequences for stripping from pass output.
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+const (
+	passDomainSecretsPath = "gordon/env"             //nolint:gosec // Not a credential, this is a pass store path.
+	passAttachmentPath    = "gordon/env/attachments" //nolint:gosec // Not a credential, this is a pass store path.
+)
+
+// PassStore implements the DomainSecretStore interface using the pass password manager.
+type PassStore struct {
+	timeout time.Duration
+	log     zerowrap.Logger
+}
+
+// NewPassStore creates a new pass-based domain secret store.
+func NewPassStore(log zerowrap.Logger) (*PassStore, error) {
+	if err := exec.Command("pass", "version").Run(); err != nil {
+		return nil, fmt.Errorf("pass is not available: %w", err)
+	}
+
+	log.Debug().
+		Str(zerowrap.FieldLayer, "adapter").
+		Str(zerowrap.FieldAdapter, "domainsecrets").
+		Str("provider", "pass").
+		Msg("domain secret store initialized")
+
+	return &PassStore{
+		timeout: 10 * time.Second,
+		log:     log,
+	}, nil
+}
+
+// ListKeys returns the list of secret keys for a domain (not values).
+func (s *PassStore) ListKeys(domainName string) ([]string, error) {
+	manifestPath, err := s.manifestPath(domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	content, exists, err := s.passShow(ctx, manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return []string{}, nil
+	}
+
+	keys := []string{}
+	for _, line := range strings.Split(content, "\n") {
+		key := strings.TrimSpace(line)
+		if key == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// GetAll returns all secrets for a domain as a key-value map.
+func (s *PassStore) GetAll(domainName string) (map[string]string, error) {
+	keys, err := s.ListKeys(domainName)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	secretsMap := make(map[string]string)
+	for _, key := range keys {
+		keyPath, err := s.keyPath(domainName, key)
+		if err != nil {
+			return nil, err
+		}
+
+		value, exists, err := s.passShow(ctx, keyPath)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			s.log.Warn().
+				Str(zerowrap.FieldLayer, "adapter").
+				Str(zerowrap.FieldAdapter, "domainsecrets").
+				Str("domain", domainName).
+				Str("key", key).
+				Msg("secret listed in manifest but missing in pass")
+			continue
+		}
+		secretsMap[key] = value
+	}
+
+	return secretsMap, nil
+}
+
+// Set sets or updates multiple secrets for a domain.
+func (s *PassStore) Set(domainName string, secretsMap map[string]string) error {
+	if _, err := s.domainPath(domainName); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	for key, value := range secretsMap {
+		keyPath, err := s.keyPath(domainName, key)
+		if err != nil {
+			return err
+		}
+		if err := s.passInsert(ctx, keyPath, value); err != nil {
+			return fmt.Errorf("failed to store secret %s: %w", key, err)
+		}
+	}
+
+	existingKeys, err := s.ListKeys(domainName)
+	if err != nil {
+		return err
+	}
+
+	keySet := make(map[string]struct{}, len(existingKeys)+len(secretsMap))
+	for _, key := range existingKeys {
+		keySet[key] = struct{}{}
+	}
+	for key := range secretsMap {
+		keySet[key] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	manifestPath, err := s.manifestPath(domainName)
+	if err != nil {
+		return err
+	}
+
+	if err := s.passInsert(ctx, manifestPath, strings.Join(keys, "\n")); err != nil {
+		return fmt.Errorf("failed to update manifest: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a specific secret key from a domain.
+func (s *PassStore) Delete(domainName, key string) error {
+	if _, err := s.domainPath(domainName); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	keyPath, err := s.keyPath(domainName, key)
+	if err != nil {
+		return err
+	}
+	if err := s.passRemove(ctx, keyPath); err != nil {
+		return err
+	}
+
+	keys, err := s.ListKeys(domainName)
+	if err != nil {
+		return err
+	}
+
+	updated := make([]string, 0, len(keys))
+	for _, existingKey := range keys {
+		if existingKey == key {
+			continue
+		}
+		updated = append(updated, existingKey)
+	}
+	sort.Strings(updated)
+
+	manifestPath, err := s.manifestPath(domainName)
+	if err != nil {
+		return err
+	}
+
+	if err := s.passInsert(ctx, manifestPath, strings.Join(updated, "\n")); err != nil {
+		return fmt.Errorf("failed to update manifest: %w", err)
+	}
+
+	return nil
+}
+
+// ListAttachmentKeys finds attachment secrets for a domain from pass.
+func (s *PassStore) ListAttachmentKeys(domainName string) ([]out.AttachmentSecrets, error) {
+	if _, err := s.domainPath(domainName); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	containers, err := s.listTopLevelEntries(ctx, passAttachmentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sanitizedDomain := sanitizeDomainForContainer(domainName)
+	prefix := "gordon-" + sanitizedDomain + "-"
+
+	var results []out.AttachmentSecrets
+	for _, containerName := range containers {
+		if !strings.HasPrefix(containerName, prefix) {
+			continue
+		}
+
+		manifestPath := fmt.Sprintf("%s/%s/.keys", passAttachmentPath, containerName)
+		if err := secrets.ValidatePath(manifestPath); err != nil {
+			return nil, err
+		}
+
+		content, exists, err := s.passShow(ctx, manifestPath)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+
+		keys := []string{}
+		for _, line := range strings.Split(content, "\n") {
+			key := strings.TrimSpace(line)
+			if key == "" {
+				continue
+			}
+			keys = append(keys, key)
+		}
+
+		if len(keys) > 0 {
+			results = append(results, out.AttachmentSecrets{
+				Service: containerName,
+				Keys:    keys,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+func (s *PassStore) domainPath(domainName string) (string, error) {
+	safeDomain, err := s.sanitizeDomain(domainName)
+	if err != nil {
+		return "", err
+	}
+	path := fmt.Sprintf("%s/%s", passDomainSecretsPath, safeDomain)
+	if err := secrets.ValidatePath(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (s *PassStore) keyPath(domainName, key string) (string, error) {
+	domainPath, err := s.domainPath(domainName)
+	if err != nil {
+		return "", err
+	}
+	path := fmt.Sprintf("%s/%s", domainPath, key)
+	if err := secrets.ValidatePath(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (s *PassStore) manifestPath(domainName string) (string, error) {
+	domainPath, err := s.domainPath(domainName)
+	if err != nil {
+		return "", err
+	}
+	path := fmt.Sprintf("%s/.keys", domainPath)
+	if err := secrets.ValidatePath(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (s *PassStore) sanitizeDomain(domainName string) (string, error) {
+	safeDomain, err := domain.SanitizeDomainForEnvFile(domainName)
+	if err != nil {
+		s.log.Warn().
+			Str(zerowrap.FieldLayer, "adapter").
+			Str(zerowrap.FieldAdapter, "domainsecrets").
+			Str("domain", domainName).
+			Err(err).
+			Msg("rejected invalid domain")
+		return "", domain.ErrPathTraversal
+	}
+	return safeDomain, nil
+}
+
+// ManifestExists checks if the manifest exists for a domain.
+func (s *PassStore) ManifestExists(domainName string) (bool, error) {
+	manifestPath, err := s.manifestPath(domainName)
+	if err != nil {
+		return false, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	_, exists, err := s.passShow(ctx, manifestPath)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
+func (s *PassStore) passInsert(ctx context.Context, path, value string) error {
+	cmd := exec.CommandContext(ctx, "pass", "insert", "-m", "-f", path)
+	cmd.Stdin = strings.NewReader(value)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pass insert failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func (s *PassStore) passRemove(ctx context.Context, path string) error {
+	cmd := exec.CommandContext(ctx, "pass", "rm", "-f", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if passEntryMissing(string(output)) {
+			return nil
+		}
+		return fmt.Errorf("pass rm failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func (s *PassStore) passShow(ctx context.Context, path string) (string, bool, error) {
+	cmd := exec.CommandContext(ctx, "pass", "show", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if passEntryMissing(string(output)) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("pass show failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), true, nil
+}
+
+func (s *PassStore) listTopLevelEntries(ctx context.Context, basePath string) ([]string, error) {
+	if err := secrets.ValidatePath(basePath); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, "pass", "ls", basePath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if passEntryMissing(string(output)) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("pass ls failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	entries := []string{}
+	for _, entry := range parsePassListOutput(basePath, string(output)) {
+		if entry.depth == 1 {
+			entries = append(entries, entry.name)
+		}
+	}
+
+	return entries, nil
+}
+
+type passListEntry struct {
+	name  string
+	depth int
+}
+
+func parsePassListOutput(basePath, output string) []passListEntry {
+	lines := strings.Split(output, "\n")
+	entries := []passListEntry{}
+
+	for _, line := range lines {
+		line = ansiRegex.ReplaceAllString(line, "")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		depth := 0
+		for {
+			switch {
+			case strings.HasPrefix(line, "│   "):
+				line = strings.TrimPrefix(line, "│   ")
+				depth++
+			case strings.HasPrefix(line, "|   "):
+				line = strings.TrimPrefix(line, "|   ")
+				depth++
+			case strings.HasPrefix(line, "    "):
+				line = strings.TrimPrefix(line, "    ")
+				depth++
+			default:
+				goto prefixDone
+			}
+		}
+	prefixDone:
+
+		switch {
+		case strings.HasPrefix(line, "├── "):
+			line = strings.TrimPrefix(line, "├── ")
+			depth++
+		case strings.HasPrefix(line, "└── "):
+			line = strings.TrimPrefix(line, "└── ")
+			depth++
+		case strings.HasPrefix(line, "|-- "):
+			line = strings.TrimPrefix(line, "|-- ")
+			depth++
+		case strings.HasPrefix(line, "`-- "):
+			line = strings.TrimPrefix(line, "`-- ")
+			depth++
+		}
+
+		name := strings.TrimSpace(line)
+		if name == "" || name == basePath {
+			continue
+		}
+		if depth == 0 {
+			continue
+		}
+
+		entries = append(entries, passListEntry{name: name, depth: depth})
+	}
+
+	return entries
+}
+
+func passEntryMissing(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "not in the password store") ||
+		strings.Contains(lower, "password store is empty")
+}

--- a/internal/adapters/out/domainsecrets/pass_store.go
+++ b/internal/adapters/out/domainsecrets/pass_store.go
@@ -387,7 +387,8 @@ func (s *PassStore) passShow(ctx context.Context, path string) (string, bool, er
 	}
 
 	clean := ansiRegex.ReplaceAllString(string(output), "")
-	return strings.TrimSpace(clean), true, nil
+	clean = strings.TrimRight(clean, "\r\n")
+	return clean, true, nil
 }
 
 func (s *PassStore) listTopLevelEntries(ctx context.Context, basePath string) ([]string, error) {

--- a/internal/adapters/out/domainsecrets/pass_store.go
+++ b/internal/adapters/out/domainsecrets/pass_store.go
@@ -257,7 +257,9 @@ func (s *PassStore) ListAttachmentKeys(domainName string) ([]out.AttachmentSecre
 			return nil, err
 		}
 
-		content, exists, err := s.passShow(ctx, manifestPath)
+		showCtx, showCancel := context.WithTimeout(context.Background(), s.timeout)
+		content, exists, err := s.passShow(showCtx, manifestPath)
+		showCancel()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/adapters/out/domainsecrets/pass_store_test.go
+++ b/internal/adapters/out/domainsecrets/pass_store_test.go
@@ -1,0 +1,74 @@
+package domainsecrets
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func requirePass(t *testing.T) {
+	if err := exec.Command("pass", "version").Run(); err != nil {
+		t.Skip("pass not available")
+	}
+	if err := exec.Command("pass", "ls").Run(); err != nil {
+		t.Skip("pass store not initialized")
+	}
+}
+
+func cleanupPassDomain(t *testing.T, domainName string, keys []string) {
+	safeDomain, err := domain.SanitizeDomainForEnvFile(domainName)
+	if err != nil {
+		return
+	}
+
+	for _, key := range keys {
+		path := fmt.Sprintf("%s/%s/%s", passDomainSecretsPath, safeDomain, key)
+		_ = exec.Command("pass", "rm", "-f", path).Run()
+	}
+
+	manifestPath := fmt.Sprintf("%s/%s/.keys", passDomainSecretsPath, safeDomain)
+	_ = exec.Command("pass", "rm", "-f", manifestPath).Run()
+}
+
+func TestPassStore_SetGetDelete(t *testing.T) {
+	requirePass(t)
+
+	store, err := NewPassStore(testLogger())
+	require.NoError(t, err)
+
+	domainName := fmt.Sprintf("test.%d.example.com", time.Now().UnixNano())
+	keys := []string{"API_KEY", "DB_PASSWORD"}
+	defer cleanupPassDomain(t, domainName, keys)
+
+	secretsMap := map[string]string{
+		"API_KEY":     "alpha",
+		"DB_PASSWORD": "bravo",
+	}
+
+	err = store.Set(domainName, secretsMap)
+	require.NoError(t, err)
+
+	keysList, err := store.ListKeys(domainName)
+	require.NoError(t, err)
+	assert.Len(t, keysList, 2)
+	assert.ElementsMatch(t, keys, keysList)
+
+	values, err := store.GetAll(domainName)
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", strings.TrimSpace(values["API_KEY"]))
+	assert.Equal(t, "bravo", strings.TrimSpace(values["DB_PASSWORD"]))
+
+	err = store.Delete(domainName, "DB_PASSWORD")
+	require.NoError(t, err)
+
+	keysList, err = store.ListKeys(domainName)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"API_KEY"}, keysList)
+}

--- a/internal/adapters/out/domainsecrets/store.go
+++ b/internal/adapters/out/domainsecrets/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bnema/zerowrap"
@@ -148,6 +149,56 @@ func (s *FileStore) Delete(domainName, key string) error {
 	return s.writeSecretsAtomic(domainName, existing)
 }
 
+// SetAttachment sets or updates multiple secrets for an attachment container.
+func (s *FileStore) SetAttachment(containerName string, secrets map[string]string) error {
+	// Validate container name first
+	if _, err := s.validateAttachmentEnvFilePath(containerName); err != nil {
+		return err
+	}
+
+	// Ensure env directory exists
+	if err := os.MkdirAll(s.envDir, 0700); err != nil {
+		return fmt.Errorf("failed to create env directory: %w", err)
+	}
+
+	// Read existing secrets
+	existing, err := s.GetAllAttachment(containerName)
+	if err != nil {
+		return err
+	}
+
+	// Merge new secrets with existing
+	for key, value := range secrets {
+		existing[key] = value
+	}
+
+	// Write back atomically
+	return s.writeAttachmentSecretsAtomic(containerName, existing)
+}
+
+// GetAllAttachment returns all secrets for an attachment container as a key-value map.
+func (s *FileStore) GetAllAttachment(containerName string) (map[string]string, error) {
+	envFile, err := s.validateAttachmentEnvFilePath(containerName)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read attachment env file: %w", err)
+	}
+
+	secrets, err := domain.ParseEnvData(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse attachment env file: %w", err)
+	}
+
+	return secrets, nil
+}
+
 // writeSecretsAtomic writes all secrets to the domain's env file atomically.
 // It writes to a temporary file first, syncs it, then renames to the final path.
 func (s *FileStore) writeSecretsAtomic(domainName string, secrets map[string]string) error {
@@ -174,9 +225,15 @@ func (s *FileStore) writeSecretsAtomic(domainName string, secrets map[string]str
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
-	// Write each secret
-	for key, value := range secrets {
-		if _, err := fmt.Fprintf(file, "%s=%s\n", key, value); err != nil {
+	// Write each secret in sorted order for deterministic output
+	keys := make([]string, 0, len(secrets))
+	for key := range secrets {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, err := fmt.Fprintf(file, "%s=%s\n", key, secrets[key]); err != nil {
 			file.Close()
 			os.Remove(tmpFile)
 			return fmt.Errorf("failed to write secret %s: %w", key, err)
@@ -248,12 +305,118 @@ func (s *FileStore) validateEnvFilePath(domainName string) (string, error) {
 	return path, nil
 }
 
+// getAttachmentEnvFilePath converts a container name to its attachment env file path.
+// Attachment env files follow the pattern: gordon-<containerName>.env
+//
+// SECURITY: Validates container name and ensures the resulting path stays within envDir.
+func (s *FileStore) getAttachmentEnvFilePath(containerName string) (string, error) {
+	if err := domain.ValidateContainerName(containerName); err != nil {
+		s.log.Warn().
+			Str(zerowrap.FieldLayer, "adapter").
+			Str(zerowrap.FieldAdapter, "domainsecrets").
+			Str("container", containerName).
+			Err(err).
+			Msg("rejected invalid container name")
+		return "", err
+	}
+
+	fullPath := filepath.Join(s.envDir, "gordon-"+containerName+".env")
+
+	// SECURITY: Final validation - ensure path stays within envDir
+	cleanPath := filepath.Clean(fullPath)
+	cleanEnvDir := filepath.Clean(s.envDir)
+	if !strings.HasPrefix(cleanPath, cleanEnvDir+string(filepath.Separator)) {
+		s.log.Error().
+			Str(zerowrap.FieldLayer, "adapter").
+			Str(zerowrap.FieldAdapter, "domainsecrets").
+			Str("container", containerName).
+			Str("attempted_path", fullPath).
+			Msg("path traversal attempt blocked - path escapes env directory")
+		return "", domain.ErrPathTraversal
+	}
+
+	return fullPath, nil
+}
+
+// validateAttachmentEnvFilePath validates that a container name produces a valid attachment env file path.
+// Returns an error if the container name is invalid or would result in path traversal.
+func (s *FileStore) validateAttachmentEnvFilePath(containerName string) (string, error) {
+	return s.getAttachmentEnvFilePath(containerName)
+}
+
+// writeAttachmentSecretsAtomic writes all secrets to the attachment's env file atomically.
+// It writes to a temporary file first, syncs it, then renames to the final path.
+func (s *FileStore) writeAttachmentSecretsAtomic(containerName string, secrets map[string]string) error {
+	envFile, err := s.validateAttachmentEnvFilePath(containerName)
+	if err != nil {
+		return err
+	}
+	tmpFile := envFile + ".tmp"
+
+	file, err := os.OpenFile(tmpFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to create temp attachment env file: %w", err)
+	}
+
+	// Write header comment
+	if _, err := fmt.Fprintf(file, "# Environment variables for attachment %s\n", containerName); err != nil {
+		file.Close()
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to write header: %w", err)
+	}
+	if _, err := fmt.Fprintf(file, "# Managed by Gordon admin API\n\n"); err != nil {
+		file.Close()
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to write header: %w", err)
+	}
+
+	// Write each secret in sorted order for deterministic output
+	keys := make([]string, 0, len(secrets))
+	for key := range secrets {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, err := fmt.Fprintf(file, "%s=%s\n", key, secrets[key]); err != nil {
+			file.Close()
+			os.Remove(tmpFile)
+			return fmt.Errorf("failed to write secret %s: %w", key, err)
+		}
+	}
+
+	// Sync to ensure data is on disk before rename
+	if err := file.Sync(); err != nil {
+		file.Close()
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to sync attachment env file: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to close attachment env file: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpFile, envFile); err != nil {
+		os.Remove(tmpFile)
+		return fmt.Errorf("failed to rename attachment env file: %w", err)
+	}
+
+	return nil
+}
+
 // ListAttachmentKeys finds attachment env files for a domain and returns their keys.
+// Supports both new (collision-resistant) and legacy container naming for backwards compatibility.
 // Attachment env files follow the naming pattern: gordon-{sanitized-domain}-{service}.env
 func (s *FileStore) ListAttachmentKeys(domainName string) ([]out.AttachmentSecrets, error) {
-	// Sanitize domain the same way container service does
-	sanitized := sanitizeDomainForContainer(domainName)
-	prefix := "gordon-" + sanitized + "-"
+	// Try both new and legacy sanitization for backwards compatibility
+	sanitized := domain.SanitizeDomainForContainer(domainName)
+	sanitizedLegacy := domain.SanitizeDomainForContainerLegacy(domainName)
+	prefixes := []string{
+		"gordon-" + sanitized + "-",       // New format (collision-resistant)
+		"gordon-" + sanitizedLegacy + "-", // Old format (buggy but backwards compatible)
+	}
 
 	// List all files in env directory
 	entries, err := os.ReadDir(s.envDir)
@@ -264,55 +427,64 @@ func (s *FileStore) ListAttachmentKeys(domainName string) ([]out.AttachmentSecre
 		return nil, fmt.Errorf("failed to read env directory: %w", err)
 	}
 
+	seen := make(map[string]bool)
 	var results []out.AttachmentSecrets
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
 		name := entry.Name()
-		// Check if this is an attachment file for the domain
-		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".env") {
-			// Extract service name from filename
-			// e.g., "gordon-git-bnema-dev-gitea-postgres.env" → "gitea-postgres"
-			serviceName := strings.TrimPrefix(name, prefix)
-			serviceName = strings.TrimSuffix(serviceName, ".env")
-			if serviceName == "" {
-				continue
-			}
 
-			// The full container name is the filename without .env
-			containerName := strings.TrimSuffix(name, ".env")
-
-			// Read keys from this file using existing method
-			// Note: We use the container name directly since it matches the env file naming
-			keys, err := s.listKeysFromFile(filepath.Join(s.envDir, name))
-			if err != nil {
-				s.log.Warn().
-					Err(err).
-					Str("file", name).
-					Str("domain", domainName).
-					Msg("failed to read attachment secrets file")
-				continue
+		// Check if this matches any of our prefixes
+		var matchedPrefix string
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".env") {
+				matchedPrefix = prefix
+				break
 			}
+		}
+		if matchedPrefix == "" {
+			continue
+		}
 
-			if len(keys) > 0 {
-				results = append(results, out.AttachmentSecrets{
-					Service: containerName,
-					Keys:    keys,
-				})
-			}
+		// Extract container name from filename
+		containerName := strings.TrimSuffix(name, ".env")
+
+		// Deduplicate results
+		if seen[containerName] {
+			continue
+		}
+		seen[containerName] = true
+
+		// Extract service name from filename
+		// e.g., "gordon-git-bnema-dev-gitea-postgres.env" → "gitea-postgres"
+		serviceName := strings.TrimPrefix(name, matchedPrefix)
+		serviceName = strings.TrimSuffix(serviceName, ".env")
+		if serviceName == "" {
+			continue
+		}
+
+		// Read keys from this file using existing method
+		// Note: We use the container name directly since it matches the env file naming
+		keys, err := s.listKeysFromFile(filepath.Join(s.envDir, name))
+		if err != nil {
+			s.log.Warn().
+				Err(err).
+				Str("file", name).
+				Str("domain", domainName).
+				Msg("failed to read attachment secrets file")
+			continue
+		}
+
+		if len(keys) > 0 {
+			results = append(results, out.AttachmentSecrets{
+				Service: containerName,
+				Keys:    keys,
+			})
 		}
 	}
 
 	return results, nil
-}
-
-// sanitizeDomainForContainer matches the sanitizeName function in container service.
-func sanitizeDomainForContainer(domain string) string {
-	result := strings.ReplaceAll(domain, ".", "-")
-	result = strings.ReplaceAll(result, ":", "-")
-	result = strings.ReplaceAll(result, "/", "-")
-	return result
 }
 
 // listKeysFromFile reads secret keys from a specific env file path.

--- a/internal/adapters/out/domainsecrets/store_test.go
+++ b/internal/adapters/out/domainsecrets/store_test.go
@@ -6,16 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/gordon/internal/domain"
 )
-
-func testLogger() zerowrap.Logger {
-	return zerowrap.Default()
-}
 
 func TestFileStore_PathTraversal(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "domainsecrets-test-*")

--- a/internal/adapters/out/domainsecrets/store_test.go
+++ b/internal/adapters/out/domainsecrets/store_test.go
@@ -116,6 +116,183 @@ func TestFileStore_PathContainment(t *testing.T) {
 	}
 }
 
+func TestSanitizeDomainForContainer(t *testing.T) {
+	tests := []struct {
+		domain      string
+		expected    string
+		description string
+	}{
+		{
+			domain:      "git.example.com",
+			expected:    "git__example__com",
+			description: "Dots become double underscores",
+		},
+		{
+			domain:      "git-example.com",
+			expected:    "git-example__com",
+			description: "Hyphens preserved, dots become underscores",
+		},
+		{
+			domain:      "app:8080.example.com",
+			expected:    "app-_8080__example__com",
+			description: "Colons become hyphen-underscore",
+		},
+		{
+			domain:      "git.example.com:3000",
+			expected:    "git__example__com-_3000",
+			description: "Multiple separators handled distinctly",
+		},
+		{
+			domain:      "simple.com",
+			expected:    "simple__com",
+			description: "Simple domain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.domain, func(t *testing.T) {
+			result := domain.SanitizeDomainForContainer(tt.domain)
+			assert.Equal(t, tt.expected, result, "sanitization should match expected")
+		})
+	}
+
+	// Verify no collisions between potentially conflicting domains
+	t.Run("NoCollisions", func(t *testing.T) {
+		domains := []string{
+			"git.example.com",
+			"git-example.com",
+			"app:8080.example.com",
+			"app-8080-example.com",
+		}
+
+		results := make(map[string]string)
+		for _, d := range domains {
+			result := domain.SanitizeDomainForContainer(d)
+			if original, exists := results[result]; exists {
+				t.Errorf("COLLISION: %q and %q both sanitize to %q", original, d, result)
+			}
+			results[result] = d
+		}
+	})
+}
+
+func TestFileStore_AttachmentOperations(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "domainsecrets-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFileStore(tmpDir, testLogger())
+	require.NoError(t, err)
+
+	containerName := "gitea-postgres"
+
+	t.Run("SetAttachment creates new file", func(t *testing.T) {
+		err := store.SetAttachment(containerName, map[string]string{
+			"POSTGRES_DB":       "gitea",
+			"POSTGRES_PASSWORD": "secret123",
+		})
+		require.NoError(t, err)
+
+		// Verify file exists
+		expectedFile := filepath.Join(tmpDir, "gordon-"+containerName+".env")
+		_, err = os.Stat(expectedFile)
+		assert.NoError(t, err, "expected attachment env file to exist at %s", expectedFile)
+	})
+
+	t.Run("GetAllAttachment retrieves secrets", func(t *testing.T) {
+		secrets, err := store.GetAllAttachment(containerName)
+		require.NoError(t, err)
+		assert.Equal(t, "gitea", secrets["POSTGRES_DB"])
+		assert.Equal(t, "secret123", secrets["POSTGRES_PASSWORD"])
+	})
+
+	t.Run("SetAttachment merges with existing", func(t *testing.T) {
+		err := store.SetAttachment(containerName, map[string]string{
+			"NEW_VAR": "new_value",
+		})
+		require.NoError(t, err)
+
+		// Should have both old and new secrets
+		secrets, err := store.GetAllAttachment(containerName)
+		require.NoError(t, err)
+		assert.Equal(t, "gitea", secrets["POSTGRES_DB"])
+		assert.Equal(t, "secret123", secrets["POSTGRES_PASSWORD"])
+		assert.Equal(t, "new_value", secrets["NEW_VAR"])
+	})
+
+	t.Run("GetAllAttachment returns empty map for non-existent container", func(t *testing.T) {
+		secrets, err := store.GetAllAttachment("non-existent")
+		require.NoError(t, err)
+		assert.Empty(t, secrets)
+	})
+
+	t.Run("SetAttachment with hyphenated container name", func(t *testing.T) {
+		hyphenatedContainer := "gordon-git-example-com-gitea-postgres"
+		err := store.SetAttachment(hyphenatedContainer, map[string]string{
+			"KEY": "value",
+		})
+		require.NoError(t, err)
+
+		secrets, err := store.GetAllAttachment(hyphenatedContainer)
+		require.NoError(t, err)
+		assert.Equal(t, "value", secrets["KEY"])
+	})
+}
+
+func TestFileStore_AttachmentPathTraversal(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "domainsecrets-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewFileStore(tmpDir, testLogger())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		container  string
+		wantSetErr bool
+		wantGetErr bool
+	}{
+		// Valid container names
+		{"simple", "postgres", false, false},
+		{"with hyphen", "gitea-postgres", false, false},
+		{"with underscore", "gitea_postgres", false, false},
+		{"complex real container", "gordon-git-example-com-gitea-postgres", false, false},
+
+		// Invalid container names - should fail
+		{"empty", "", true, true},
+		{"starts with number", "1container", true, true},
+		{"starts with hyphen", "-container", true, true},
+		{"starts with underscore", "_container", true, true},
+		{"path traversal", "../etc", true, true},
+		{"contains slash", "container/name", true, true},
+		{"contains backslash", "container\\name", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test SetAttachment
+			err := store.SetAttachment(tt.container, map[string]string{"KEY": "value"})
+			if tt.wantSetErr {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Test GetAllAttachment
+			_, err = store.GetAllAttachment(tt.container)
+			if tt.wantGetErr {
+				require.Error(t, err)
+			} else {
+				if !tt.wantSetErr {
+					// Only check no error if we successfully set it
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
 func TestFileStore_ValidDomainOperations(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "domainsecrets-test-*")
 	require.NoError(t, err)

--- a/internal/adapters/out/envloader/pass_loader.go
+++ b/internal/adapters/out/envloader/pass_loader.go
@@ -1,0 +1,90 @@
+// Package envloader implements the environment variable loader adapter.
+package envloader
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/bnema/zerowrap"
+
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+)
+
+// PassLoader implements the EnvLoader interface using pass-backed secrets.
+type PassLoader struct {
+	store *domainsecrets.PassStore
+	log   zerowrap.Logger
+}
+
+// NewPassLoader creates a new pass-based environment loader.
+func NewPassLoader(store *domainsecrets.PassStore, log zerowrap.Logger) (*PassLoader, error) {
+	if store == nil {
+		return nil, fmt.Errorf("pass store is required")
+	}
+
+	log.Debug().
+		Str(zerowrap.FieldLayer, "adapter").
+		Str(zerowrap.FieldAdapter, "envloader").
+		Str("provider", "pass").
+		Msg("env loader initialized")
+
+	return &PassLoader{
+		store: store,
+		log:   log,
+	}, nil
+}
+
+// LoadEnv loads environment variables for a given domain.
+func (l *PassLoader) LoadEnv(ctx context.Context, domain string) ([]string, error) {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "adapter",
+		zerowrap.FieldAdapter: "envloader",
+		zerowrap.FieldAction:  "LoadEnv",
+		"domain":              domain,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	secretsMap, err := l.store.GetAll(domain)
+	if err != nil {
+		return nil, log.WrapErr(err, "failed to load env from pass")
+	}
+
+	keys := make([]string, 0, len(secretsMap))
+	for key := range secretsMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	envVars := make([]string, 0, len(keys))
+	for _, key := range keys {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", key, secretsMap[key]))
+	}
+
+	log.Info().Int(zerowrap.FieldCount, len(envVars)).Msg("loaded environment variables for route")
+
+	return envVars, nil
+}
+
+// CreateEnvFile is a no-op for pass-backed loader.
+func (l *PassLoader) CreateEnvFile(ctx context.Context, domain string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "adapter",
+		zerowrap.FieldAdapter: "envloader",
+		zerowrap.FieldAction:  "CreateEnvFile",
+		"domain":              domain,
+	})
+	log := zerowrap.FromCtx(ctx)
+	log.Debug().Msg("pass loader does not create env files")
+	return nil
+}
+
+// EnvFileExists checks if a manifest exists for a domain in pass.
+func (l *PassLoader) EnvFileExists(domain string) bool {
+	exists, err := l.store.ManifestExists(domain)
+	if err != nil {
+		l.log.Warn().Err(err).Str("domain", domain).Msg("failed to check pass manifest")
+		return false
+	}
+	return exists
+}

--- a/internal/adapters/out/envloader/pass_loader_test.go
+++ b/internal/adapters/out/envloader/pass_loader_test.go
@@ -1,0 +1,108 @@
+package envloader
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+	"github.com/bnema/zerowrap"
+)
+
+func passCmd(args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "pass", args...).Run()
+}
+
+func requirePass(t *testing.T) {
+	if err := passCmd("version"); err != nil {
+		t.Skip("pass not available")
+	}
+	if err := passCmd("ls"); err != nil {
+		t.Skip("pass store not initialized")
+	}
+}
+
+func cleanupPassEnv(t *testing.T, path string) {
+	_ = passCmd("rm", "-rf", path)
+}
+
+func TestPassLoader_LoadEnv_Domain(t *testing.T) {
+	requirePass(t)
+
+	log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+	store, err := domainsecrets.NewPassStore(log)
+	require.NoError(t, err)
+
+	loader, err := NewPassLoader(store, log)
+	require.NoError(t, err)
+
+	domainName := fmt.Sprintf("test.%d.example.com", time.Now().UnixNano())
+	defer cleanupPassEnv(t, fmt.Sprintf("%s/%s", domainsecrets.PassDomainSecretsPath, domainName))
+
+	secretsMap := map[string]string{
+		"API_KEY": "test123",
+		"DB_HOST": "localhost",
+	}
+	err = store.Set(domainName, secretsMap)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	envVars, err := loader.LoadEnv(ctx, domainName)
+	require.NoError(t, err)
+	assert.Len(t, envVars, 2)
+	assert.Contains(t, envVars, "API_KEY=test123")
+	assert.Contains(t, envVars, "DB_HOST=localhost")
+}
+
+func TestPassLoader_LoadEnv_Attachment(t *testing.T) {
+	requirePass(t)
+
+	log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+	store, err := domainsecrets.NewPassStore(log)
+	require.NoError(t, err)
+
+	loader, err := NewPassLoader(store, log)
+	require.NoError(t, err)
+
+	containerName := fmt.Sprintf("gordon-gitea-postgres-%d", time.Now().UnixNano())
+	defer cleanupPassEnv(t, fmt.Sprintf("%s/%s", domainsecrets.PassAttachmentPath, containerName))
+
+	secretsMap := map[string]string{
+		"POSTGRES_USER":     "gitea",
+		"POSTGRES_PASSWORD": "secret123",
+	}
+	err = store.SetAttachment(containerName, secretsMap)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	envVars, err := loader.LoadEnv(ctx, containerName)
+	require.NoError(t, err)
+	assert.Len(t, envVars, 2)
+	assert.Contains(t, envVars, "POSTGRES_USER=gitea")
+	assert.Contains(t, envVars, "POSTGRES_PASSWORD=secret123")
+}
+
+func TestPassLoader_LoadEnv_EmptyDomain(t *testing.T) {
+	requirePass(t)
+
+	log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+	store, err := domainsecrets.NewPassStore(log)
+	require.NoError(t, err)
+
+	loader, err := NewPassLoader(store, log)
+	require.NoError(t, err)
+
+	domainName := fmt.Sprintf("empty.%d.example.com", time.Now().UnixNano())
+
+	ctx := context.Background()
+	envVars, err := loader.LoadEnv(ctx, domainName)
+	require.NoError(t, err)
+	assert.Len(t, envVars, 0)
+}

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bnema/zerowrap"
+
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func migrateEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
+	entries, err := readEnvDir(envDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isPlainEnvFile(name) {
+			continue
+		}
+		if err := migrateEnvFile(envDir, name, passStore, log); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readEnvDir(envDir string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(envDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read env directory: %w", err)
+	}
+	return entries, nil
+}
+
+func isPlainEnvFile(name string) bool {
+	return strings.HasSuffix(name, ".env") && !strings.HasSuffix(name, ".env.migrated")
+}
+
+func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
+	filePath := filepath.Join(envDir, name)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read env file %s: %w", filePath, err)
+	}
+
+	domainName := strings.TrimSuffix(name, ".env")
+	secrets, err := domain.ParseEnvData(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse env file %s: %w", filePath, err)
+	}
+
+	existingKeys, err := passStore.ListKeys(domainName)
+	if err != nil {
+		return fmt.Errorf("failed to read pass keys for %s: %w", domainName, err)
+	}
+
+	missing := missingSecrets(existingKeys, secrets)
+	if len(missing) > 0 {
+		if err := passStore.Set(domainName, missing); err != nil {
+			return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
+		}
+	}
+
+	migratedPath := filePath + ".migrated"
+	if err := os.Rename(filePath, migratedPath); err != nil {
+		return fmt.Errorf("failed to rename env file %s: %w", filePath, err)
+	}
+
+	log.Info().
+		Int(zerowrap.FieldCount, len(missing)).
+		Str("domain", domainName).
+		Msg("migrated secrets for domain from plain text to pass")
+	log.Info().
+		Str("file", migratedPath).
+		Msg("original file renamed to .env.migrated - you can safely remove it")
+
+	return nil
+}
+
+func missingSecrets(existingKeys []string, secrets map[string]string) map[string]string {
+	if len(secrets) == 0 {
+		return nil
+	}
+
+	existingSet := make(map[string]struct{}, len(existingKeys))
+	for _, key := range existingKeys {
+		existingSet[key] = struct{}{}
+	}
+
+	missing := make(map[string]string)
+	for key, value := range secrets {
+		if _, exists := existingSet[key]; exists {
+			continue
+		}
+		missing[key] = value
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return missing
+}

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -31,6 +31,10 @@ func migrateEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, lo
 		}
 	}
 
+	if err := migrateAttachmentEnvFilesToPass(envDir, passStore, log); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -126,4 +130,94 @@ func missingSecrets(existingKeys []string, secrets map[string]string) map[string
 	}
 
 	return missing
+}
+
+func migrateAttachmentEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
+	entries, err := readEnvDir(envDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isAttachmentEnvFile(name) {
+			continue
+		}
+		if err := migrateAttachmentEnvFile(envDir, name, passStore, log); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isAttachmentEnvFile(name string) bool {
+	if !strings.HasSuffix(name, ".env") || strings.HasSuffix(name, ".env.migrated") {
+		return false
+	}
+	return strings.HasPrefix(name, "gordon-")
+}
+
+func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
+	filePath := filepath.Join(envDir, name)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read attachment env file %s: %w", filePath, err)
+	}
+
+	containerName := extractContainerNameFromAttachmentFile(name)
+	secrets, err := domain.ParseEnvData(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse attachment env file %s: %w", filePath, err)
+	}
+	if len(secrets) == 0 {
+		log.Info().
+			Str("file", filePath).
+			Msg("no secrets found in attachment env file; skipping migration")
+		return nil
+	}
+
+	existingSecrets, err := passStore.GetAllAttachment(containerName)
+	if err != nil {
+		return fmt.Errorf("failed to read pass secrets for attachment %s: %w", containerName, err)
+	}
+
+	existingKeys := make([]string, 0, len(existingSecrets))
+	for key := range existingSecrets {
+		existingKeys = append(existingKeys, key)
+	}
+
+	missing := missingSecrets(existingKeys, secrets)
+	if len(missing) > 0 {
+		if err := passStore.SetAttachment(containerName, missing); err != nil {
+			return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
+		}
+		log.Info().
+			Int(zerowrap.FieldCount, len(missing)).
+			Str("container", containerName).
+			Msg("migrated secrets for attachment container from plain text to pass")
+	} else {
+		log.Info().
+			Str("container", containerName).
+			Msg("all attachment secrets already exist in pass; no migration needed")
+	}
+
+	migratedPath := filePath + ".migrated"
+	if err := os.Rename(filePath, migratedPath); err != nil {
+		return fmt.Errorf("failed to rename attachment env file %s: %w", filePath, err)
+	}
+
+	log.Info().
+		Str("file", migratedPath).
+		Msg("original attachment file renamed to .env.migrated - you can safely remove it")
+
+	return nil
+}
+
+func extractContainerNameFromAttachmentFile(filename string) string {
+	name := strings.TrimSuffix(filename, ".env")
+	return name
 }

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -46,7 +46,14 @@ func readEnvDir(envDir string) ([]os.DirEntry, error) {
 }
 
 func isPlainEnvFile(name string) bool {
-	return strings.HasSuffix(name, ".env") && !strings.HasSuffix(name, ".env.migrated")
+	if !strings.HasSuffix(name, ".env") || strings.HasSuffix(name, ".env.migrated") {
+		return false
+	}
+	// Skip attachment env files: gordon-<sanitized-domain>-<service>.env
+	if strings.HasPrefix(name, "gordon-") {
+		return false
+	}
+	return true
 }
 
 func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -61,6 +61,12 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 	if err != nil {
 		return fmt.Errorf("failed to parse env file %s: %w", filePath, err)
 	}
+	if len(secrets) == 0 {
+		log.Info().
+			Str("file", filePath).
+			Msg("no secrets found in env file; skipping migration")
+		return nil
+	}
 
 	existingKeys, err := passStore.ListKeys(domainName)
 	if err != nil {

--- a/internal/app/migrate_env_test.go
+++ b/internal/app/migrate_env_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bnema/zerowrap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func passCmd(args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "pass", args...).Run()
+}
+
+func requirePass(t *testing.T) {
+	if err := passCmd("version"); err != nil {
+		t.Skip("pass not available")
+	}
+	if err := passCmd("ls"); err != nil {
+		t.Skip("pass store not initialized")
+	}
+}
+
+func cleanupPassDomain(t *testing.T, domainName string, keys []string) {
+	safeDomain, err := domain.SanitizeDomainForEnvFile(domainName)
+	if err != nil {
+		return
+	}
+
+	for _, key := range keys {
+		path := fmt.Sprintf("%s/%s/%s", domainsecrets.PassDomainSecretsPath, safeDomain, key)
+		_ = passCmd("rm", "-f", path)
+	}
+
+	manifestPath := fmt.Sprintf("%s/%s/.keys", domainsecrets.PassDomainSecretsPath, safeDomain)
+	_ = passCmd("rm", "-f", manifestPath)
+}
+
+func TestMigrateEnvFile(t *testing.T) {
+	requirePass(t)
+
+	tmpDir, err := os.MkdirTemp("", "migrate-env-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerowrap.Default()
+	store, err := domainsecrets.NewPassStore(logger)
+	require.NoError(t, err)
+
+	domainName := fmt.Sprintf("test.%d.example.com", time.Now().UnixNano())
+	keys := []string{"API_KEY", "DB_PASSWORD"}
+	defer cleanupPassDomain(t, domainName, keys)
+
+	envContent := "API_KEY=secret123\nDB_PASSWORD=pass456\n"
+	envFileName := domainName + ".env"
+	envFilePath := filepath.Join(tmpDir, envFileName)
+	err = os.WriteFile(envFilePath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	err = migrateEnvFile(tmpDir, envFileName, store, logger)
+	require.NoError(t, err)
+
+	migratedPath := envFilePath + ".migrated"
+	_, err = os.Stat(envFilePath)
+	assert.True(t, os.IsNotExist(err), "original .env file should be removed")
+
+	_, err = os.Stat(migratedPath)
+	assert.NoError(t, err, ".env.migrated file should exist")
+
+	passKeys, err := store.ListKeys(domainName)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, keys, passKeys)
+
+	values, err := store.GetAll(domainName)
+	require.NoError(t, err)
+	assert.Equal(t, "secret123", values["API_KEY"])
+	assert.Equal(t, "pass456", values["DB_PASSWORD"])
+}

--- a/internal/app/migrate_env_test.go
+++ b/internal/app/migrate_env_test.go
@@ -87,3 +87,127 @@ func TestMigrateEnvFile(t *testing.T) {
 	assert.Equal(t, "secret123", values["API_KEY"])
 	assert.Equal(t, "pass456", values["DB_PASSWORD"])
 }
+
+func cleanupPassAttachment(t *testing.T, containerName string, keys []string) {
+	for _, key := range keys {
+		path := fmt.Sprintf("%s/%s/%s", domainsecrets.PassAttachmentPath, containerName, key)
+		_ = passCmd("rm", "-f", path)
+	}
+
+	manifestPath := fmt.Sprintf("%s/%s/.keys", domainsecrets.PassAttachmentPath, containerName)
+	_ = passCmd("rm", "-f", manifestPath)
+}
+
+func TestMigrateAttachmentEnvFile(t *testing.T) {
+	requirePass(t)
+
+	tmpDir, err := os.MkdirTemp("", "migrate-attachment-env-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	logger := zerowrap.Default()
+	store, err := domainsecrets.NewPassStore(logger)
+	require.NoError(t, err)
+
+	containerName := fmt.Sprintf("gitea-postgres-%d", time.Now().UnixNano())
+	keys := []string{"POSTGRES_USER", "POSTGRES_PASSWORD"}
+	defer cleanupPassAttachment(t, containerName, keys)
+
+	envContent := "POSTGRES_USER=gitea\nPOSTGRES_PASSWORD=secret123\n"
+	envFileName := "gordon-" + containerName + ".env"
+	envFilePath := filepath.Join(tmpDir, envFileName)
+	err = os.WriteFile(envFilePath, []byte(envContent), 0600)
+	require.NoError(t, err)
+
+	err = migrateAttachmentEnvFile(tmpDir, envFileName, store, logger)
+	require.NoError(t, err)
+
+	migratedPath := envFilePath + ".migrated"
+	_, err = os.Stat(envFilePath)
+	assert.True(t, os.IsNotExist(err), "original .env file should be removed")
+
+	_, err = os.Stat(migratedPath)
+	assert.NoError(t, err, ".env.migrated file should exist")
+
+	values, err := store.GetAllAttachment(containerName)
+	require.NoError(t, err)
+	assert.Equal(t, "gitea", values["POSTGRES_USER"])
+	assert.Equal(t, "secret123", values["POSTGRES_PASSWORD"])
+}
+
+func TestIsAttachmentEnvFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{
+			name:     "attachment env file",
+			filename: "gordon-gitea-postgres.env",
+			want:     true,
+		},
+		{
+			name:     "attachment env file with complex name",
+			filename: "gordon-git-example-com-gitea-postgres.env",
+			want:     true,
+		},
+		{
+			name:     "plain domain env file",
+			filename: "example.com.env",
+			want:     false,
+		},
+		{
+			name:     "migrated attachment file",
+			filename: "gordon-gitea-postgres.env.migrated",
+			want:     false,
+		},
+		{
+			name:     "non-env file",
+			filename: "config.yaml",
+			want:     false,
+		},
+		{
+			name:     "gordon prefix but no env suffix",
+			filename: "gordon-something",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAttachmentEnvFile(tt.filename)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractContainerNameFromAttachmentFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "simple attachment file",
+			filename: "gordon-gitea-postgres.env",
+			want:     "gordon-gitea-postgres",
+		},
+		{
+			name:     "complex attachment file",
+			filename: "gordon-git-example-com-gitea-redis.env",
+			want:     "gordon-git-example-com-gitea-redis",
+		},
+		{
+			name:     "single word container",
+			filename: "gordon-redis.env",
+			want:     "gordon-redis",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractContainerNameFromAttachmentFile(tt.filename)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -847,10 +847,16 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 		if err != nil {
 			return nil, log.WrapErr(err, "failed to resolve service token expiry")
 		}
+		// Note: Service tokens are not auto-refreshed. If the token expires during
+		// container runtime, the container will need to be recreated to get a new token.
 		serviceToken, err := svc.authSvc.GenerateToken(ctx, serviceTokenSubject, []string{"pull"}, expiry)
 		if err != nil {
 			return nil, log.WrapErr(err, "failed to generate registry service token")
 		}
+		log.Info().
+			Str("subject", serviceTokenSubject).
+			Str("expiry", expiry.String()).
+			Msg("generated service token for container registry access")
 		containerConfig.ServiceTokenUsername = serviceTokenSubject
 		containerConfig.ServiceToken = serviceToken
 	}

--- a/internal/boundaries/out/domain_secrets.go
+++ b/internal/boundaries/out/domain_secrets.go
@@ -23,6 +23,12 @@ type DomainSecretStore interface {
 	// Delete removes a specific secret key from a domain.
 	Delete(domain, key string) error
 
+	// SetAttachment sets or updates multiple secrets for an attachment container.
+	SetAttachment(containerName string, secrets map[string]string) error
+
+	// GetAllAttachment returns all secrets for an attachment container as a key-value map.
+	GetAllAttachment(containerName string) (map[string]string, error)
+
 	// ListAttachmentKeys finds and returns secret keys for attachment containers
 	// associated with the given domain. Returns a list of AttachmentSecrets, one
 	// for each attachment that has secrets configured.

--- a/internal/boundaries/out/mocks/mock_domain_secret_store.go
+++ b/internal/boundaries/out/mocks/mock_domain_secret_store.go
@@ -155,6 +155,68 @@ func (_c *MockDomainSecretStore_GetAll_Call) RunAndReturn(run func(domain string
 	return _c
 }
 
+// GetAllAttachment provides a mock function for the type MockDomainSecretStore
+func (_mock *MockDomainSecretStore) GetAllAttachment(containerName string) (map[string]string, error) {
+	ret := _mock.Called(containerName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllAttachment")
+	}
+
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (map[string]string, error)); ok {
+		return returnFunc(containerName)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) map[string]string); ok {
+		r0 = returnFunc(containerName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(containerName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDomainSecretStore_GetAllAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllAttachment'
+type MockDomainSecretStore_GetAllAttachment_Call struct {
+	*mock.Call
+}
+
+// GetAllAttachment is a helper method to define mock.On call
+//   - containerName string
+func (_e *MockDomainSecretStore_Expecter) GetAllAttachment(containerName interface{}) *MockDomainSecretStore_GetAllAttachment_Call {
+	return &MockDomainSecretStore_GetAllAttachment_Call{Call: _e.mock.On("GetAllAttachment", containerName)}
+}
+
+func (_c *MockDomainSecretStore_GetAllAttachment_Call) Run(run func(containerName string)) *MockDomainSecretStore_GetAllAttachment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainSecretStore_GetAllAttachment_Call) Return(stringToString map[string]string, err error) *MockDomainSecretStore_GetAllAttachment_Call {
+	_c.Call.Return(stringToString, err)
+	return _c
+}
+
+func (_c *MockDomainSecretStore_GetAllAttachment_Call) RunAndReturn(run func(containerName string) (map[string]string, error)) *MockDomainSecretStore_GetAllAttachment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListAttachmentKeys provides a mock function for the type MockDomainSecretStore
 func (_mock *MockDomainSecretStore) ListAttachmentKeys(domain string) ([]out.AttachmentSecrets, error) {
 	ret := _mock.Called(domain)
@@ -332,6 +394,63 @@ func (_c *MockDomainSecretStore_Set_Call) Return(err error) *MockDomainSecretSto
 }
 
 func (_c *MockDomainSecretStore_Set_Call) RunAndReturn(run func(domain string, secrets map[string]string) error) *MockDomainSecretStore_Set_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetAttachment provides a mock function for the type MockDomainSecretStore
+func (_mock *MockDomainSecretStore) SetAttachment(containerName string, secrets map[string]string) error {
+	ret := _mock.Called(containerName, secrets)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAttachment")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, map[string]string) error); ok {
+		r0 = returnFunc(containerName, secrets)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDomainSecretStore_SetAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAttachment'
+type MockDomainSecretStore_SetAttachment_Call struct {
+	*mock.Call
+}
+
+// SetAttachment is a helper method to define mock.On call
+//   - containerName string
+//   - secrets map[string]string
+func (_e *MockDomainSecretStore_Expecter) SetAttachment(containerName interface{}, secrets interface{}) *MockDomainSecretStore_SetAttachment_Call {
+	return &MockDomainSecretStore_SetAttachment_Call{Call: _e.mock.On("SetAttachment", containerName, secrets)}
+}
+
+func (_c *MockDomainSecretStore_SetAttachment_Call) Run(run func(containerName string, secrets map[string]string)) *MockDomainSecretStore_SetAttachment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 map[string]string
+		if args[1] != nil {
+			arg1 = args[1].(map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainSecretStore_SetAttachment_Call) Return(err error) *MockDomainSecretStore_SetAttachment_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDomainSecretStore_SetAttachment_Call) RunAndReturn(run func(containerName string, secrets map[string]string) error) *MockDomainSecretStore_SetAttachment_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -10,6 +10,7 @@ import (
 // envDomainRegex validates domain names used for env secrets.
 // Allows: alphanumeric, dots, hyphens, colons (for ports), and forward slashes (for paths).
 var envDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:/-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
+var envKeyRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // SanitizeDomainForEnvFile validates and sanitizes a domain name for env file storage.
 // Returns a safe domain string suitable for filenames.
@@ -67,4 +68,18 @@ func ParseEnvData(data []byte) (map[string]string, error) {
 	}
 
 	return secrets, nil
+}
+
+// ValidateEnvKey validates an env key for storage.
+func ValidateEnvKey(key string) error {
+	if key == "" {
+		return ErrPathTraversal
+	}
+	if strings.Contains(key, "..") || strings.ContainsAny(key, "/\\") {
+		return ErrPathTraversal
+	}
+	if !envKeyRegex.MatchString(key) {
+		return ErrPathTraversal
+	}
+	return nil
 }

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -11,6 +11,7 @@ import (
 // Allows: alphanumeric, dots, hyphens, colons (for ports), and forward slashes (for paths).
 var envDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:/-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
 var envKeyRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var containerNameRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
 
 // SanitizeDomainForEnvFile validates and sanitizes a domain name for env file storage.
 // Returns a safe domain string suitable for filenames.
@@ -86,6 +87,22 @@ func ValidateEnvKey(key string) error {
 	}
 	if !envKeyRegex.MatchString(key) {
 		return ErrInvalidEnvKey
+	}
+	return nil
+}
+
+// ValidateContainerName validates a container name for attachment storage.
+// Container names can contain alphanumeric characters, hyphens, and underscores,
+// but must start with a letter.
+func ValidateContainerName(name string) error {
+	if name == "" {
+		return ErrInvalidContainerName
+	}
+	if strings.Contains(name, "..") || strings.ContainsAny(name, "/\\") {
+		return ErrPathTraversal
+	}
+	if !containerNameRegex.MatchString(name) {
+		return ErrInvalidContainerName
 	}
 	return nil
 }

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -1,0 +1,70 @@
+package domain
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"strings"
+)
+
+// envDomainRegex validates domain names used for env secrets.
+// Allows: alphanumeric, dots, hyphens, colons (for ports), and forward slashes (for paths).
+var envDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:/-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
+
+// SanitizeDomainForEnvFile validates and sanitizes a domain name for env file storage.
+// Returns a safe domain string suitable for filenames.
+func SanitizeDomainForEnvFile(domainName string) (string, error) {
+	if domainName == "" {
+		return "", ErrPathTraversal
+	}
+
+	if strings.Contains(domainName, "..") {
+		return "", ErrPathTraversal
+	}
+
+	if !envDomainRegex.MatchString(domainName) {
+		return "", ErrPathTraversal
+	}
+
+	safeDomain := strings.ReplaceAll(domainName, ".", "_")
+	safeDomain = strings.ReplaceAll(safeDomain, ":", "_")
+	safeDomain = strings.ReplaceAll(safeDomain, "/", "_")
+	return safeDomain, nil
+}
+
+// ParseEnvData parses env data into a key-value map.
+func ParseEnvData(data []byte) (map[string]string, error) {
+	secrets := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if len(value) >= 2 {
+			if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
+				(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+				value = value[1 : len(value)-1]
+			}
+		}
+
+		if key != "" {
+			secrets[key] = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return secrets, nil
+}

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -37,6 +37,8 @@ func SanitizeDomainForEnvFile(domainName string) (string, error) {
 func ParseEnvData(data []byte) (map[string]string, error) {
 	secrets := make(map[string]string)
 	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Allow large env values (certs/keys) without hitting the default ~64KB limit.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/internal/domain/env_test.go
+++ b/internal/domain/env_test.go
@@ -1,0 +1,149 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeDomainForEnvFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		domain  string
+		want    string
+		wantErr bool
+	}{
+		{name: "simple domain", domain: "example.com", want: "example_com"},
+		{name: "subdomain", domain: "app.example.com", want: "app_example_com"},
+		{name: "domain with port", domain: "example.com:8080", want: "example_com_8080"},
+		{name: "domain with path", domain: "example.com/path", want: "example_com_path"},
+		{name: "single char", domain: "a", want: "a"},
+		{name: "hyphenated", domain: "my-app.example.com", want: "my-app_example_com"},
+		{name: "empty", domain: "", wantErr: true},
+		{name: "path traversal", domain: "../etc/passwd", wantErr: true},
+		{name: "double dots", domain: "foo..bar", wantErr: true},
+		{name: "starts with dot", domain: ".hidden", wantErr: true},
+		{name: "ends with dot", domain: "trailing.", wantErr: true},
+		{name: "space", domain: "has space", wantErr: true},
+		{name: "special chars", domain: "bad$domain", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizeDomainForEnvFile(tt.domain)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseEnvData(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "simple key-value",
+			data: "FOO=bar\nBAZ=qux",
+			want: map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name: "double-quoted value",
+			data: `KEY="hello world"`,
+			want: map[string]string{"KEY": "hello world"},
+		},
+		{
+			name: "single-quoted value",
+			data: `KEY='hello world'`,
+			want: map[string]string{"KEY": "hello world"},
+		},
+		{
+			name: "comment lines",
+			data: "# this is a comment\nKEY=val",
+			want: map[string]string{"KEY": "val"},
+		},
+		{
+			name: "empty lines",
+			data: "\n\nKEY=val\n\n",
+			want: map[string]string{"KEY": "val"},
+		},
+		{
+			name: "value with equals",
+			data: "URL=postgres://host:5432/db?opt=1",
+			want: map[string]string{"URL": "postgres://host:5432/db?opt=1"},
+		},
+		{
+			name: "no value",
+			data: "NOVALUE",
+			want: map[string]string{},
+		},
+		{
+			name: "empty value",
+			data: "KEY=",
+			want: map[string]string{"KEY": ""},
+		},
+		{
+			name: "empty input",
+			data: "",
+			want: map[string]string{},
+		},
+		{
+			name: "large value within buffer",
+			data: "BIG=" + strings.Repeat("x", 100000),
+			want: map[string]string{"BIG": strings.Repeat("x", 100000)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseEnvData([]byte(tt.data))
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateEnvKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{name: "simple", key: "FOO", wantErr: false},
+		{name: "with underscore", key: "FOO_BAR", wantErr: false},
+		{name: "starts with underscore", key: "_PRIVATE", wantErr: false},
+		{name: "lowercase", key: "foo", wantErr: false},
+		{name: "mixed", key: "myApp_v2", wantErr: false},
+		{name: "empty", key: "", wantErr: true},
+		{name: "starts with number", key: "1BAD", wantErr: true},
+		{name: "contains dot", key: "FOO.BAR", wantErr: true},
+		{name: "contains slash", key: "FOO/BAR", wantErr: true},
+		{name: "contains backslash", key: `FOO\BAR`, wantErr: true},
+		{name: "path traversal", key: "..", wantErr: true},
+		{name: "contains hyphen", key: "FOO-BAR", wantErr: true},
+		{name: "contains space", key: "FOO BAR", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateEnvKey(tt.key)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -63,6 +63,7 @@ var (
 	ErrInsufficientScope = errors.New("insufficient scope for operation")
 	ErrInvalidScope      = errors.New("invalid scope format")
 	ErrSSRFBlocked       = errors.New("request to internal/blocked network not allowed")
+	ErrInvalidEnvKey     = errors.New("invalid environment variable key")
 
 	// Attachment errors
 	ErrAttachmentNotFound    = errors.New("attachment not found")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -46,9 +46,10 @@ var (
 	ErrConfigLoadFailed = errors.New("failed to load configuration")
 
 	// Environment errors
-	ErrEnvFileNotFound  = errors.New("environment file not found")
-	ErrSecretNotFound   = errors.New("secret not found")
-	ErrProviderNotFound = errors.New("secret provider not found")
+	ErrEnvFileNotFound      = errors.New("environment file not found")
+	ErrSecretNotFound       = errors.New("secret not found")
+	ErrProviderNotFound     = errors.New("secret provider not found")
+	ErrInvalidContainerName = errors.New("invalid container name")
 
 	// Authentication errors
 	ErrInvalidToken       = errors.New("invalid token")

--- a/internal/domain/sanitize.go
+++ b/internal/domain/sanitize.go
@@ -1,0 +1,38 @@
+package domain
+
+import "strings"
+
+// SanitizeDomainForContainer makes a domain safe for container naming.
+// It uses distinct replacements to avoid collisions between domains like
+// "git.example.com" and "git-example.com" (which would both become "git-example-com"
+// if we naively replaced all separators with hyphens).
+//
+// Replacements:
+//
+//	. → __ (double underscore, distinct from single _ in some conventions)
+//	: → -_ (hyphen-underscore combo, used for ports)
+//	/ → -- (double hyphen, distinct from colon to avoid :/ collisions)
+func SanitizeDomainForContainer(domain string) string {
+	result := strings.ReplaceAll(domain, ".", "__")
+	result = strings.ReplaceAll(result, ":", "-_")
+	result = strings.ReplaceAll(result, "/", "--")
+	return result
+}
+
+// SanitizeDomainForContainerLegacy uses the OLD (buggy) sanitization that replaces
+// all separators with hyphens, for backwards compatibility.
+//
+// IMPORTANT: This is maintained ONLY for finding old containers during upgrades.
+// New containers always use the collision-resistant SanitizeDomainForContainer().
+//
+// Migration strategy:
+// - During binary upgrades, legacy containers are found using this function
+// - Old containers are stopped and removed, then replaced with new containers
+// - New containers use the collision-resistant SanitizeDomainForContainer() naming
+// - After all deployments are upgraded, this function can be removed in a major version
+func SanitizeDomainForContainerLegacy(domain string) string {
+	result := strings.ReplaceAll(domain, ".", "-")
+	result = strings.ReplaceAll(result, ":", "-")
+	result = strings.ReplaceAll(result, "/", "-")
+	return result
+}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -21,8 +21,8 @@ type Config struct {
 	RegistryAuthEnabled      bool
 	RegistryDomain           string
 	RegistryPort             int
-	RegistryUsername         string
-	RegistryPassword         string
+	ServiceTokenUsername     string
+	ServiceToken             string
 	InternalRegistryUsername string
 	InternalRegistryPassword string
 	PullPolicy               string
@@ -754,7 +754,10 @@ func (s *Service) pullImage(ctx context.Context, pullRef string, isInternal bool
 			return log.WrapErr(err, "failed to pull image")
 		}
 	case s.config.RegistryAuthEnabled:
-		if err := s.runtime.PullImageWithAuth(ctx, pullRef, s.config.RegistryUsername, s.config.RegistryPassword); err != nil {
+		if s.config.ServiceTokenUsername == "" || s.config.ServiceToken == "" {
+			return log.WrapErr(fmt.Errorf("registry service token not configured"), "failed to pull image for registry auth")
+		}
+		if err := s.runtime.PullImageWithAuth(ctx, pullRef, s.config.ServiceTokenUsername, s.config.ServiceToken); err != nil {
 			return log.WrapErr(err, "failed to pull image with auth")
 		}
 	default:

--- a/wiki/guides/secrets-pass.md
+++ b/wiki/guides/secrets-pass.md
@@ -106,16 +106,17 @@ token_secret = "gordon/auth/token_secret"
 # password_hash = "gordon/auth/password_hash"
 ```
 
-### Using Secrets in Environment Files
+### Using Route Secrets
 
-Reference pass secrets in your app's environment files:
+With the pass backend, per-domain secrets are stored in pass, not `.env` files.
 
 ```bash
-# ~/.gordon/env/app_mydomain_com.env
-DATABASE_URL=postgresql://user:${pass:myapp/db/password}@postgres:5432/app
-API_KEY=${pass:myapp/api/key}
-JWT_SECRET=${pass:myapp/jwt/secret}
+# Store secrets for a domain
+gordon secrets set app.mydomain.com DATABASE_URL "postgresql://user:pass@postgres:5432/app"
+gordon secrets set app.mydomain.com API_KEY "your-api-key"
 ```
+
+Gordon migrates existing `.env` files on startup and renames them to `.env.migrated`.
 
 ## Organizing Secrets
 

--- a/wiki/guides/secrets-sops.md
+++ b/wiki/guides/secrets-sops.md
@@ -208,6 +208,8 @@ The path format is `file:key.path` where:
 - `file` is the SOPS-encrypted file path
 - `key.path` is dot-notation to the value
 
+Route secrets remain in `.env` files with `${sops:...}` references. The SOPS backend is used for auth secrets (like `token_secret`) and provider lookups.
+
 ### Using Secrets in Environment Files
 
 Reference SOPS secrets in your app's environment files:


### PR DESCRIPTION
## Summary
- Add pass-backed domain secrets with migration from existing .env files, plus pass env loader support
- Switch registry pulls to use a service token, add external pull tests, and document registry auth behavior
- Extend CLI auth login to accept tokens (with verification) and document auth/token flows
- Simplify auth documentation and clarify token secret sources and getting started guidance
- Harden pass secrets handling with per-key timeouts, ANSI stripping, env key validation in domain, and safe rollback

## Tests
- make lint
- make test
- go test ./internal/usecase/container/...
- go test ./internal/adapters/in/cli/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-based CLI login (password or token), per-remote token verification/persistence; registry service tokens for authenticated image pulls.
  * Pass-backed per-domain secrets store and env loader with automatic migration of existing .env files to .env.migrated; attachment secret support.

* **Documentation**
  * Auth, secrets, and env docs rewritten for token-first flows, backend behaviors, env-var options, scopes, migration, and troubleshooting.

* **Chores**
  * Installer supports selecting pre-release versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->