### PR TITLE
restore admin restart and tags endpoints

### DIFF
--- a/internal/adapters/dto/admin_repository_tags.go
+++ b/internal/adapters/dto/admin_repository_tags.go
@@ -1,0 +1,7 @@
+package dto
+
+// RepositoryTagsResponse represents a repository tags listing response.
+type RepositoryTagsResponse struct {
+	Repository string   `json:"repository"`
+	Tags       []string `json:"tags"`
+}

--- a/internal/adapters/dto/admin_restart.go
+++ b/internal/adapters/dto/admin_restart.go
@@ -1,0 +1,7 @@
+package dto
+
+// RestartResponse represents a restart response.
+type RestartResponse struct {
+	Status string `json:"status"`
+	Domain string `json:"domain"`
+}

--- a/internal/adapters/in/cli/push_test.go
+++ b/internal/adapters/in/cli/push_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateBuildArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantErr bool
+	}{
+		{"valid simple", "FOO=bar", false},
+		{"valid with underscore key", "_FOO=bar", false},
+		{"valid with numbers in key", "FOO123=bar", false},
+		{"valid empty value", "FOO=", false},
+		{"valid complex value", "FOO=bar baz=qux", false},
+		{"invalid no equals", "FOO", true},
+		{"invalid starts with number", "1FOO=bar", true},
+		{"invalid starts with dash", "-FOO=bar", true},
+		{"invalid special chars in key", "FOO-BAR=baz", true},
+		{"invalid empty string", "", true},
+		{"invalid equals only", "=value", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBuildArg(tt.arg)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseImageRef(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        string
+		wantRegistry string
+		wantName     string
+		wantTag      string
+	}{
+		{"full ref", "reg.example.com/myapp:v1.0.0", "reg.example.com", "myapp", "v1.0.0"},
+		{"no tag", "reg.example.com/myapp", "reg.example.com", "myapp", "latest"},
+		{"latest tag", "reg.example.com/myapp:latest", "reg.example.com", "myapp", "latest"},
+		{"no slash", "myapp:v1.0.0", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, name, tag := parseImageRef(tt.image)
+			assert.Equal(t, tt.wantRegistry, registry)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantTag, tag)
+		})
+	}
+}

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bnema/gordon/internal/boundaries/in"
 	"github.com/bnema/gordon/internal/boundaries/out"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/registry"
 	"github.com/bnema/gordon/pkg/validation"
 )
 
@@ -837,6 +838,10 @@ func (h *Handler) handleTags(w http.ResponseWriter, r *http.Request, path string
 
 	tags, err := h.registrySvc.ListTags(ctx, repository)
 	if err != nil {
+		if errors.Is(err, registry.ErrRepositoryNotFound) {
+			h.sendError(w, http.StatusNotFound, "repository not found")
+			return
+		}
 		h.sendError(w, http.StatusInternalServerError, "failed to list tags")
 		return
 	}

--- a/internal/boundaries/in/container.go
+++ b/internal/boundaries/in/container.go
@@ -23,6 +23,10 @@ type ContainerService interface {
 	// Get retrieves a container by domain name.
 	Get(ctx context.Context, domain string) (*domain.Container, bool)
 
+	// Restart restarts a running container for the given domain.
+	// If withAttachments is true, also restarts attachment containers.
+	Restart(ctx context.Context, domain string, withAttachments bool) error
+
 	// List returns all managed containers.
 	List(ctx context.Context) map[string]*domain.Container
 

--- a/internal/boundaries/in/mocks/mock_container_service.go
+++ b/internal/boundaries/in/mocks/mock_container_service.go
@@ -574,6 +574,69 @@ func (_c *MockContainerService_Remove_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// Restart provides a mock function for the type MockContainerService
+func (_mock *MockContainerService) Restart(ctx context.Context, domain1 string, withAttachments bool) error {
+	ret := _mock.Called(ctx, domain1, withAttachments)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Restart")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, bool) error); ok {
+		r0 = returnFunc(ctx, domain1, withAttachments)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockContainerService_Restart_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Restart'
+type MockContainerService_Restart_Call struct {
+	*mock.Call
+}
+
+// Restart is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain1 string
+//   - withAttachments bool
+func (_e *MockContainerService_Expecter) Restart(ctx interface{}, domain1 interface{}, withAttachments interface{}) *MockContainerService_Restart_Call {
+	return &MockContainerService_Restart_Call{Call: _e.mock.On("Restart", ctx, domain1, withAttachments)}
+}
+
+func (_c *MockContainerService_Restart_Call) Run(run func(ctx context.Context, domain1 string, withAttachments bool)) *MockContainerService_Restart_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerService_Restart_Call) Return(err error) *MockContainerService_Restart_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockContainerService_Restart_Call) RunAndReturn(run func(ctx context.Context, domain1 string, withAttachments bool) error) *MockContainerService_Restart_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Shutdown provides a mock function for the type MockContainerService
 func (_mock *MockContainerService) Shutdown(ctx context.Context) error {
 	ret := _mock.Called(ctx)

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -223,7 +223,12 @@ func (s *Service) Restart(ctx context.Context, domainName string, withAttachment
 
 	s.mu.RLock()
 	container, exists := s.containers[domainName]
-	attachmentIDs := s.attachments[domainName]
+	attachments := s.attachments[domainName]
+	var attachmentIDs []string
+	if len(attachments) > 0 {
+		attachmentIDs = make([]string, len(attachments))
+		copy(attachmentIDs, attachments)
+	}
 	s.mu.RUnlock()
 
 	if !exists || container == nil {

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -212,6 +212,44 @@ func (s *Service) Deploy(ctx context.Context, route domain.Route) (*domain.Conta
 	return newContainer, nil
 }
 
+// Restart restarts a running container for the given domain.
+func (s *Service) Restart(ctx context.Context, domainName string, withAttachments bool) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "Restart",
+		"domain":              domainName,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	s.mu.RLock()
+	container, exists := s.containers[domainName]
+	attachmentIDs := s.attachments[domainName]
+	s.mu.RUnlock()
+
+	if !exists || container == nil {
+		return domain.ErrContainerNotFound
+	}
+
+	// Restart the main container
+	if err := s.runtime.RestartContainer(ctx, container.ID); err != nil {
+		return log.WrapErr(err, "failed to restart container")
+	}
+	log.Info().Str(zerowrap.FieldEntityID, container.ID).Msg("container restarted")
+
+	// Restart attachments if requested
+	if withAttachments && len(attachmentIDs) > 0 {
+		for _, attachID := range attachmentIDs {
+			if err := s.runtime.RestartContainer(ctx, attachID); err != nil {
+				log.Warn().Err(err).Str("attachment_id", attachID).Msg("failed to restart attachment")
+				continue // Don't fail the whole operation for one attachment
+			}
+			log.Info().Str("attachment_id", attachID).Msg("attachment restarted")
+		}
+	}
+
+	return nil
+}
+
 // Stop stops a running container.
 func (s *Service) Stop(ctx context.Context, containerID string) error {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -597,6 +598,52 @@ func TestService_Restart_Success(t *testing.T) {
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
 
 	err := svc.Restart(ctx, "test.example.com", false)
+
+	assert.NoError(t, err)
+}
+
+func TestService_Restart_Error(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{})
+	ctx := testContext()
+
+	svc.containers["test.example.com"] = &domain.Container{
+		ID:     "container-123",
+		Name:   "gordon-test.example.com",
+		Status: "running",
+	}
+
+	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(errors.New("restart failed"))
+
+	err := svc.Restart(ctx, "test.example.com", false)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to restart container")
+}
+
+func TestService_Restart_WithAttachments(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{})
+	ctx := testContext()
+
+	svc.containers["test.example.com"] = &domain.Container{
+		ID:     "container-123",
+		Name:   "gordon-test.example.com",
+		Status: "running",
+	}
+	svc.attachments["test.example.com"] = []string{"container-attach-1", "container-attach-2"}
+
+	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
+	runtime.EXPECT().RestartContainer(mock.Anything, "container-attach-1").Return(nil)
+	runtime.EXPECT().RestartContainer(mock.Anything, "container-attach-2").Return(fmt.Errorf("boom"))
+
+	err := svc.Restart(ctx, "test.example.com", true)
 
 	assert.NoError(t, err)
 }

--- a/internal/usecase/registry/errors.go
+++ b/internal/usecase/registry/errors.go
@@ -1,0 +1,6 @@
+package registry
+
+import "errors"
+
+// ErrRepositoryNotFound indicates a registry repository does not exist.
+var ErrRepositoryNotFound = errors.New("repository not found")


### PR DESCRIPTION
## Summary
- add admin API handlers for restart and tags endpoints used by CLI
- wire container service restart logic and DTOs
- include coverage for restart/tags behavior and validation

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restart containers (optionally restarting attached containers)
  * List repository tags via admin API endpoints

* **Tests**
  * CLI argument and image reference parsing validation tests
  * Comprehensive tests for new admin endpoints covering success and error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->