### PR TITLE
fix(registry): exclude digest references from tag list

### DIFF
--- a/internal/adapters/out/filesystem/manifest.go
+++ b/internal/adapters/out/filesystem/manifest.go
@@ -339,6 +339,15 @@ func (s *ManifestStorage) removeFromTagsList(name, reference string) error {
 		return err
 	}
 
+	// Drop any legacy digest entries before persisting
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if !validation.IsDigest(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+	tags = filtered
+
 	// Remove tag if present
 	var newTags []string
 	for _, tag := range tags {

--- a/internal/adapters/out/filesystem/manifest.go
+++ b/internal/adapters/out/filesystem/manifest.go
@@ -303,6 +303,17 @@ func (s *ManifestStorage) deleteManifestContentType(name, reference string) erro
 
 // Tags management helpers
 
+// filterOutDigests removes digest entries from a tag list.
+func filterOutDigests(tags []string) []string {
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if !validation.IsDigest(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
 func (s *ManifestStorage) updateTagsList(name, reference string) error {
 	if validation.IsDigest(reference) {
 		return nil
@@ -313,14 +324,7 @@ func (s *ManifestStorage) updateTagsList(name, reference string) error {
 		return err
 	}
 
-	// Drop any legacy digest entries before persisting
-	filtered := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		if !validation.IsDigest(tag) {
-			filtered = append(filtered, tag)
-		}
-	}
-	tags = filtered
+	tags = filterOutDigests(tags)
 
 	// Add tag if not already present
 	for _, tag := range tags {
@@ -339,14 +343,7 @@ func (s *ManifestStorage) removeFromTagsList(name, reference string) error {
 		return err
 	}
 
-	// Drop any legacy digest entries before persisting
-	filtered := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		if !validation.IsDigest(tag) {
-			filtered = append(filtered, tag)
-		}
-	}
-	tags = filtered
+	tags = filterOutDigests(tags)
 
 	// Remove tag if present
 	var newTags []string

--- a/internal/adapters/out/filesystem/manifest.go
+++ b/internal/adapters/out/filesystem/manifest.go
@@ -304,6 +304,10 @@ func (s *ManifestStorage) deleteManifestContentType(name, reference string) erro
 // Tags management helpers
 
 func (s *ManifestStorage) updateTagsList(name, reference string) error {
+	if validation.ValidateDigest(reference) == nil {
+		return nil
+	}
+
 	tags, err := s.ListTags(name)
 	if err != nil {
 		return err

--- a/internal/adapters/out/filesystem/manifest.go
+++ b/internal/adapters/out/filesystem/manifest.go
@@ -304,7 +304,7 @@ func (s *ManifestStorage) deleteManifestContentType(name, reference string) erro
 // Tags management helpers
 
 func (s *ManifestStorage) updateTagsList(name, reference string) error {
-	if validation.ValidateDigest(reference) == nil {
+	if validation.IsDigest(reference) {
 		return nil
 	}
 
@@ -312,6 +312,15 @@ func (s *ManifestStorage) updateTagsList(name, reference string) error {
 	if err != nil {
 		return err
 	}
+
+	// Drop any legacy digest entries before persisting
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if !validation.IsDigest(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+	tags = filtered
 
 	// Add tag if not already present
 	for _, tag := range tags {

--- a/internal/adapters/out/filesystem/manifest_test.go
+++ b/internal/adapters/out/filesystem/manifest_test.go
@@ -482,7 +482,8 @@ func TestManifestStorage_UpdateTagsList_CleansLegacyDigestEntries(t *testing.T) 
 	require.NoError(t, err)
 
 	// Verify tags.json contains digest entries
-	tagsBefore, _ := storage.ListTags("myapp")
+	tagsBefore, err := storage.ListTags("myapp")
+	require.NoError(t, err)
 	require.Len(t, tagsBefore, 4, "Should have 4 entries (2 tags + 2 digests)")
 
 	// Add a new tag - this should trigger cleanup of legacy digest entries
@@ -496,6 +497,49 @@ func TestManifestStorage_UpdateTagsList_CleansLegacyDigestEntries(t *testing.T) 
 	assert.Contains(t, tagsAfter, "v1.0")
 	assert.Contains(t, tagsAfter, "v2.0")
 	assert.Contains(t, tagsAfter, "v3.0")
+	assert.NotContains(t, tagsAfter, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	assert.NotContains(t, tagsAfter, "sha256:a6b1c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+}
+
+func TestManifestStorage_RemoveFromTagsList_CleansLegacyDigestEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := testLogger()
+
+	storage, err := NewManifestStorage(tmpDir, log)
+	require.NoError(t, err)
+
+	manifestData := []byte(`{"schemaVersion": 2}`)
+	contentType := "application/vnd.docker.distribution.manifest.v2+json"
+
+	// Create initial tags
+	err = storage.PutManifest("myapp", "v1.0", contentType, manifestData)
+	require.NoError(t, err)
+	err = storage.PutManifest("myapp", "v2.0", contentType, manifestData)
+	require.NoError(t, err)
+	err = storage.PutManifest("myapp", "v3.0", contentType, manifestData)
+	require.NoError(t, err)
+
+	// Manually inject digest entries into tags.json to simulate legacy data
+	tagsPath := filepath.Join(tmpDir, "repositories", "myapp", "tags.json")
+	err = os.WriteFile(tagsPath, []byte(`["v1.0","v2.0","v3.0","sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","sha256:a6b1c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]`), 0600)
+	require.NoError(t, err)
+
+	// Verify tags.json contains digest entries
+	tagsBefore, err := storage.ListTags("myapp")
+	require.NoError(t, err)
+	require.Len(t, tagsBefore, 5, "Should have 5 entries (3 tags + 2 digests)")
+
+	// Delete a tag - this should trigger cleanup of legacy digest entries
+	err = storage.DeleteManifest("myapp", "v2.0")
+	require.NoError(t, err)
+
+	// Verify that digest entries were cleaned up and v2.0 was removed
+	tagsAfter, err := storage.ListTags("myapp")
+	require.NoError(t, err)
+	assert.Len(t, tagsAfter, 2, "Should have 2 entries (only remaining tags, digests removed)")
+	assert.Contains(t, tagsAfter, "v1.0")
+	assert.Contains(t, tagsAfter, "v3.0")
+	assert.NotContains(t, tagsAfter, "v2.0")
 	assert.NotContains(t, tagsAfter, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	assert.NotContains(t, tagsAfter, "sha256:a6b1c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 }

--- a/internal/adapters/out/filesystem/manifest_test.go
+++ b/internal/adapters/out/filesystem/manifest_test.go
@@ -173,6 +173,25 @@ func TestManifestStorage_ListTags_Empty(t *testing.T) {
 	assert.Empty(t, tags)
 }
 
+func TestManifestStorage_ListTags_SkipsDigestReference(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := testLogger()
+
+	storage, err := NewManifestStorage(tmpDir, log)
+	require.NoError(t, err)
+
+	manifestData := []byte(`{"schemaVersion": 2}`)
+	contentType := "application/vnd.docker.distribution.manifest.v2+json"
+
+	err = storage.PutManifest("myapp", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", contentType, manifestData)
+	require.NoError(t, err)
+
+	tags, err := storage.ListTags("myapp")
+	require.NoError(t, err)
+
+	assert.Empty(t, tags)
+}
+
 func TestManifestStorage_ListTags_AfterDelete(t *testing.T) {
 	tmpDir := t.TempDir()
 	log := testLogger()

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -253,7 +253,7 @@ func (s *Service) ListTags(ctx context.Context, name string) ([]string, error) {
 
 	filtered := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		if validation.ValidateDigest(tag) == nil {
+		if validation.IsDigest(tag) {
 			continue
 		}
 		filtered = append(filtered, tag)

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bnema/gordon/internal/boundaries/out"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/pkg/validation"
 )
 
 // Service implements the RegistryService interface.
@@ -250,7 +251,15 @@ func (s *Service) ListTags(ctx context.Context, name string) ([]string, error) {
 		return nil, log.WrapErr(err, "failed to list tags")
 	}
 
-	return tags, nil
+	filtered := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if validation.ValidateDigest(tag) == nil {
+			continue
+		}
+		filtered = append(filtered, tag)
+	}
+
+	return filtered, nil
 }
 
 // ListRepositories returns all repository names.

--- a/internal/usecase/registry/service_test.go
+++ b/internal/usecase/registry/service_test.go
@@ -375,7 +375,12 @@ func TestService_ListTags_Success(t *testing.T) {
 	svc := NewService(blobStorage, manifestStorage, eventBus)
 	ctx := testContext()
 
-	manifestStorage.EXPECT().ListTags("myapp").Return([]string{"latest", "v1.0", "v2.0"}, nil)
+	manifestStorage.EXPECT().ListTags("myapp").Return([]string{
+		"latest",
+		"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		"v1.0",
+		"v2.0",
+	}, nil)
 
 	tags, err := svc.ListTags(ctx, "myapp")
 

--- a/pkg/validation/path.go
+++ b/pkg/validation/path.go
@@ -102,6 +102,12 @@ func ValidateDigest(digest string) error {
 	return nil
 }
 
+// IsDigest checks if a string is a valid Docker content digest.
+// Returns true if the string is a valid digest format.
+func IsDigest(digest string) bool {
+	return ValidateDigest(digest) == nil
+}
+
 // ValidateUUID validates a blob upload UUID.
 // UUIDs are server-generated but still validated for safety.
 func ValidateUUID(uuid string) error {


### PR DESCRIPTION
## Summary
- skip storing digest references in registry tag lists
- filter any legacy digest entries from tag listings
- add coverage for digest-skipping behavior

## Testing
- go test ./internal/adapters/out/filesystem -run TestManifestStorage_ListTags_SkipsDigestReference
- go test ./internal/usecase/registry -run TestService_ListTags_Success
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Digest-style references are now excluded from tag listings and are removed when tags are updated or deleted, ensuring repository tag views show only human-friendly tag names.
  * Tag listing now filters out digest entries at read time to prevent legacy digest artifacts from appearing.

* **Tests**
  * Added tests confirming digest references are skipped and legacy digest entries are cleaned when tags are added or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->