### PR TITLE
feat(secrets): add attachment secrets CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 gordon
 .env
 dist/
+docs/plans/

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -212,7 +212,7 @@ gordon secrets set app.mydomain.com -a redis REDIS_PASSWORD=cache-secret
 gordon secrets list app.mydomain.com
 
 # Redeploy to pick up new secrets
-gordon push app.mydomain.com
+gordon deploy app.mydomain.com
 ```
 
 ## Related

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -23,7 +23,7 @@ Storage depends on the secrets backend:
 
 ## gordon secrets list
 
-List all secrets for a specific domain.
+List all secrets for a specific domain. When attachment secrets are present, they are displayed in a tree view below the domain secrets.
 
 ```bash
 gordon secrets list <domain>
@@ -55,11 +55,16 @@ gordon secrets list myapp.local --remote https://gordon.mydomain.com --token $TO
 ### Output
 
 ```
-Secret                    Value (masked)
---------------------------------------------------------------------------------
-DATABASE_URL              postgres://...
+Secrets for app.mydomain.com
+
+Key                       Value
+DATABASE_URL              ****
 API_KEY                   ****
-JWT_SECRET                ****
+├─ [postgres]
+│  ├─ POSTGRES_USER       ****
+│  └─ POSTGRES_PASSWORD   ****
+└─ [redis]
+   └─ REDIS_PASSWORD      ****
 ```
 
 ---
@@ -69,7 +74,7 @@ JWT_SECRET                ****
 Set a secret value for a domain.
 
 ```bash
-gordon secrets set <domain> <key> <value>
+gordon secrets set <domain> <KEY=value>...
 gordon secrets set myapp.local DATABASE_URL "postgres://..."
 ```
 
@@ -85,6 +90,7 @@ gordon secrets set myapp.local DATABASE_URL "postgres://..."
 
 | Option | Description |
 |--------|-------------|
+| `--attachment` / `-a` | Target an attachment service (e.g., postgres, redis) |
 | `--remote` | Remote Gordon URL |
 | `--token` | Authentication token for remote |
 
@@ -97,6 +103,13 @@ gordon secrets set myapp.local API_KEY "your-api-key"
 
 # Remote (override)
 gordon secrets set myapp.local DATABASE_URL "postgres://..." --remote https://gordon.mydomain.com --token $TOKEN
+
+# Set attachment secrets
+gordon secrets set app.mydomain.com --attachment postgres POSTGRES_PASSWORD=secret
+gordon secrets set app.mydomain.com -a redis REDIS_PASSWORD=mysecret
+
+# Multiple secrets at once
+gordon secrets set app.mydomain.com -a postgres POSTGRES_USER=admin POSTGRES_PASSWORD=secret
 ```
 
 ---
@@ -120,6 +133,7 @@ gordon secrets remove <domain> <key>
 
 | Option | Description |
 |--------|-------------|
+| `--attachment` / `-a` | Target an attachment service (e.g., postgres, redis) |
 | `--remote` | Remote Gordon URL |
 | `--token` | Authentication token for remote |
 
@@ -131,6 +145,9 @@ gordon secrets remove myapp.local DATABASE_URL
 
 # Remote (override)
 gordon secrets remove myapp.local DATABASE_URL --remote https://gordon.mydomain.com --token $TOKEN
+
+# Remove attachment secret
+gordon secrets remove app.mydomain.com --attachment postgres POSTGRES_PASSWORD
 ```
 
 ---
@@ -180,6 +197,22 @@ gordon secrets set myapp.local JWT_SECRET "$NEW_JWT_SECRET"
 
 # Redeploy to pick up new secret
 gordon routes deploy myapp.local
+```
+
+### Attachment Secrets
+
+```bash
+# Configure database credentials
+gordon secrets set app.mydomain.com -a postgres POSTGRES_USER=admin POSTGRES_PASSWORD=secret
+
+# Configure cache credentials
+gordon secrets set app.mydomain.com -a redis REDIS_PASSWORD=cache-secret
+
+# Verify
+gordon secrets list app.mydomain.com
+
+# Redeploy to pick up new secrets
+gordon push app.mydomain.com
 ```
 
 ## Related

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -183,7 +183,7 @@ gordon secrets set myapp.example.com DATABASE_URL "$DATABASE_URL"
 gordon secrets set myapp.example.com API_KEY "$API_KEY"
 
 # Deploy
-gordon routes deploy myapp.example.com
+gordon deploy myapp.example.com
 ```
 
 ### Rotating Secrets
@@ -196,7 +196,7 @@ NEW_JWT_SECRET=$(openssl rand -base64 32)
 gordon secrets set myapp.local JWT_SECRET "$NEW_JWT_SECRET"
 
 # Redeploy to pick up new secret
-gordon routes deploy myapp.local
+gordon deploy myapp.local
 ```
 
 ### Attachment Secrets

--- a/docs/config/secrets.md
+++ b/docs/config/secrets.md
@@ -57,6 +57,8 @@ token_secret = "gordon/auth/token_secret"
 **Route secrets storage:**
 - `gordon secrets set` stores per-domain secrets in pass under `gordon/env/<sanitized-domain>/<KEY>` (dots/colons/slashes → underscores)
 - Existing `.env` files are auto-migrated on startup and renamed to `.env.migrated`
+- Attachment secrets are stored under `gordon/env/attachments/<container-name>/<KEY>` with a `.keys` manifest
+- Use `gordon secrets set <domain> --attachment <service> KEY=value` to manage them
 
 ### SOPS
 
@@ -98,6 +100,11 @@ DB_PASSWORD=${sops:secrets.yaml:database.password}
 - Domain secrets stay in `.env` files
 - Use `${sops:...}` syntax to resolve encrypted values
 
+**Attachment secrets storage:**
+- Attachment secrets are stored in `gordon-<container-name>.env` files alongside domain env files
+- Use `${sops:...}` syntax inside attachment env files to resolve encrypted values
+- Use `gordon secrets set <domain> --attachment <service> KEY=value` to manage them
+
 ### Unsafe (Development Only)
 
 Stores secrets as plain text files:
@@ -115,6 +122,11 @@ secrets_backend = "unsafe"
 │       ├── password_hash
 │       └── token_secret
 ```
+
+**Attachment secrets:**
+- Stored as `gordon-<container-name>.env` files in the env directory
+- Example: `gordon-app__mydomain__com-postgres.env`
+- Use `gordon secrets set <domain> --attachment <service> KEY=value` to manage them
 
 **Usage:**
 ```bash

--- a/docs/plans/2026-02-06-attachment-secrets.md
+++ b/docs/plans/2026-02-06-attachment-secrets.md
@@ -1,0 +1,893 @@
+# Attachment Secrets CLI Support — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow `gordon secrets set` and `gordon secrets remove` to target attachment containers via an `--attachment` flag, closing issue #56.
+
+**Architecture:** The storage layer (`DomainSecretStore.SetAttachment`) and file format (`gordon-{container}.env`) already exist. The gap is a missing `DeleteAttachment` in the store, missing attachment methods on the `SecretService` use case, a missing admin API endpoint for attachment secrets, and missing `--attachment` flag on CLI commands. We thread through all layers: storage → use case → admin API → remote client → CLI.
+
+**Tech Stack:** Go, cobra (CLI), mockery (mock generation), httptest
+
+---
+
+### Task 1: Add `DeleteAttachment` to storage interface and implementation
+
+The `DomainSecretStore` has `SetAttachment` but no `DeleteAttachment`. We need it to remove individual keys from attachment env files.
+
+**Files:**
+- Modify: `internal/boundaries/out/domain_secrets.go:13-36`
+- Modify: `internal/adapters/out/domainsecrets/store.go` (add method after `SetAttachment`)
+- Test: `internal/adapters/out/domainsecrets/store_test.go`
+
+**Step 1: Write the failing test**
+
+Add to `store_test.go`, near the existing `SetAttachment` tests (~line 229):
+
+```go
+func TestFileStore_DeleteAttachment(t *testing.T) {
+	dir := t.TempDir()
+	store := NewFileStore(dir, testLogger())
+	containerName := "app__example__com-postgres"
+
+	// Seed with two secrets
+	err := store.SetAttachment(containerName, map[string]string{
+		"POSTGRES_USER":     "admin",
+		"POSTGRES_PASSWORD": "secret",
+	})
+	require.NoError(t, err)
+
+	t.Run("deletes single key", func(t *testing.T) {
+		err := store.DeleteAttachment(containerName, "POSTGRES_PASSWORD")
+		require.NoError(t, err)
+
+		secrets, err := store.GetAllAttachment(containerName)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"POSTGRES_USER": "admin"}, secrets)
+	})
+
+	t.Run("deleting nonexistent key is no-op", func(t *testing.T) {
+		err := store.DeleteAttachment(containerName, "NONEXISTENT")
+		require.NoError(t, err)
+	})
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/adapters/out/domainsecrets/... -count=1 -run TestFileStore_DeleteAttachment -v`
+Expected: FAIL — `store.DeleteAttachment` undefined
+
+**Step 3: Add to interface and implement**
+
+In `internal/boundaries/out/domain_secrets.go`, add to the `DomainSecretStore` interface:
+
+```go
+	// DeleteAttachment removes a specific secret key from an attachment container.
+	DeleteAttachment(containerName, key string) error
+```
+
+In `internal/adapters/out/domainsecrets/store.go`, add after the `SetAttachment` method (~line 177):
+
+```go
+// DeleteAttachment removes a specific secret key from an attachment container.
+func (s *FileStore) DeleteAttachment(containerName, key string) error {
+	// Validate container name first
+	if _, err := s.validateAttachmentEnvFilePath(containerName); err != nil {
+		return err
+	}
+
+	// Read existing secrets
+	existing, err := s.GetAllAttachment(containerName)
+	if err != nil {
+		return err
+	}
+
+	// Remove the key
+	delete(existing, key)
+
+	// Write back atomically
+	return s.writeAttachmentSecretsAtomic(containerName, existing)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/adapters/out/domainsecrets/... -count=1 -run TestFileStore_DeleteAttachment -v`
+Expected: PASS
+
+**Step 5: Regenerate mocks**
+
+Run: `mockery`
+Expected: Regenerates `internal/boundaries/out/mocks/mock_domain_secret_store.go` with new `DeleteAttachment` method.
+
+**Step 6: Run go fmt and full test suite**
+
+Run: `go fmt ./... && go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 7: Commit**
+
+```bash
+git add internal/boundaries/out/domain_secrets.go internal/adapters/out/domainsecrets/store.go internal/adapters/out/domainsecrets/store_test.go internal/boundaries/out/mocks/mock_domain_secret_store.go
+git commit -m "feat(secrets): add DeleteAttachment to storage layer
+
+Add ability to remove individual keys from attachment env files,
+matching the existing SetAttachment capability."
+```
+
+---
+
+### Task 2: Add attachment methods to SecretService interface and use case
+
+The use case layer needs to resolve `(domain, service)` → container name and call through to the store.
+
+**Files:**
+- Modify: `internal/boundaries/in/secrets.go:11-31`
+- Modify: `internal/usecase/secrets/service.go`
+- Test: `internal/usecase/secrets/service_test.go` (create if needed)
+
+**Step 1: Write the failing test**
+
+Create or add to `internal/usecase/secrets/service_test.go`:
+
+```go
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bnema/zerowrap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
+)
+
+func testLogger() zerowrap.Logger {
+	return zerowrap.Default()
+}
+
+func TestService_SetAttachment(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	secrets := map[string]string{"POSTGRES_PASSWORD": "secret"}
+
+	// domain "app.example.com" + service "postgres" → container name "app__example__com-postgres"
+	store.EXPECT().SetAttachment("app__example__com-postgres", secrets).Return(nil)
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres", secrets)
+	assert.NoError(t, err)
+}
+
+func TestService_DeleteAttachment(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	store.EXPECT().DeleteAttachment("app__example__com-postgres", "OLD_KEY").Return(nil)
+
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", "postgres", "OLD_KEY")
+	assert.NoError(t, err)
+}
+
+func TestService_SetAttachment_InvalidDomain(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "", "postgres", map[string]string{"K": "V"})
+	assert.Error(t, err)
+}
+
+func TestService_SetAttachment_EmptyService(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "", map[string]string{"K": "V"})
+	assert.ErrorIs(t, err, ErrServiceEmpty)
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/usecase/secrets/... -count=1 -run "TestService_SetAttachment|TestService_DeleteAttachment" -v`
+Expected: FAIL — `svc.SetAttachment` undefined
+
+**Step 3: Add to interface and implement**
+
+In `internal/boundaries/in/secrets.go`, add to the `SecretService` interface:
+
+```go
+	// SetAttachment sets or updates secrets for an attachment container.
+	// Resolves the container name from domain + service name.
+	SetAttachment(ctx context.Context, domain, service string, secrets map[string]string) error
+
+	// DeleteAttachment removes a secret key from an attachment container.
+	// Resolves the container name from domain + service name.
+	DeleteAttachment(ctx context.Context, domain, service, key string) error
+```
+
+In `internal/usecase/secrets/service.go`, add the error variable and methods:
+
+```go
+var ErrServiceEmpty = errors.New("service name cannot be empty")
+```
+
+Add the import for the `domain` package:
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/bnema/gordon/internal/domain"
+)
+```
+
+Add the methods:
+
+```go
+// SetAttachment sets or updates secrets for an attachment container.
+func (s *Service) SetAttachment(ctx context.Context, domainName, service string, secrets map[string]string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "SetAttachment",
+		"domain":              domainName,
+		"service":             service,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	if err := ValidateDomain(domainName); err != nil {
+		log.Warn().Err(err).Msg("domain validation failed")
+		return err
+	}
+	if service == "" {
+		return ErrServiceEmpty
+	}
+
+	containerName := resolveContainerName(domainName, service)
+	if err := s.store.SetAttachment(containerName, secrets); err != nil {
+		log.Error().Err(err).Str("container", containerName).Msg("failed to set attachment secrets")
+		return err
+	}
+
+	log.Info().Str("container", containerName).Int("count", len(secrets)).Msg("attachment secrets set")
+	return nil
+}
+
+// DeleteAttachment removes a secret key from an attachment container.
+func (s *Service) DeleteAttachment(ctx context.Context, domainName, service, key string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "DeleteAttachment",
+		"domain":              domainName,
+		"service":             service,
+		"key":                 key,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	if err := ValidateDomain(domainName); err != nil {
+		log.Warn().Err(err).Msg("domain validation failed")
+		return err
+	}
+	if service == "" {
+		return ErrServiceEmpty
+	}
+
+	containerName := resolveContainerName(domainName, service)
+	if err := s.store.DeleteAttachment(containerName, key); err != nil {
+		log.Error().Err(err).Str("container", containerName).Msg("failed to delete attachment secret")
+		return err
+	}
+
+	log.Info().Str("container", containerName).Msg("attachment secret deleted")
+	return nil
+}
+
+// resolveContainerName builds the attachment container name from domain and service.
+// Must match the naming convention in container service's deployAttachedService().
+func resolveContainerName(domainName, service string) string {
+	return domain.SanitizeDomainForContainer(domainName) + "-" + service
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/usecase/secrets/... -count=1 -v`
+Expected: ALL PASS
+
+**Step 5: Regenerate mocks**
+
+Run: `mockery`
+Expected: Regenerates `internal/boundaries/in/mocks/mock_secret_service.go` with new methods.
+
+**Step 6: Run go fmt and full test suite**
+
+Run: `go fmt ./... && go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 7: Commit**
+
+```bash
+git add internal/boundaries/in/secrets.go internal/usecase/secrets/service.go internal/usecase/secrets/service_test.go internal/boundaries/in/mocks/mock_secret_service.go
+git commit -m "feat(secrets): add SetAttachment/DeleteAttachment to use case layer
+
+Resolves (domain, service) to container name and delegates to
+the storage layer. Matches container naming from deployAttachedService()."
+```
+
+---
+
+### Task 3: Add admin API endpoint for attachment secrets
+
+Add `/admin/secrets/{domain}/attachments/{service}` routes for POST (set) and DELETE (with key).
+
+**Files:**
+- Modify: `internal/adapters/in/http/admin/handler.go:446-518`
+- Test: `internal/adapters/in/http/admin/handler_test.go`
+
+**Step 1: Write the failing tests**
+
+Add to `handler_test.go`:
+
+```go
+func TestHandler_AttachmentSecretsPost(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+
+	handler := NewHandler(configSvc, authSvc, containerSvc, inmocks.NewMockHealthService(t), secretSvc, nil, inmocks.NewMockRegistryService(t), nil, testLogger())
+
+	secretSvc.EXPECT().SetAttachment(mock.Anything, "app.example.com", "postgres", map[string]string{"POSTGRES_PASSWORD": "secret"}).Return(nil)
+
+	body := `{"POSTGRES_PASSWORD": "secret"}`
+	req := httptest.NewRequest("POST", "/admin/secrets/app.example.com/attachments/postgres", bytes.NewBufferString(body))
+	req = req.WithContext(ctxWithScopes("admin:secrets:write"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_AttachmentSecretsDelete(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+
+	handler := NewHandler(configSvc, authSvc, containerSvc, inmocks.NewMockHealthService(t), secretSvc, nil, inmocks.NewMockRegistryService(t), nil, testLogger())
+
+	secretSvc.EXPECT().DeleteAttachment(mock.Anything, "app.example.com", "postgres", "OLD_KEY").Return(nil)
+
+	req := httptest.NewRequest("DELETE", "/admin/secrets/app.example.com/attachments/postgres/OLD_KEY", nil)
+	req = req.WithContext(ctxWithScopes("admin:secrets:write"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/adapters/in/http/admin/... -count=1 -run "TestHandler_AttachmentSecrets" -v`
+Expected: FAIL — routes not recognized, 400 or 404
+
+**Step 3: Implement the endpoint**
+
+In `handler.go`, modify the `handleSecrets` function. Replace the path parsing section (lines 451-462) to detect the `/attachments/` sub-path:
+
+```go
+func (h *Handler) handleSecrets(w http.ResponseWriter, r *http.Request, path string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	// Parse path: /secrets/{domain}, /secrets/{domain}/{key},
+	// or /secrets/{domain}/attachments/{service}[/{key}]
+	trimmed := strings.TrimPrefix(path, "/secrets/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 0 || parts[0] == "" {
+		h.sendError(w, http.StatusBadRequest, "domain required")
+		return
+	}
+
+	secretDomain := parts[0]
+
+	// Check for attachment sub-path: /secrets/{domain}/attachments/{service}[/{key}]
+	if len(parts) >= 3 && parts[1] == "attachments" {
+		service := parts[2]
+		attachmentKey := ""
+		if len(parts) > 3 {
+			attachmentKey = parts[3]
+		}
+		h.handleAttachmentSecrets(w, r, secretDomain, service, attachmentKey)
+		return
+	}
+
+	secretKey := ""
+	if len(parts) > 1 {
+		secretKey = parts[1]
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.handleSecretsGet(w, r, secretDomain)
+
+	case http.MethodPost:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestSize)
+
+		var data map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+			log.Warn().Err(err).Msg("invalid secrets JSON")
+			h.sendError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+
+		if err := h.secretSvc.Set(ctx, secretDomain, data); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Msg("failed to set secrets")
+			h.sendError(w, http.StatusBadRequest, "invalid domain")
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Int("count", len(data)).Msg("secrets set")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "updated"})
+
+	case http.MethodDelete:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+		if secretKey == "" {
+			h.sendError(w, http.StatusBadRequest, "key required in path")
+			return
+		}
+
+		if err := h.secretSvc.Delete(ctx, secretDomain, secretKey); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Str("key", secretKey).Msg("failed to delete secret")
+			h.sendError(w, http.StatusBadRequest, "invalid domain")
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Str("key", secretKey).Msg("secret deleted")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "deleted"})
+
+	default:
+		h.sendError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+```
+
+Add the new handler method:
+
+```go
+// handleAttachmentSecrets handles /admin/secrets/{domain}/attachments/{service}[/{key}].
+func (h *Handler) handleAttachmentSecrets(w http.ResponseWriter, r *http.Request, secretDomain, service, key string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	switch r.Method {
+	case http.MethodPost:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestSize)
+
+		var data map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+			log.Warn().Err(err).Msg("invalid attachment secrets JSON")
+			h.sendError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+
+		if err := h.secretSvc.SetAttachment(ctx, secretDomain, service, data); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Str("service", service).Msg("failed to set attachment secrets")
+			h.sendError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Str("service", service).Int("count", len(data)).Msg("attachment secrets set")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "updated"})
+
+	case http.MethodDelete:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+		if key == "" {
+			h.sendError(w, http.StatusBadRequest, "key required in path")
+			return
+		}
+
+		if err := h.secretSvc.DeleteAttachment(ctx, secretDomain, service, key); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Str("service", service).Str("key", key).Msg("failed to delete attachment secret")
+			h.sendError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Str("service", service).Str("key", key).Msg("attachment secret deleted")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "deleted"})
+
+	default:
+		h.sendError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/adapters/in/http/admin/... -count=1 -v`
+Expected: ALL PASS (both new and existing tests)
+
+**Step 5: Run go fmt**
+
+Run: `go fmt ./internal/adapters/in/http/admin/...`
+
+**Step 6: Commit**
+
+```bash
+git add internal/adapters/in/http/admin/handler.go internal/adapters/in/http/admin/handler_test.go
+git commit -m "feat(api): add attachment secrets endpoints
+
+POST /admin/secrets/{domain}/attachments/{service} to set secrets.
+DELETE /admin/secrets/{domain}/attachments/{service}/{key} to remove."
+```
+
+---
+
+### Task 4: Add remote client methods
+
+**Files:**
+- Modify: `internal/adapters/in/cli/remote/client.go` (after `DeleteSecret` ~line 296)
+
+**Step 1: Implement the client methods**
+
+No separate test file exists for the remote client (it's tested via integration). Add the methods:
+
+```go
+// SetAttachmentSecrets sets secrets for an attachment container.
+func (c *Client) SetAttachmentSecrets(ctx context.Context, domain, service string, secrets map[string]string) error {
+	path := "/secrets/" + url.PathEscape(domain) + "/attachments/" + url.PathEscape(service)
+	resp, err := c.request(ctx, http.MethodPost, path, secrets)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}
+
+// DeleteAttachmentSecret removes a secret from an attachment container.
+func (c *Client) DeleteAttachmentSecret(ctx context.Context, domain, service, key string) error {
+	path := "/secrets/" + url.PathEscape(domain) + "/attachments/" + url.PathEscape(service) + "/" + url.PathEscape(key)
+	resp, err := c.request(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}
+```
+
+**Step 2: Run go fmt and verify build**
+
+Run: `go fmt ./internal/adapters/in/cli/remote/... && go build ./...`
+Expected: Clean build
+
+**Step 3: Commit**
+
+```bash
+git add internal/adapters/in/cli/remote/client.go
+git commit -m "feat(client): add attachment secrets API methods"
+```
+
+---
+
+### Task 5: Add `--attachment` flag to `secrets set` and `secrets remove` CLI commands
+
+**Files:**
+- Modify: `internal/adapters/in/cli/secrets.go:214-270` (set command)
+- Modify: `internal/adapters/in/cli/secrets.go:272-327` (remove command)
+
+**Step 1: Write the failing test for flag parsing**
+
+Add to `internal/adapters/in/cli/secrets_test.go` (create file):
+
+```go
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveContainerName(t *testing.T) {
+	tests := []struct {
+		domain  string
+		service string
+		want    string
+	}{
+		{"app.example.com", "postgres", "app__example__com-postgres"},
+		{"git.example.com", "redis", "git__example__com-redis"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.domain+"/"+tt.service, func(t *testing.T) {
+			got := resolveAttachmentContainerName(tt.domain, tt.service)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/adapters/in/cli/... -count=1 -run TestResolveContainerName -v`
+Expected: FAIL — `resolveAttachmentContainerName` undefined
+
+**Step 3: Implement**
+
+In `secrets.go`, add the helper:
+
+```go
+// resolveAttachmentContainerName builds the container name from domain and service.
+// Must match the naming in usecase/container deployAttachedService() and usecase/secrets resolveContainerName().
+func resolveAttachmentContainerName(domainName, service string) string {
+	return domain.SanitizeDomainForContainer(domainName) + "-" + service
+}
+```
+
+Add the import for the domain package at the top of `secrets.go`:
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/bnema/gordon/internal/domain"
+)
+```
+
+Now modify `newSecretsSetCmd()` to add the `--attachment` flag. Replace the function:
+
+```go
+func newSecretsSetCmd() *cobra.Command {
+	var attachment string
+
+	cmd := &cobra.Command{
+		Use:   "set <domain> <KEY=value>...",
+		Short: "Set secrets for a domain or attachment",
+		Long: `Set one or more secrets for a domain or an attachment container.
+
+Secrets are specified as KEY=value pairs. Multiple secrets can be set at once.
+
+Use --attachment to target an attachment service (e.g., postgres, redis) instead
+of the main domain container.
+
+Examples:
+  gordon secrets set app.mydomain.com DATABASE_URL=postgres://localhost/db
+  gordon secrets set app.mydomain.com API_KEY=secret123 DEBUG=false
+  gordon secrets set app.mydomain.com --attachment postgres POSTGRES_PASSWORD=secret
+  gordon secrets set app.mydomain.com --attachment redis REDIS_PASSWORD=secret`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			secretDomain := args[0]
+			pairs := args[1:]
+
+			// Parse KEY=value pairs
+			secrets := make(map[string]string)
+			for _, pair := range pairs {
+				parts := strings.SplitN(pair, "=", 2)
+				if len(parts) != 2 {
+					fmt.Println(styles.RenderError(fmt.Sprintf("Invalid format: %s (expected KEY=value)", pair)))
+					return nil
+				}
+				secrets[parts[0]] = parts[1]
+			}
+
+			client, isRemote := GetRemoteClient()
+			if isRemote {
+				if attachment != "" {
+					if err := client.SetAttachmentSecrets(ctx, secretDomain, attachment, secrets); err != nil {
+						return fmt.Errorf("failed to set attachment secrets: %w", err)
+					}
+				} else {
+					if err := client.SetSecrets(ctx, secretDomain, secrets); err != nil {
+						return fmt.Errorf("failed to set secrets: %w", err)
+					}
+				}
+			} else {
+				local, err := GetLocalServices(configPath)
+				if err != nil {
+					return fmt.Errorf("failed to initialize local services: %w", err)
+				}
+				if attachment != "" {
+					if err := local.GetSecretService().SetAttachment(ctx, secretDomain, attachment, secrets); err != nil {
+						return fmt.Errorf("failed to set attachment secrets: %w", err)
+					}
+				} else {
+					if err := local.GetSecretService().Set(ctx, secretDomain, secrets); err != nil {
+						return fmt.Errorf("failed to set secrets: %w", err)
+					}
+				}
+			}
+
+			target := secretDomain
+			if attachment != "" {
+				target = fmt.Sprintf("%s [%s]", secretDomain, attachment)
+			}
+
+			if len(secrets) == 1 {
+				for key := range secrets {
+					fmt.Println(styles.RenderSuccess(fmt.Sprintf("Secret set: %s on %s", key, target)))
+				}
+			} else {
+				fmt.Println(styles.RenderSuccess(fmt.Sprintf("Set %d secrets for %s", len(secrets), target)))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&attachment, "attachment", "a", "", "Target an attachment service (e.g., postgres, redis)")
+
+	return cmd
+}
+```
+
+Now modify `newSecretsRemoveCmd()` similarly:
+
+```go
+func newSecretsRemoveCmd() *cobra.Command {
+	var (
+		force      bool
+		attachment string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove <domain> <key>",
+		Short: "Remove a secret",
+		Long: `Remove a secret from a domain or attachment container.
+
+Use --attachment to target an attachment service instead of the main domain.
+
+Examples:
+  gordon secrets remove app.mydomain.com OLD_API_KEY
+  gordon secrets remove app.mydomain.com OLD_API_KEY --force
+  gordon secrets remove app.mydomain.com --attachment postgres POSTGRES_PASSWORD`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			secretDomain := args[0]
+			key := args[1]
+
+			target := secretDomain
+			if attachment != "" {
+				target = fmt.Sprintf("%s [%s]", secretDomain, attachment)
+			}
+
+			// Confirm unless --force
+			if !force {
+				confirmed, err := components.RunConfirm(
+					fmt.Sprintf("Remove secret '%s' from %s?", key, target),
+				)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					fmt.Println(styles.Theme.Muted.Render("Cancelled"))
+					return nil
+				}
+			}
+
+			client, isRemote := GetRemoteClient()
+			if isRemote {
+				if attachment != "" {
+					if err := client.DeleteAttachmentSecret(ctx, secretDomain, attachment, key); err != nil {
+						return fmt.Errorf("failed to remove attachment secret: %w", err)
+					}
+				} else {
+					if err := client.DeleteSecret(ctx, secretDomain, key); err != nil {
+						return fmt.Errorf("failed to remove secret: %w", err)
+					}
+				}
+			} else {
+				local, err := GetLocalServices(configPath)
+				if err != nil {
+					return fmt.Errorf("failed to initialize local services: %w", err)
+				}
+				if attachment != "" {
+					if err := local.GetSecretService().DeleteAttachment(ctx, secretDomain, attachment, key); err != nil {
+						return fmt.Errorf("failed to remove attachment secret: %w", err)
+					}
+				} else {
+					if err := local.GetSecretService().Delete(ctx, secretDomain, key); err != nil {
+						return fmt.Errorf("failed to remove secret: %w", err)
+					}
+				}
+			}
+
+			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Secret removed: %s from %s", key, target)))
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation")
+	cmd.Flags().StringVarP(&attachment, "attachment", "a", "", "Target an attachment service (e.g., postgres, redis)")
+
+	return cmd
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/adapters/in/cli/... -count=1 -v`
+Expected: ALL PASS
+
+**Step 5: Run go fmt and full suite**
+
+Run: `go fmt ./... && go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add internal/adapters/in/cli/secrets.go internal/adapters/in/cli/secrets_test.go
+git commit -m "feat(cli): add --attachment flag to secrets set/remove
+
+Closes #56. Users can now configure attachment secrets via:
+  gordon secrets set <domain> --attachment <service> KEY=value
+  gordon secrets remove <domain> --attachment <service> KEY"
+```
+
+---
+
+### Task 6: Update secrets command description and verify end-to-end
+
+**Files:**
+- Modify: `internal/adapters/in/cli/secrets.go:16-33` (parent command description)
+
+**Step 1: Update parent command long description**
+
+```go
+func newSecretsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Manage secrets",
+		Long: `Manage secrets (environment variables) for routes and attachments.
+
+Secrets are stored per-domain and injected into containers as environment variables.
+Use --attachment to target attachment containers (databases, caches, etc.).
+
+When targeting a remote Gordon instance (via --remote flag or GORDON_REMOTE env var),
+these commands operate on the remote server.`,
+	}
+
+	cmd.AddCommand(newSecretsListCmd())
+	cmd.AddCommand(newSecretsSetCmd())
+	cmd.AddCommand(newSecretsRemoveCmd())
+
+	return cmd
+}
+```
+
+**Step 2: Run full test suite**
+
+Run: `go test ./... -count=1`
+Expected: ALL PASS
+
+**Step 3: Run go vet and build**
+
+Run: `go vet ./... && go build ./...`
+Expected: Clean
+
+**Step 4: Commit**
+
+```bash
+git add internal/adapters/in/cli/secrets.go
+git commit -m "docs(cli): update secrets command description for attachments"
+```

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -295,6 +295,26 @@ func (c *Client) DeleteSecret(ctx context.Context, secretDomain, key string) err
 	return parseResponse(resp, nil)
 }
 
+// SetAttachmentSecrets sets secrets for an attachment container.
+func (c *Client) SetAttachmentSecrets(ctx context.Context, domain, service string, secrets map[string]string) error {
+	path := "/secrets/" + url.PathEscape(domain) + "/attachments/" + url.PathEscape(service)
+	resp, err := c.request(ctx, http.MethodPost, path, secrets)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}
+
+// DeleteAttachmentSecret removes a secret from an attachment container.
+func (c *Client) DeleteAttachmentSecret(ctx context.Context, domain, service, key string) error {
+	path := "/secrets/" + url.PathEscape(domain) + "/attachments/" + url.PathEscape(service) + "/" + url.PathEscape(key)
+	resp, err := c.request(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}
+
 // Status API
 
 // Status represents the Gordon server status.

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -242,8 +242,7 @@ Examples:
 			for _, pair := range pairs {
 				parts := strings.SplitN(pair, "=", 2)
 				if len(parts) != 2 {
-					fmt.Println(styles.RenderError(fmt.Sprintf("Invalid format: %s (expected KEY=value)", pair)))
-					return nil
+					return fmt.Errorf("invalid format: %s (expected KEY=value)", pair)
 				}
 				secrets[parts[0]] = parts[1]
 			}

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -445,9 +445,6 @@ func (h *Handler) handleNetworks(w http.ResponseWriter, r *http.Request) {
 
 // handleSecrets handles /admin/secrets endpoints.
 func (h *Handler) handleSecrets(w http.ResponseWriter, r *http.Request, path string) {
-	ctx := r.Context()
-	log := zerowrap.FromCtx(ctx)
-
 	// Parse path: /secrets/{domain} or /secrets/{domain}/{key}
 	parts := strings.Split(strings.TrimPrefix(path, "/secrets/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
@@ -456,6 +453,18 @@ func (h *Handler) handleSecrets(w http.ResponseWriter, r *http.Request, path str
 	}
 
 	secretDomain := parts[0]
+
+	// Check for attachment sub-path: /secrets/{domain}/attachments/{service}[/{key}]
+	if len(parts) >= 3 && parts[1] == "attachments" {
+		service := parts[2]
+		attachmentKey := ""
+		if len(parts) > 3 {
+			attachmentKey = parts[3]
+		}
+		h.handleAttachmentSecrets(w, r, secretDomain, service, attachmentKey)
+		return
+	}
+
 	secretKey := ""
 	if len(parts) > 1 {
 		secretKey = parts[1]
@@ -464,57 +473,66 @@ func (h *Handler) handleSecrets(w http.ResponseWriter, r *http.Request, path str
 	switch r.Method {
 	case http.MethodGet:
 		h.handleSecretsGet(w, r, secretDomain)
-
 	case http.MethodPost:
-		// Check write permission
-		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
-			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
-			return
-		}
-
-		// Limit request body size
-		r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestSize)
-
-		// Set secret(s)
-		var data map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-			log.Warn().Err(err).Msg("invalid secrets JSON")
-			h.sendError(w, http.StatusBadRequest, "invalid JSON")
-			return
-		}
-
-		if err := h.secretSvc.Set(ctx, secretDomain, data); err != nil {
-			log.Error().Err(err).Str("domain", secretDomain).Msg("failed to set secrets")
-			h.sendError(w, http.StatusBadRequest, "invalid domain")
-			return
-		}
-
-		log.Info().Str("domain", secretDomain).Int("count", len(data)).Msg("secrets set")
-		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "updated"})
-
+		h.handleSecretsPost(w, r, secretDomain)
 	case http.MethodDelete:
-		// Check write permission
-		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
-			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
-			return
-		}
-		if secretKey == "" {
-			h.sendError(w, http.StatusBadRequest, "key required in path")
-			return
-		}
-
-		if err := h.secretSvc.Delete(ctx, secretDomain, secretKey); err != nil {
-			log.Error().Err(err).Str("domain", secretDomain).Str("key", secretKey).Msg("failed to delete secret")
-			h.sendError(w, http.StatusBadRequest, "invalid domain")
-			return
-		}
-
-		log.Info().Str("domain", secretDomain).Str("key", secretKey).Msg("secret deleted")
-		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "deleted"})
-
+		h.handleSecretsDelete(w, r, secretDomain, secretKey)
 	default:
 		h.sendError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// handleSecretsPost handles POST /admin/secrets/{domain} - set secrets.
+func (h *Handler) handleSecretsPost(w http.ResponseWriter, r *http.Request, secretDomain string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestSize)
+
+	var data map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		log.Warn().Err(err).Msg("invalid secrets JSON")
+		h.sendError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	if err := h.secretSvc.Set(ctx, secretDomain, data); err != nil {
+		log.Error().Err(err).Str("domain", secretDomain).Msg("failed to set secrets")
+		h.sendError(w, http.StatusBadRequest, "invalid domain")
+		return
+	}
+
+	log.Info().Str("domain", secretDomain).Int("count", len(data)).Msg("secrets set")
+	h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "updated"})
+}
+
+// handleSecretsDelete handles DELETE /admin/secrets/{domain}/{key} - delete a secret.
+func (h *Handler) handleSecretsDelete(w http.ResponseWriter, r *http.Request, secretDomain, secretKey string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+		return
+	}
+	if secretKey == "" {
+		h.sendError(w, http.StatusBadRequest, "key required in path")
+		return
+	}
+
+	if err := h.secretSvc.Delete(ctx, secretDomain, secretKey); err != nil {
+		log.Error().Err(err).Str("domain", secretDomain).Str("key", secretKey).Msg("failed to delete secret")
+		h.sendError(w, http.StatusBadRequest, "invalid domain")
+		return
+	}
+
+	log.Info().Str("domain", secretDomain).Str("key", secretKey).Msg("secret deleted")
+	h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "deleted"})
 }
 
 // handleSecretsGet handles GET /admin/secrets/{domain} - list secrets.
@@ -550,6 +568,61 @@ func (h *Handler) handleSecretsGet(w http.ResponseWriter, r *http.Request, secre
 		Keys:        keys,
 		Attachments: attachmentDTOs,
 	})
+}
+
+// handleAttachmentSecrets handles /admin/secrets/{domain}/attachments/{service}[/{key}] endpoints.
+func (h *Handler) handleAttachmentSecrets(w http.ResponseWriter, r *http.Request, secretDomain, service, key string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	switch r.Method {
+	case http.MethodPost:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxAdminRequestSize)
+
+		var data map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+			log.Warn().Err(err).Msg("invalid attachment secrets JSON")
+			h.sendError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+
+		if err := h.secretSvc.SetAttachment(ctx, secretDomain, service, data); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Str("service", service).Msg("failed to set attachment secrets")
+			h.sendError(w, http.StatusBadRequest, "invalid domain or service")
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Str("service", service).Int("count", len(data)).Msg("attachment secrets set")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "updated"})
+
+	case http.MethodDelete:
+		if !HasAccess(ctx, domain.AdminResourceSecrets, domain.AdminActionWrite) {
+			h.sendError(w, http.StatusForbidden, "insufficient permissions for secrets:write")
+			return
+		}
+
+		if key == "" {
+			h.sendError(w, http.StatusBadRequest, "key required in path")
+			return
+		}
+
+		if err := h.secretSvc.DeleteAttachment(ctx, secretDomain, service, key); err != nil {
+			log.Error().Err(err).Str("domain", secretDomain).Str("service", service).Str("key", key).Msg("failed to delete attachment secret")
+			h.sendError(w, http.StatusBadRequest, "invalid domain or service")
+			return
+		}
+
+		log.Info().Str("domain", secretDomain).Str("service", service).Str("key", key).Msg("attachment secret deleted")
+		h.sendJSON(w, http.StatusOK, dto.SecretsStatusResponse{Status: "deleted"})
+
+	default:
+		h.sendError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
 }
 
 // handleHealth handles /admin/health endpoint.

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -1143,7 +1143,7 @@ func TestHandler_AttachmentSecretsDelete_RequiresKey(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "key required")
+	assert.Contains(t, rec.Body.String(), "invalid attachment path")
 }
 
 func TestHandler_AttachmentSecretsPost_InvalidJSON(t *testing.T) {

--- a/internal/adapters/out/domainsecrets/store.go
+++ b/internal/adapters/out/domainsecrets/store.go
@@ -176,6 +176,26 @@ func (s *FileStore) SetAttachment(containerName string, secrets map[string]strin
 	return s.writeAttachmentSecretsAtomic(containerName, existing)
 }
 
+// DeleteAttachment removes a specific secret key from an attachment container.
+func (s *FileStore) DeleteAttachment(containerName, key string) error {
+	// Validate container name first
+	if _, err := s.validateAttachmentEnvFilePath(containerName); err != nil {
+		return err
+	}
+
+	// Read existing secrets
+	existing, err := s.GetAllAttachment(containerName)
+	if err != nil {
+		return err
+	}
+
+	// Remove the key (no-op if not present)
+	delete(existing, key)
+
+	// Write back atomically
+	return s.writeAttachmentSecretsAtomic(containerName, existing)
+}
+
 // GetAllAttachment returns all secrets for an attachment container as a key-value map.
 func (s *FileStore) GetAllAttachment(containerName string) (map[string]string, error) {
 	envFile, err := s.validateAttachmentEnvFilePath(containerName)

--- a/internal/boundaries/in/mocks/mock_secret_service.go
+++ b/internal/boundaries/in/mocks/mock_secret_service.go
@@ -101,6 +101,75 @@ func (_c *MockSecretService_Delete_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
+// DeleteAttachment provides a mock function for the type MockSecretService
+func (_mock *MockSecretService) DeleteAttachment(ctx context.Context, domain string, service string, key string) error {
+	ret := _mock.Called(ctx, domain, service, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAttachment")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, domain, service, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockSecretService_DeleteAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAttachment'
+type MockSecretService_DeleteAttachment_Call struct {
+	*mock.Call
+}
+
+// DeleteAttachment is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+//   - service string
+//   - key string
+func (_e *MockSecretService_Expecter) DeleteAttachment(ctx interface{}, domain interface{}, service interface{}, key interface{}) *MockSecretService_DeleteAttachment_Call {
+	return &MockSecretService_DeleteAttachment_Call{Call: _e.mock.On("DeleteAttachment", ctx, domain, service, key)}
+}
+
+func (_c *MockSecretService_DeleteAttachment_Call) Run(run func(ctx context.Context, domain string, service string, key string)) *MockSecretService_DeleteAttachment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSecretService_DeleteAttachment_Call) Return(err error) *MockSecretService_DeleteAttachment_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockSecretService_DeleteAttachment_Call) RunAndReturn(run func(ctx context.Context, domain string, service string, key string) error) *MockSecretService_DeleteAttachment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAll provides a mock function for the type MockSecretService
 func (_mock *MockSecretService) GetAll(ctx context.Context, domain string) (map[string]string, error) {
 	ret := _mock.Called(ctx, domain)
@@ -372,6 +441,75 @@ func (_c *MockSecretService_Set_Call) Return(err error) *MockSecretService_Set_C
 }
 
 func (_c *MockSecretService_Set_Call) RunAndReturn(run func(ctx context.Context, domain string, secrets map[string]string) error) *MockSecretService_Set_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetAttachment provides a mock function for the type MockSecretService
+func (_mock *MockSecretService) SetAttachment(ctx context.Context, domain string, service string, secrets map[string]string) error {
+	ret := _mock.Called(ctx, domain, service, secrets)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAttachment")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) error); ok {
+		r0 = returnFunc(ctx, domain, service, secrets)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockSecretService_SetAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAttachment'
+type MockSecretService_SetAttachment_Call struct {
+	*mock.Call
+}
+
+// SetAttachment is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+//   - service string
+//   - secrets map[string]string
+func (_e *MockSecretService_Expecter) SetAttachment(ctx interface{}, domain interface{}, service interface{}, secrets interface{}) *MockSecretService_SetAttachment_Call {
+	return &MockSecretService_SetAttachment_Call{Call: _e.mock.On("SetAttachment", ctx, domain, service, secrets)}
+}
+
+func (_c *MockSecretService_SetAttachment_Call) Run(run func(ctx context.Context, domain string, service string, secrets map[string]string)) *MockSecretService_SetAttachment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]string
+		if args[3] != nil {
+			arg3 = args[3].(map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockSecretService_SetAttachment_Call) Return(err error) *MockSecretService_SetAttachment_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockSecretService_SetAttachment_Call) RunAndReturn(run func(ctx context.Context, domain string, service string, secrets map[string]string) error) *MockSecretService_SetAttachment_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/in/secrets.go
+++ b/internal/boundaries/in/secrets.go
@@ -28,4 +28,12 @@ type SecretService interface {
 	// Delete removes a specific secret key from a domain.
 	// Returns an error if the domain is invalid.
 	Delete(ctx context.Context, domain, key string) error
+
+	// SetAttachment sets or updates multiple secrets for an attachment container.
+	// The container name is derived from the domain and service name.
+	SetAttachment(ctx context.Context, domain, service string, secrets map[string]string) error
+
+	// DeleteAttachment removes a specific secret key from an attachment container.
+	// The container name is derived from the domain and service name.
+	DeleteAttachment(ctx context.Context, domain, service, key string) error
 }

--- a/internal/boundaries/out/domain_secrets.go
+++ b/internal/boundaries/out/domain_secrets.go
@@ -29,6 +29,9 @@ type DomainSecretStore interface {
 	// GetAllAttachment returns all secrets for an attachment container as a key-value map.
 	GetAllAttachment(containerName string) (map[string]string, error)
 
+	// DeleteAttachment removes a specific secret key from an attachment container.
+	DeleteAttachment(containerName, key string) error
+
 	// ListAttachmentKeys finds and returns secret keys for attachment containers
 	// associated with the given domain. Returns a list of AttachmentSecrets, one
 	// for each attachment that has secrets configured.

--- a/internal/boundaries/out/mocks/mock_domain_secret_store.go
+++ b/internal/boundaries/out/mocks/mock_domain_secret_store.go
@@ -93,6 +93,63 @@ func (_c *MockDomainSecretStore_Delete_Call) RunAndReturn(run func(domain string
 	return _c
 }
 
+// DeleteAttachment provides a mock function for the type MockDomainSecretStore
+func (_mock *MockDomainSecretStore) DeleteAttachment(containerName string, key string) error {
+	ret := _mock.Called(containerName, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAttachment")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(containerName, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDomainSecretStore_DeleteAttachment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAttachment'
+type MockDomainSecretStore_DeleteAttachment_Call struct {
+	*mock.Call
+}
+
+// DeleteAttachment is a helper method to define mock.On call
+//   - containerName string
+//   - key string
+func (_e *MockDomainSecretStore_Expecter) DeleteAttachment(containerName interface{}, key interface{}) *MockDomainSecretStore_DeleteAttachment_Call {
+	return &MockDomainSecretStore_DeleteAttachment_Call{Call: _e.mock.On("DeleteAttachment", containerName, key)}
+}
+
+func (_c *MockDomainSecretStore_DeleteAttachment_Call) Run(run func(containerName string, key string)) *MockDomainSecretStore_DeleteAttachment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainSecretStore_DeleteAttachment_Call) Return(err error) *MockDomainSecretStore_DeleteAttachment_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDomainSecretStore_DeleteAttachment_Call) RunAndReturn(run func(containerName string, key string) error) *MockDomainSecretStore_DeleteAttachment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAll provides a mock function for the type MockDomainSecretStore
 func (_mock *MockDomainSecretStore) GetAll(domain string) (map[string]string, error) {
 	ret := _mock.Called(domain)

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -19,7 +19,7 @@ var (
 	ErrDomainPathTraversal = errors.New("domain contains path traversal sequence")
 	ErrDomainInvalidChars  = errors.New("domain contains invalid characters")
 	ErrServiceEmpty        = errors.New("service name cannot be empty")
-	ErrInvalidServiceName  = errors.New("invalid service name: must start with a letter and contain only lowercase letters, numbers, and hyphens")
+	ErrInvalidServiceName  = errors.New("invalid service name: must start with a letter, contain only lowercase letters, numbers, and hyphens, be at most 63 characters, and not end with a hyphen")
 )
 
 // Service implements the SecretService interface.
@@ -263,14 +263,14 @@ func validateServiceName(service string) error {
 // Ensures the total name does not exceed Docker's 255-character limit.
 func resolveContainerName(domainName, service string) string {
 	sanitized := domain.SanitizeDomainForContainer(domainName)
-	name := sanitized + "-" + service
+	name := "gordon-" + sanitized + "-" + service
 
 	// Docker container names are limited to 255 characters
 	if len(name) > 255 {
-		// Truncate the domain part to fit, keeping room for "-" and service name
-		maxDomainLen := 255 - 1 - len(service)
+		// Truncate the domain part to fit, keeping room for "gordon-", "-", and service name
+		maxDomainLen := 255 - 7 - 1 - len(service) // 7 for "gordon-", 1 for "-"
 		if maxDomainLen > 0 {
-			name = sanitized[:maxDomainLen] + "-" + service
+			name = "gordon-" + sanitized[:maxDomainLen] + "-" + service
 		}
 	}
 	return name

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -260,8 +260,20 @@ func validateServiceName(service string) error {
 }
 
 // resolveContainerName builds the container name from a domain and service.
+// Ensures the total name does not exceed Docker's 255-character limit.
 func resolveContainerName(domainName, service string) string {
-	return domain.SanitizeDomainForContainer(domainName) + "-" + service
+	sanitized := domain.SanitizeDomainForContainer(domainName)
+	name := sanitized + "-" + service
+
+	// Docker container names are limited to 255 characters
+	if len(name) > 255 {
+		// Truncate the domain part to fit, keeping room for "-" and service name
+		maxDomainLen := 255 - 1 - len(service)
+		if maxDomainLen > 0 {
+			name = sanitized[:maxDomainLen] + "-" + service
+		}
+	}
+	return name
 }
 
 // ValidateDomain validates that a domain is safe to use for secret storage.

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Domain validation errors.
@@ -17,6 +18,8 @@ var (
 	ErrDomainTooLong       = errors.New("domain exceeds maximum length of 253 characters")
 	ErrDomainPathTraversal = errors.New("domain contains path traversal sequence")
 	ErrDomainInvalidChars  = errors.New("domain contains invalid characters")
+	ErrServiceEmpty        = errors.New("service name cannot be empty")
+	ErrInvalidServiceName  = errors.New("invalid service name: must start with a letter and contain only lowercase letters, numbers, and hyphens")
 )
 
 // Service implements the SecretService interface.
@@ -163,6 +166,102 @@ func (s *Service) Delete(ctx context.Context, domain, key string) error {
 
 	log.Info().Msg("secret deleted")
 	return nil
+}
+
+// SetAttachment sets or updates multiple secrets for an attachment container.
+func (s *Service) SetAttachment(ctx context.Context, domainName, service string, secrets map[string]string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "SetAttachment",
+		"domain":              domainName,
+		"service":             service,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	if err := ValidateDomain(domainName); err != nil {
+		log.Warn().Err(err).Msg("domain validation failed")
+		return err
+	}
+
+	if err := validateServiceName(service); err != nil {
+		log.Warn().Err(err).Msg("service name validation failed")
+		return err
+	}
+
+	containerName := resolveContainerName(domainName, service)
+
+	if err := s.store.SetAttachment(containerName, secrets); err != nil {
+		log.Error().Err(err).Msg("failed to set attachment secrets")
+		return err
+	}
+
+	log.Info().Int("count", len(secrets)).Str("container", containerName).Msg("attachment secrets set")
+	return nil
+}
+
+// DeleteAttachment removes a specific secret key from an attachment container.
+func (s *Service) DeleteAttachment(ctx context.Context, domainName, service, key string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "DeleteAttachment",
+		"domain":              domainName,
+		"service":             service,
+		"key":                 key,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	if err := ValidateDomain(domainName); err != nil {
+		log.Warn().Err(err).Msg("domain validation failed")
+		return err
+	}
+
+	if err := validateServiceName(service); err != nil {
+		log.Warn().Err(err).Msg("service name validation failed")
+		return err
+	}
+
+	containerName := resolveContainerName(domainName, service)
+
+	if err := s.store.DeleteAttachment(containerName, key); err != nil {
+		log.Error().Err(err).Msg("failed to delete attachment secret")
+		return err
+	}
+
+	log.Info().Str("container", containerName).Msg("attachment secret deleted")
+	return nil
+}
+
+// validateServiceName checks that a service name is safe and follows Docker-style conventions.
+func validateServiceName(service string) error {
+	if service == "" {
+		return ErrServiceEmpty
+	}
+	// DNS labels are limited to 63 characters (RFC 1035)
+	if len(service) > 63 {
+		return ErrInvalidServiceName
+	}
+	// Docker-style: lowercase letter start, then lowercase alphanumeric + hyphens
+	for i, c := range service {
+		if i == 0 {
+			if c < 'a' || c > 'z' {
+				return ErrInvalidServiceName
+			}
+			continue
+		}
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
+			return ErrInvalidServiceName
+		}
+	}
+	// Trailing hyphen is not allowed in DNS labels
+	if service[len(service)-1] == '-' {
+		return ErrInvalidServiceName
+	}
+	return nil
+}
+
+// resolveContainerName builds the container name from a domain and service.
+func resolveContainerName(domainName, service string) string {
+	return domain.SanitizeDomainForContainer(domainName) + "-" + service
 }
 
 // ValidateDomain validates that a domain is safe to use for secret storage.

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -459,3 +459,87 @@ func TestService_ValidationHappensBeforeStore(t *testing.T) {
 	// Verify no store methods were called (mockery would fail if unexpected calls happened)
 	mock.AssertExpectationsForObjects(t, store)
 }
+
+func TestService_SetAttachment(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	secrets := map[string]string{"POSTGRES_PASSWORD": "secret123"}
+	store.EXPECT().SetAttachment("app__example__com-postgres", secrets).Return(nil)
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres", secrets)
+	assert.NoError(t, err)
+}
+
+func TestService_DeleteAttachment(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	store.EXPECT().DeleteAttachment("app__example__com-postgres", "OLD_KEY").Return(nil)
+
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", "postgres", "OLD_KEY")
+	assert.NoError(t, err)
+}
+
+func TestService_SetAttachment_InvalidDomain(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "", "postgres", map[string]string{"KEY": "val"})
+	assert.ErrorIs(t, err, ErrDomainEmpty)
+}
+
+func TestService_SetAttachment_EmptyService(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "", map[string]string{"KEY": "val"})
+	assert.ErrorIs(t, err, ErrServiceEmpty)
+}
+
+func TestService_DeleteAttachment_InvalidDomain(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.DeleteAttachment(context.Background(), "", "postgres", "SOME_KEY")
+	assert.ErrorIs(t, err, ErrDomainEmpty)
+}
+
+func TestService_DeleteAttachment_EmptyService(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", "", "SOME_KEY")
+	assert.ErrorIs(t, err, ErrServiceEmpty)
+}
+
+func TestService_SetAttachment_InvalidServiceName(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "../evil", map[string]string{"K": "V"})
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
+func TestService_DeleteAttachment_InvalidServiceName(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", "foo/bar", "SOME_KEY")
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
+func TestService_AttachmentValidationHappensBeforeStore(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	// With invalid service name, store methods should never be called
+	err := svc.SetAttachment(context.Background(), "app.example.com", "../evil", map[string]string{"key": "value"})
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+
+	err = svc.DeleteAttachment(context.Background(), "app.example.com", "../evil", "key")
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+
+	// Verify no store methods were called
+	mock.AssertExpectationsForObjects(t, store)
+}

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -465,7 +465,7 @@ func TestService_SetAttachment(t *testing.T) {
 	svc := NewService(store, testLogger())
 
 	secrets := map[string]string{"POSTGRES_PASSWORD": "secret123"}
-	store.EXPECT().SetAttachment("app__example__com-postgres", secrets).Return(nil)
+	store.EXPECT().SetAttachment("gordon-app__example__com-postgres", secrets).Return(nil)
 
 	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres", secrets)
 	assert.NoError(t, err)
@@ -475,7 +475,7 @@ func TestService_DeleteAttachment(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
 	svc := NewService(store, testLogger())
 
-	store.EXPECT().DeleteAttachment("app__example__com-postgres", "OLD_KEY").Return(nil)
+	store.EXPECT().DeleteAttachment("gordon-app__example__com-postgres", "OLD_KEY").Return(nil)
 
 	err := svc.DeleteAttachment(context.Background(), "app.example.com", "postgres", "OLD_KEY")
 	assert.NoError(t, err)

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -529,6 +529,42 @@ func TestService_DeleteAttachment_InvalidServiceName(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidServiceName)
 }
 
+func TestService_SetAttachment_ServiceNameTooLong(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	// Service name exceeds DNS label limit of 63 characters
+	longService := strings.Repeat("a", 64)
+	err := svc.SetAttachment(context.Background(), "app.example.com", longService, map[string]string{"K": "V"})
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
+func TestService_SetAttachment_ServiceNameTrailingHyphen(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres-", map[string]string{"K": "V"})
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
+func TestService_DeleteAttachment_ServiceNameTooLong(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	// Service name exceeds DNS label limit of 63 characters
+	longService := strings.Repeat("a", 64)
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", longService, "SOME_KEY")
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
+func TestService_DeleteAttachment_ServiceNameTrailingHyphen(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger())
+
+	err := svc.DeleteAttachment(context.Background(), "app.example.com", "redis-", "SOME_KEY")
+	assert.ErrorIs(t, err, ErrInvalidServiceName)
+}
+
 func TestService_AttachmentValidationHappensBeforeStore(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
 	svc := NewService(store, testLogger())


### PR DESCRIPTION
## Summary
- Add `--attachment` / `-a` flag to `gordon secrets set` and `gordon secrets remove` commands
- Support managing secrets for attachment containers (databases, caches, etc.) separately from domain secrets
- List attachment secrets in tree view under domain secrets
- Add HTTP endpoints for attachment secrets (POST/DELETE under `/admin/secrets/{domain}/attachments/{service}`)
- Implement `DeleteAttachment` in storage layer (pass and file backends)
- Improve service name validation (max 63 chars, no trailing hyphen per DNS RFC 1035)
- Add comprehensive test coverage for attachment secret operations

## Changes
- **CLI**: `gordon secrets set/remove --attachment <service>` to target attachment containers
- **API**: New admin endpoints for attachment secrets with proper authentication
- **Storage**: DeleteAttachment method in both pass and file-based secret stores
- **Validation**: Enhanced service name validation (DNS label limits)
- **Docs**: Updated CLI/config documentation with attachment secrets examples

## Storage
Attachment secrets are stored separately:
- **pass**: `gordon/env/attachments/<container-name>/<KEY>` with manifest
- **sops/unsafe**: `gordon-<container-name>.env` files

## Example Usage
```bash
# Set database password
gordon secrets set app.mydomain.com -a postgres POSTGRES_PASSWORD=secret

# Set multiple secrets
gordon secrets set app.mydomain.com -a postgres POSTGRES_USER=admin POSTGRES_PASSWORD=secret

# List all secrets (domain + attachments in tree view)
gordon secrets list app.mydomain.com

# Remove attachment secret
gordon secrets remove app.mydomain.com -a postgres POSTGRES_PASSWORD
```

## Testing
- Added unit tests for all attachment secret operations
- Added validation tests for service names
- Tests verify store methods are never called for invalid inputs
- All existing tests passing

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--attachment` flag to `gordon secrets set` and `gordon secrets remove` commands for managing attachment-specific secrets.
  * Introduced hierarchical tree-view display showing attachment secrets nested under domain secrets.
  * Added new API endpoints for setting and deleting attachment secrets.

* **Documentation**
  * Expanded guides with attachment secrets configuration examples and workflows across all secret backends.
  * Added end-to-end examples for postgres and redis attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->