### PR TITLE
Fix review feedback: concurrency, security, startup, and deployment improvements

### DIFF
--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -943,7 +943,7 @@ func (h *Handler) handleContainerLogs(w http.ResponseWriter, r *http.Request, lo
 	logLines, err := h.logSvc.GetContainerLogs(ctx, logDomain, lines)
 	if err != nil {
 		log.Warn().Err(err).Str("domain", logDomain).Msg("failed to get container logs")
-		h.sendError(w, http.StatusInternalServerError, fmt.Sprintf("failed to get logs: %v", err))
+		h.sendError(w, http.StatusInternalServerError, "failed to get container logs")
 		return
 	}
 

--- a/internal/adapters/in/http/auth/handler.go
+++ b/internal/adapters/in/http/auth/handler.go
@@ -2,6 +2,7 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -342,5 +343,7 @@ func (h *Handler) isInternalAuth(username, password string) bool {
 	if h.internalAuth.Username == "" || h.internalAuth.Password == "" {
 		return false
 	}
-	return username == h.internalAuth.Username && password == h.internalAuth.Password
+	usernameMatch := subtle.ConstantTimeCompare([]byte(username), []byte(h.internalAuth.Username)) == 1
+	passwordMatch := subtle.ConstantTimeCompare([]byte(password), []byte(h.internalAuth.Password)) == 1
+	return usernameMatch && passwordMatch
 }

--- a/internal/adapters/in/http/auth/handler_test.go
+++ b/internal/adapters/in/http/auth/handler_test.go
@@ -413,3 +413,76 @@ func TestIsLocalhostRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_isInternalAuth(t *testing.T) {
+	tests := []struct {
+		name         string
+		username     string
+		password     string
+		internalAuth InternalAuth
+		wantResult   bool
+	}{
+		{
+			name:     "correct credentials",
+			username: "gordon-internal",
+			password: "internal-secret",
+			internalAuth: InternalAuth{
+				Username: "gordon-internal",
+				Password: "internal-secret",
+			},
+			wantResult: true,
+		},
+		{
+			name:     "incorrect username",
+			username: "wrong-username",
+			password: "internal-secret",
+			internalAuth: InternalAuth{
+				Username: "gordon-internal",
+				Password: "internal-secret",
+			},
+			wantResult: false,
+		},
+		{
+			name:     "incorrect password",
+			username: "gordon-internal",
+			password: "wrong-password",
+			internalAuth: InternalAuth{
+				Username: "gordon-internal",
+				Password: "internal-secret",
+			},
+			wantResult: false,
+		},
+		{
+			name:     "empty internal auth credentials",
+			username: "gordon-internal",
+			password: "internal-secret",
+			internalAuth: InternalAuth{
+				Username: "",
+				Password: "",
+			},
+			wantResult: false,
+		},
+		{
+			name:     "partially empty internal auth",
+			username: "gordon-internal",
+			password: "internal-secret",
+			internalAuth: InternalAuth{
+				Username: "gordon-internal",
+				Password: "",
+			},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{
+				internalAuth: tt.internalAuth,
+			}
+
+			result := h.isInternalAuth(tt.username, tt.password)
+
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}

--- a/internal/adapters/in/http/auth/handler_test.go
+++ b/internal/adapters/in/http/auth/handler_test.go
@@ -463,12 +463,22 @@ func TestHandler_isInternalAuth(t *testing.T) {
 			wantResult: false,
 		},
 		{
-			name:     "partially empty internal auth",
+			name:     "partially empty internal auth - empty password",
 			username: "gordon-internal",
 			password: "internal-secret",
 			internalAuth: InternalAuth{
 				Username: "gordon-internal",
 				Password: "",
+			},
+			wantResult: false,
+		},
+		{
+			name:     "partially empty internal auth - empty username",
+			username: "gordon-internal",
+			password: "internal-secret",
+			internalAuth: InternalAuth{
+				Username: "",
+				Password: "internal-secret",
 			},
 			wantResult: false,
 		},

--- a/internal/adapters/in/http/middleware/auth.go
+++ b/internal/adapters/in/http/middleware/auth.go
@@ -303,8 +303,7 @@ func isLocalhostRequest(r *http.Request) bool {
 	// RemoteAddr includes port, e.g., "127.0.0.1:12345" or "[::1]:12345"
 	if strings.HasPrefix(host, "127.") ||
 		strings.HasPrefix(host, "[::1]") ||
-		strings.HasPrefix(host, "::1") ||
-		strings.HasPrefix(host, "localhost") {
+		strings.HasPrefix(host, "::1") {
 		return true
 	}
 	return false

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -257,7 +257,7 @@ func TestHandler_StartBlobUpload_Success(t *testing.T) {
 
 	handler := NewHandler(registrySvc, testLogger())
 
-	registrySvc.EXPECT().StartUpload(mock.Anything, "myapp").Return("1234567890-myapp", nil)
+	registrySvc.EXPECT().StartUpload(mock.Anything, "myapp").Return("550e8400-e29b-41d4-a716-446655440000", nil)
 
 	req := httptest.NewRequest("POST", "/v2/myapp/blobs/uploads/", nil)
 	rec := httptest.NewRecorder()
@@ -265,7 +265,7 @@ func TestHandler_StartBlobUpload_Success(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusAccepted, rec.Code)
-	assert.Contains(t, rec.Header().Get("Location"), "/v2/myapp/blobs/uploads/1234567890-myapp")
+	assert.Contains(t, rec.Header().Get("Location"), "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000")
 	assert.Equal(t, "0-0", rec.Header().Get("Range"))
 }
 
@@ -291,15 +291,15 @@ func TestHandler_BlobUpload_PATCH(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger())
 
 	chunkData := []byte("chunk content")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "1234567890-myapp", chunkData).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", chunkData).Return(int64(len(chunkData)), nil)
 
-	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/1234567890-myapp", bytes.NewReader(chunkData))
+	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusAccepted, rec.Code)
-	assert.Contains(t, rec.Header().Get("Location"), "/v2/myapp/blobs/uploads/1234567890-myapp")
+	assert.Contains(t, rec.Header().Get("Location"), "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000")
 }
 
 func TestHandler_BlobUpload_PUT_Finalize(t *testing.T) {
@@ -308,10 +308,10 @@ func TestHandler_BlobUpload_PUT_Finalize(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger())
 
 	chunkData := []byte("final chunk")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "1234567890-myapp", chunkData).Return(int64(len(chunkData)), nil)
-	registrySvc.EXPECT().FinishUpload(mock.Anything, "1234567890-myapp", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", chunkData).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().FinishUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(nil)
 
-	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/1234567890-myapp?digest=sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", bytes.NewReader(chunkData))
+	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000?digest=sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -330,7 +330,7 @@ func TestHandler_BlobUpload_PUT_DigestMismatch(t *testing.T) {
 	// Note: Invalid digest format is rejected by validation before reaching storage layer
 	// This test verifies that invalid digests are properly rejected
 
-	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/1234567890-myapp?digest=sha256:wrong", bytes.NewReader(chunkData))
+	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000?digest=sha256:wrong", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/internal/adapters/out/filesystem/blob.go
+++ b/internal/adapters/out/filesystem/blob.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/bnema/zerowrap"
+	"github.com/google/uuid"
 
 	"github.com/bnema/gordon/pkg/validation"
 )
@@ -167,10 +167,9 @@ func (s *BlobStorage) BlobExists(digest string) bool {
 
 // StartBlobUpload starts a new blob upload and returns the upload UUID.
 func (s *BlobStorage) StartBlobUpload(name string) (string, error) {
-	// Generate UUID-like upload ID using timestamp
-	uuid := fmt.Sprintf("%d-%s", time.Now().UnixNano(), strings.ReplaceAll(name, "/", "_"))
+	uploadID := uuid.New().String()
 
-	uploadPath, err := s.getUploadPath(uuid)
+	uploadPath, err := s.getUploadPath(uploadID)
 	if err != nil {
 		return "", fmt.Errorf("invalid upload path: %w", err)
 	}
@@ -190,11 +189,11 @@ func (s *BlobStorage) StartBlobUpload(name string) (string, error) {
 	s.log.Info().
 		Str(zerowrap.FieldLayer, "adapter").
 		Str(zerowrap.FieldAdapter, "filesystem").
-		Str("uuid", uuid).
+		Str("uuid", uploadID).
 		Str("name", name).
 		Msg("blob upload started")
 
-	return uuid, nil
+	return uploadID, nil
 }
 
 // AppendBlobChunk appends data to an in-progress upload.

--- a/internal/adapters/out/filesystem/blob_test.go
+++ b/internal/adapters/out/filesystem/blob_test.go
@@ -222,7 +222,7 @@ func TestBlobStorage_StartBlobUpload(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, uuid)
-	assert.Contains(t, uuid, "myapp")
+	assert.Len(t, uuid, 36) // standard UUID format
 
 	// Verify upload file was created
 	uploadPath := filepath.Join(tmpDir, "uploads", uuid)
@@ -260,7 +260,7 @@ func TestBlobStorage_AppendBlobChunk_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	_, err = storage.AppendBlobChunk("myapp", "1234567890-invalid", []byte("data"))
+	_, err = storage.AppendBlobChunk("myapp", "00000000-0000-0000-0000-000000000000", []byte("data"))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")
@@ -292,7 +292,7 @@ func TestBlobStorage_GetBlobUpload_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	writer, err := storage.GetBlobUpload("1234567890-invalid")
+	writer, err := storage.GetBlobUpload("00000000-0000-0000-0000-000000000000")
 
 	assert.Error(t, err)
 	assert.Nil(t, writer)
@@ -355,7 +355,7 @@ func TestBlobStorage_CancelBlobUpload_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	err = storage.CancelBlobUpload("1234567890-invalid")
+	err = storage.CancelBlobUpload("00000000-0000-0000-0000-000000000000")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")

--- a/internal/adapters/out/filesystem/blob_test.go
+++ b/internal/adapters/out/filesystem/blob_test.go
@@ -260,7 +260,7 @@ func TestBlobStorage_AppendBlobChunk_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	_, err = storage.AppendBlobChunk("myapp", "00000000-0000-0000-0000-000000000000", []byte("data"))
+	_, err = storage.AppendBlobChunk("myapp", "00000000-0000-4000-a000-000000000000", []byte("data"))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")
@@ -292,7 +292,7 @@ func TestBlobStorage_GetBlobUpload_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	writer, err := storage.GetBlobUpload("00000000-0000-0000-0000-000000000000")
+	writer, err := storage.GetBlobUpload("00000000-0000-4000-a000-000000000000")
 
 	assert.Error(t, err)
 	assert.Nil(t, writer)
@@ -355,7 +355,7 @@ func TestBlobStorage_CancelBlobUpload_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	err = storage.CancelBlobUpload("00000000-0000-0000-0000-000000000000")
+	err = storage.CancelBlobUpload("00000000-0000-4000-a000-000000000000")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -912,6 +912,12 @@ func registerEventHandlers(ctx context.Context, svc *services, cfg Config) error
 		return fmt.Errorf("failed to subscribe container deployed handler: %w", err)
 	}
 
+	// Proxy cache invalidation on config reload (clears stale targets for removed routes)
+	configReloadProxyHandler := proxy.NewConfigReloadProxyHandler(ctx, svc.proxySvc)
+	if err := svc.eventBus.Subscribe(configReloadProxyHandler); err != nil {
+		return fmt.Errorf("failed to subscribe config reload proxy handler: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -955,7 +955,7 @@ func syncAndAutoStart(ctx context.Context, svc *services, log zerowrap.Logger) {
 
 	if svc.configSvc.IsAutoRouteEnabled() {
 		routes := svc.configSvc.GetRoutes(ctx)
-		if err := svc.containerSvc.AutoStart(ctx, routes); err != nil {
+		if err := svc.containerSvc.AutoStart(domain.WithInternalDeploy(ctx), routes); err != nil {
 			log.Warn().Err(err).Msg("failed to auto-start containers")
 		}
 	}

--- a/internal/boundaries/out/eventbus.go
+++ b/internal/boundaries/out/eventbus.go
@@ -1,12 +1,14 @@
 package out
 
 import (
+	"context"
+
 	"github.com/bnema/gordon/internal/domain"
 )
 
 // EventHandler defines the contract for handling events.
 type EventHandler interface {
-	Handle(event domain.Event) error
+	Handle(ctx context.Context, event domain.Event) error
 	CanHandle(eventType domain.EventType) bool
 }
 

--- a/internal/boundaries/out/mocks/mock_event_handler.go
+++ b/internal/boundaries/out/mocks/mock_event_handler.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/bnema/gordon/internal/domain"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -88,16 +90,16 @@ func (_c *MockEventHandler_CanHandle_Call) RunAndReturn(run func(eventType domai
 }
 
 // Handle provides a mock function for the type MockEventHandler
-func (_mock *MockEventHandler) Handle(event domain.Event) error {
-	ret := _mock.Called(event)
+func (_mock *MockEventHandler) Handle(ctx context.Context, event domain.Event) error {
+	ret := _mock.Called(ctx, event)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Handle")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(domain.Event) error); ok {
-		r0 = returnFunc(event)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, domain.Event) error); ok {
+		r0 = returnFunc(ctx, event)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -110,19 +112,25 @@ type MockEventHandler_Handle_Call struct {
 }
 
 // Handle is a helper method to define mock.On call
+//   - ctx context.Context
 //   - event domain.Event
-func (_e *MockEventHandler_Expecter) Handle(event interface{}) *MockEventHandler_Handle_Call {
-	return &MockEventHandler_Handle_Call{Call: _e.mock.On("Handle", event)}
+func (_e *MockEventHandler_Expecter) Handle(ctx interface{}, event interface{}) *MockEventHandler_Handle_Call {
+	return &MockEventHandler_Handle_Call{Call: _e.mock.On("Handle", ctx, event)}
 }
 
-func (_c *MockEventHandler_Handle_Call) Run(run func(event domain.Event)) *MockEventHandler_Handle_Call {
+func (_c *MockEventHandler_Handle_Call) Run(run func(ctx context.Context, event domain.Event)) *MockEventHandler_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 domain.Event
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(domain.Event)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 domain.Event
+		if args[1] != nil {
+			arg1 = args[1].(domain.Event)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -133,7 +141,7 @@ func (_c *MockEventHandler_Handle_Call) Return(err error) *MockEventHandler_Hand
 	return _c
 }
 
-func (_c *MockEventHandler_Handle_Call) RunAndReturn(run func(event domain.Event) error) *MockEventHandler_Handle_Call {
+func (_c *MockEventHandler_Handle_Call) RunAndReturn(run func(ctx context.Context, event domain.Event) error) *MockEventHandler_Handle_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/usecase/container/autoroute.go
+++ b/internal/usecase/container/autoroute.go
@@ -60,8 +60,8 @@ func (h *AutoRouteHandler) WithEnvExtractor(extractor EnvFileExtractor, envDir s
 }
 
 // Handle handles an image.pushed event and creates routes from labels.
-func (h *AutoRouteHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *AutoRouteHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "AutoRouteHandler",
 		zerowrap.FieldEvent:   string(event.Type),

--- a/internal/usecase/container/autoroute_test.go
+++ b/internal/usecase/container/autoroute_test.go
@@ -368,7 +368,7 @@ func TestAutoRouteHandler_Handle_DisabledAutoRoute(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -389,7 +389,7 @@ func TestAutoRouteHandler_Handle_InvalidPayload(t *testing.T) {
 		Data: "invalid payload type",
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	// Handler skips invalid payload, doesn't error
 	assert.NoError(t, err)
@@ -415,7 +415,7 @@ func TestAutoRouteHandler_Handle_EmptyManifest(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -475,7 +475,7 @@ func TestAutoRouteHandler_Handle_CreatesNewRoute(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -537,7 +537,7 @@ func TestAutoRouteHandler_Handle_UpdatesExistingRoute(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -589,7 +589,7 @@ func TestAutoRouteHandler_Handle_NoUpdateIfSameImage(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -636,7 +636,7 @@ func TestAutoRouteHandler_Handle_NoDomainLabel(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -702,7 +702,7 @@ func TestAutoRouteHandler_Handle_MultipleDomains(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }

--- a/internal/usecase/container/events.go
+++ b/internal/usecase/container/events.go
@@ -28,8 +28,8 @@ func NewImagePushedHandler(ctx context.Context, containerSvc in.ContainerService
 }
 
 // Handle handles an event.
-func (h *ImagePushedHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ImagePushedHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ImagePushedHandler",
 		zerowrap.FieldEvent:   string(event.Type),
@@ -122,8 +122,8 @@ func NewConfigReloadHandler(ctx context.Context, containerSvc in.ContainerServic
 }
 
 // Handle handles an event.
-func (h *ConfigReloadHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ConfigReloadHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ConfigReloadHandler",
 		zerowrap.FieldEvent:   string(event.Type),
@@ -219,8 +219,8 @@ func NewManualReloadHandler(ctx context.Context, containerSvc in.ContainerServic
 // Handle handles an event.
 // It starts containers for configured routes that don't have a running container.
 // Running containers are NEVER restarted to ensure 100% uptime.
-func (h *ManualReloadHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ManualReloadHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ManualReloadHandler",
 		zerowrap.FieldEvent:   string(event.Type),
@@ -302,8 +302,8 @@ func NewManualDeployHandler(ctx context.Context, containerSvc in.ContainerServic
 }
 
 // Handle handles a manual deploy event for a specific route.
-func (h *ManualDeployHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ManualDeployHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ManualDeployHandler",
 		zerowrap.FieldEvent:   string(event.Type),

--- a/internal/usecase/container/events.go
+++ b/internal/usecase/container/events.go
@@ -159,7 +159,7 @@ func (h *ConfigReloadHandler) Handle(event domain.Event) error {
 					Str("new_image", route.Image).
 					Msg("image changed for route, redeploying")
 
-				if _, err := h.containerSvc.Deploy(ctx, route); err != nil {
+				if _, err := h.containerSvc.Deploy(domain.WithInternalDeploy(ctx), route); err != nil {
 					log.WrapErrWithFields(err, "failed to redeploy container", map[string]any{"domain": route.Domain})
 				}
 			}
@@ -171,7 +171,7 @@ func (h *ConfigReloadHandler) Handle(event domain.Event) error {
 				Str("image", route.Image).
 				Msg("route missing container, deploying")
 
-			if _, err := h.containerSvc.Deploy(ctx, route); err != nil {
+			if _, err := h.containerSvc.Deploy(domain.WithInternalDeploy(ctx), route); err != nil {
 				log.WrapErrWithFields(err, "failed to deploy container for route", map[string]any{"domain": route.Domain})
 			}
 		}
@@ -253,7 +253,7 @@ func (h *ManualReloadHandler) Handle(event domain.Event) error {
 			Str("image", route.Image).
 			Msg("starting container for route")
 
-		if _, err := h.containerSvc.Deploy(ctx, route); err != nil {
+		if _, err := h.containerSvc.Deploy(domain.WithInternalDeploy(ctx), route); err != nil {
 			log.WrapErrWithFields(err, "failed to start container", map[string]any{"domain": route.Domain})
 			errorCount++
 			continue

--- a/internal/usecase/container/events_test.go
+++ b/internal/usecase/container/events_test.go
@@ -63,7 +63,7 @@ func TestImagePushedHandler_Handle_DeploysMatchingRoutes(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -89,7 +89,7 @@ func TestImagePushedHandler_Handle_NoMatchingRoutes(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -107,7 +107,7 @@ func TestImagePushedHandler_Handle_EmptyImageName(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.ErrorIs(t, err, domain.ErrInvalidImageFormat)
 }
@@ -137,7 +137,7 @@ func TestImagePushedHandler_Handle_DefaultTag(t *testing.T) {
 		Tag:       "", // Empty tag should default to "latest"
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -164,7 +164,7 @@ func TestImagePushedHandler_Handle_DeployError(t *testing.T) {
 	}
 
 	// Handler logs error but doesn't fail
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -192,7 +192,7 @@ func TestImagePushedHandler_Handle_StripsRegistryDomain(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -237,7 +237,7 @@ func TestConfigReloadHandler_Handle_DeploysNewRoutes(t *testing.T) {
 		Type: domain.EventConfigReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -273,7 +273,7 @@ func TestConfigReloadHandler_Handle_StopsRemovedRoutes(t *testing.T) {
 		Type: domain.EventConfigReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -313,7 +313,7 @@ func TestConfigReloadHandler_Handle_RedeploysChangedImage(t *testing.T) {
 		Type: domain.EventConfigReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -349,7 +349,7 @@ func TestConfigReloadHandler_Handle_NoChanges(t *testing.T) {
 		Type: domain.EventConfigReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -397,7 +397,7 @@ func TestManualReloadHandler_Handle_StartsOnlyMissingContainers(t *testing.T) {
 		Type: domain.EventManualReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -428,7 +428,7 @@ func TestManualReloadHandler_Handle_StartsMissingContainer(t *testing.T) {
 		Type: domain.EventManualReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -467,7 +467,7 @@ func TestManualReloadHandler_Handle_DeployErrors(t *testing.T) {
 		Type: domain.EventManualReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	// Should return error indicating some failures
 	assert.Error(t, err)
@@ -497,7 +497,7 @@ func TestManualReloadHandler_Handle_DoesNotRestartRunningContainers(t *testing.T
 		Type: domain.EventManualReload,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -539,7 +539,7 @@ func TestManualDeployHandler_Handle_DeploysSpecificRoute(t *testing.T) {
 		Data: &domain.ManualDeployPayload{Domain: "app1.example.com"},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 }
@@ -561,7 +561,7 @@ func TestManualDeployHandler_Handle_RouteNotFound(t *testing.T) {
 		Data: &domain.ManualDeployPayload{Domain: "unknown.example.com"},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "route not found")
@@ -580,7 +580,7 @@ func TestManualDeployHandler_Handle_InvalidPayload(t *testing.T) {
 		Data: nil,
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid manual deploy payload")
@@ -599,7 +599,7 @@ func TestManualDeployHandler_Handle_EmptyDomain(t *testing.T) {
 		Data: &domain.ManualDeployPayload{Domain: ""},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid manual deploy payload")
@@ -623,7 +623,7 @@ func TestManualDeployHandler_Handle_DeployError(t *testing.T) {
 		Data: &domain.ManualDeployPayload{Domain: "app.example.com"},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to deploy")

--- a/internal/usecase/proxy/events.go
+++ b/internal/usecase/proxy/events.go
@@ -28,8 +28,8 @@ func NewContainerDeployedHandler(ctx context.Context, invalidator TargetInvalida
 }
 
 // Handle handles a container.deployed event by invalidating the proxy cache.
-func (h *ContainerDeployedHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ContainerDeployedHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ContainerDeployedHandler",
 		zerowrap.FieldEvent:   string(event.Type),
@@ -84,8 +84,8 @@ func NewConfigReloadProxyHandler(ctx context.Context, refresher TargetRefresher)
 }
 
 // Handle clears all cached proxy targets so they are re-resolved from current state.
-func (h *ConfigReloadProxyHandler) Handle(event domain.Event) error {
-	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+func (h *ConfigReloadProxyHandler) Handle(ctx context.Context, event domain.Event) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldHandler: "ConfigReloadProxyHandler",
 		zerowrap.FieldEvent:   string(event.Type),

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -281,7 +281,9 @@ func (s *Service) RefreshTargets(ctx context.Context) error {
 
 // UpdateConfig updates the service configuration.
 func (s *Service) UpdateConfig(config Config) {
+	s.mu.Lock()
 	s.config = config
+	s.mu.Unlock()
 }
 
 // Helper methods

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -70,9 +70,14 @@ func NewService(
 
 // ServeHTTP handles incoming HTTP requests and proxies them to the appropriate backend.
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Copy config under RLock to avoid data race with UpdateConfig
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+
 	// SECURITY: Limit request body size to prevent resource exhaustion.
-	if s.config.MaxBodySize > 0 {
-		r.Body = http.MaxBytesReader(w, r.Body, s.config.MaxBodySize)
+	if cfg.MaxBodySize > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, cfg.MaxBodySize)
 	}
 
 	// Enrich request context with fields for downstream logging
@@ -88,7 +93,7 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log := zerowrap.FromCtx(ctx)
 
 	// Check if this is the registry domain
-	if s.config.RegistryDomain != "" && r.Host == s.config.RegistryDomain {
+	if cfg.RegistryDomain != "" && r.Host == cfg.RegistryDomain {
 		log.Info().Msg("routing request to registry")
 		s.proxyToRegistry(w, r)
 		return
@@ -348,9 +353,14 @@ func (s *Service) proxyToTarget(w http.ResponseWriter, r *http.Request, target *
 }
 
 func (s *Service) proxyToRegistry(w http.ResponseWriter, r *http.Request) {
+	// Copy config under RLock to avoid data race with UpdateConfig
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+
 	log := zerowrap.FromCtx(r.Context())
 
-	targetURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", s.config.RegistryPort))
+	targetURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", cfg.RegistryPort))
 	if err != nil {
 		log.WrapErr(err, "failed to parse registry target URL")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -361,11 +371,11 @@ func (s *Service) proxyToRegistry(w http.ResponseWriter, r *http.Request) {
 		func(w http.ResponseWriter, _ *http.Request, err error) {
 			// Check if this is a MaxBytesError (request body too large)
 			if err.Error() == "http: request body too large" {
-				log.Warn().Err(err).Int("registry_port", s.config.RegistryPort).Msg("registry proxy error: request body too large")
+				log.Warn().Err(err).Int("registry_port", cfg.RegistryPort).Msg("registry proxy error: request body too large")
 				http.Error(w, "Request Entity Too Large", http.StatusRequestEntityTooLarge)
 				return
 			}
-			log.Error().Err(err).Int("registry_port", s.config.RegistryPort).Msg("registry proxy error")
+			log.Error().Err(err).Int("registry_port", cfg.RegistryPort).Msg("registry proxy error")
 			http.Error(w, "Registry Unavailable", http.StatusServiceUnavailable)
 		},
 		func(resp *http.Response) error {

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -361,7 +361,7 @@ func TestContainerDeployedHandler_Handle_InvalidatesCache(t *testing.T) {
 		},
 	}
 
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 
 	assert.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestContainerDeployedHandler_Handle_NoDomain(t *testing.T) {
 	}
 
 	// Should not error, just skip
-	err := handler.Handle(event)
+	err := handler.Handle(context.Background(), event)
 	assert.NoError(t, err)
 }
 

--- a/pkg/validation/path.go
+++ b/pkg/validation/path.go
@@ -28,8 +28,8 @@ var referenceRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$`)
 var digestRegex = regexp.MustCompile(`^(sha256:[a-f0-9]{64}|sha512:[a-f0-9]{128})$`)
 
 // UUID validation for blob uploads:
-// - Format: timestamp-name (where name has / replaced with _)
-var uuidRegex = regexp.MustCompile(`^[0-9]+-[a-zA-Z0-9_-]+$`)
+// - Format: standard UUID v4 (e.g., 550e8400-e29b-41d4-a716-446655440000)
+var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // MaxRepositoryNameLength is the maximum allowed length for repository names.
 const MaxRepositoryNameLength = 256

--- a/pkg/validation/path.go
+++ b/pkg/validation/path.go
@@ -29,7 +29,7 @@ var digestRegex = regexp.MustCompile(`^(sha256:[a-f0-9]{64}|sha512:[a-f0-9]{128}
 
 // UUID validation for blob uploads:
 // - Format: standard UUID v4 (e.g., 550e8400-e29b-41d4-a716-446655440000)
-var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+var uuidRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
 // MaxRepositoryNameLength is the maximum allowed length for repository names.
 const MaxRepositoryNameLength = 256

--- a/pkg/validation/path_test.go
+++ b/pkg/validation/path_test.go
@@ -164,9 +164,13 @@ func TestValidateUUID(t *testing.T) {
 		errMsg  string
 	}{
 		// Valid cases - standard UUID v4
-		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", false, ""},
-		{"another valid uuid", "6ba7b810-9dad-11d1-80b4-00c04fd430c8", false, ""},
-		{"all zeros", "00000000-0000-0000-0000-000000000000", false, ""},
+		{"valid uuid v4", "550e8400-e29b-41d4-a716-446655440000", false, ""},
+		{"another valid uuid v4", "f47ac10b-58cc-4372-a567-0e02b2c3d479", false, ""},
+
+		// Invalid cases - not UUID v4
+		{"uuid v1 wrong version", "6ba7b810-9dad-11d1-80b4-00c04fd430c8", true, "invalid UUID format"},
+		{"all zeros not v4", "00000000-0000-0000-0000-000000000000", true, "invalid UUID format"},
+		{"wrong variant nibble", "550e8400-e29b-41d4-7716-446655440000", true, "invalid UUID format"},
 
 		// Invalid cases - path traversal
 		{"path traversal", "../etc/passwd", true, "path traversal"},

--- a/pkg/validation/path_test.go
+++ b/pkg/validation/path_test.go
@@ -163,23 +163,22 @@ func TestValidateUUID(t *testing.T) {
 		wantErr bool
 		errMsg  string
 	}{
-		// Valid cases
-		{"valid uuid", "1234567890-myapp", false, ""},
-		{"with underscore", "1234567890-my_app", false, ""},
-		{"with hyphen in name", "1234567890-my-app", false, ""},
-		{"nested repo uuid", "1234567890-myorg_myapp", false, ""},
+		// Valid cases - standard UUID v4
+		{"valid uuid", "550e8400-e29b-41d4-a716-446655440000", false, ""},
+		{"another valid uuid", "6ba7b810-9dad-11d1-80b4-00c04fd430c8", false, ""},
+		{"all zeros", "00000000-0000-0000-0000-000000000000", false, ""},
 
 		// Invalid cases - path traversal
-		{"path traversal", "1234567890-../etc/passwd", true, "path traversal"},
-		{"traversal in middle", "1234567890-app/../etc", true, "path traversal"},
+		{"path traversal", "../etc/passwd", true, "path traversal"},
+		{"traversal in middle", "app/../etc", true, "path traversal"},
 
 		// Invalid cases - format
 		{"empty", "", true, "cannot be empty"},
-		{"no timestamp", "myapp", true, "invalid UUID format"},
-		{"no hyphen", "1234567890myapp", true, "invalid UUID format"},
-		{"special chars", "1234567890-my@app", true, "invalid UUID format"},
-		{"spaces", "1234567890-my app", true, "invalid UUID format"},
-		{"slash not replaced", "1234567890-myorg/myapp", true, "invalid UUID format"},
+		{"random string", "myapp", true, "invalid UUID format"},
+		{"old timestamp format", "1234567890-myapp", true, "invalid UUID format"},
+		{"uppercase hex", "550E8400-E29B-41D4-A716-446655440000", true, "invalid UUID format"},
+		{"spaces", "550e8400 e29b 41d4 a716 446655440000", true, "invalid UUID format"},
+		{"missing section", "550e8400-e29b-41d4-a716", true, "invalid UUID format"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
This PR addresses review feedback across multiple areas:

- **Concurrency fixes**: Protect config reads with RLock, fix lock scoping in container service and event bus
- **Security improvements**: Use crypto-random UUIDs for blob uploads, harden auth validation, token store validation, and remove sensitive error messages
- **Startup reliability**: Start registry listener before auto-start to prevent race conditions
- **Deployment fixes**: Mark auto-start, reload, and config-reload operations as internal deploy to use local registry

## Changes
- Fix data races in proxy and container services by properly protecting config reads with RLock
- Add timeouts to event handlers to prevent hanging handlers
- Use `crypto/rand` instead of timestamp-based UUIDs for blob uploads
- Add constant-time comparison for internal auth credentials
- Add input validation to token store to prevent path injection
- Remove sensitive error messages that could leak information
- Fix proxy cache invalidation on config reload
- Fix startup race condition where containers try to pull from registry before it's listening
- Mark internal deploy contexts for auto-start, reload, and config-reload operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Constant-time credential checks to reduce timing-attack risk
  * Token subject validation to block unsafe characters and traversal

* **Bug Fixes**
  * Fixed config data races and improved event bus timeouts/error handling
  * Stopped treating "localhost" as loopback for request checks
  * Simplified container log error messages returned to clients

* **Improvements**
  * Upload identifiers now use standard UUIDs
  * Servers wait for readiness before auto-starting containers
  * Proxy now refreshes targets on config reloads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->