### PR TITLE
feat: add native TLS listener support

### DIFF
--- a/docs/config/rate-limiting.md
+++ b/docs/config/rate-limiting.md
@@ -28,7 +28,7 @@ burst = 100
 trusted_proxies = []
 ```
 
-> **Important:** Gordon does not handle TLS termination, so production deployments require a front proxy (Cloudflare, nginx, etc.) for HTTPS. You **must** configure `trusted_proxies` to ensure rate limiting sees real client IPs instead of your proxy's IP.
+> **Important:** If you run Gordon behind a front proxy (Cloudflare, nginx, etc.), configure `trusted_proxies` so rate limiting sees real client IPs instead of your proxy's IP.
 
 ## Configuration
 
@@ -150,7 +150,7 @@ A burst of `100` with `per_ip_rps = 50` means a client can send 100 requests ins
 
 **Critical for correct IP detection in production.**
 
-Gordon is a reverse proxy that routes requests to your containers, but it **does not handle TLS termination**. For HTTPS support, you must place Gordon behind a TLS-terminating proxy like Cloudflare, nginx, or a load balancer.
+Gordon is a reverse proxy that routes requests to your containers. In production you can either terminate TLS directly in Gordon (`server.tls_enabled = true`) or place it behind a TLS-terminating proxy like Cloudflare, nginx, or a load balancer.
 
 ```
 Internet → [Cloudflare/nginx] → Gordon → Containers

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -11,6 +11,10 @@ Complete configuration reference with all options and their default values.
 [server]
 port = 80                                    # HTTP proxy port
 registry_port = 5000                         # Container registry port
+tls_enabled = false                          # Enable native HTTPS listener
+tls_port = 443                               # HTTPS proxy port when enabled
+tls_cert_file = ""                           # PEM cert path (auto-generated if empty and TLS enabled)
+tls_key_file = ""                            # PEM key path (auto-generated if empty and TLS enabled)
 gordon_domain = ""                           # Required: Gordon domain (registry + API)
 data_dir = "~/.gordon"                       # Data directory (varies by install type)
 max_blob_chunk_size = "512MB"                # Max size per registry blob upload chunk
@@ -124,6 +128,10 @@ preserve = true                              # Keep volumes when containers are 
 |---------|---------|-------------|
 | `server.port` | `80` | HTTP proxy port |
 | `server.registry_port` | `5000` | Container registry port |
+| `server.tls_enabled` | `false` | Enable native HTTPS listener |
+| `server.tls_port` | `443` | HTTPS listener port |
+| `server.tls_cert_file` | `""` | TLS cert path (auto-generated when empty) |
+| `server.tls_key_file` | `""` | TLS key path (auto-generated when empty) |
 | `server.gordon_domain` | `""` | **Required** - Gordon domain |
 | `server.data_dir` | `~/.gordon` | Data directory |
 | `server.max_blob_chunk_size` | `"512MB"` | Max size per registry blob upload chunk |

--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -8,6 +8,10 @@ Core server settings for Gordon.
 [server]
 port = 8080                              # HTTP proxy port
 registry_port = 5000                     # Container registry port
+tls_enabled = false                      # Enable native TLS listener
+tls_port = 443                           # HTTPS listener port
+tls_cert_file = ""                       # PEM certificate file (required when TLS enabled)
+tls_key_file = ""                        # PEM key file (required when TLS enabled)
 gordon_domain = "gordon.mydomain.com"    # Gordon domain (required)
 # data_dir = "~/.gordon"                 # Data storage directory (default)
 ```
@@ -18,6 +22,10 @@ gordon_domain = "gordon.mydomain.com"    # Gordon domain (required)
 |--------|------|---------|-------------|
 | `port` | int | `80` | HTTP proxy port for routing traffic to containers |
 | `registry_port` | int | `5000` | Docker registry port for image push/pull |
+| `tls_enabled` | bool | `false` | Enable native HTTPS listener for proxy traffic |
+| `tls_port` | int | `443` | HTTPS listener port when `tls_enabled` is true |
+| `tls_cert_file` | string | `""` | Path to PEM certificate file |
+| `tls_key_file` | string | `""` | Path to PEM private key file |
 | `gordon_domain` | string | **required** | Domain for Gordon (registry + admin API) |
 | `registry_domain` | string | - | Deprecated alias for `gordon_domain` |
 | `data_dir` | string | `~/.gordon` | Directory for registry data, logs, and env files |
@@ -41,6 +49,24 @@ For rootless containers, you'll typically use a high port and configure firewall
 # Forward port 80 to 8080
 sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8080
 ```
+
+### Native TLS Listener
+
+Enable native HTTPS directly in Gordon:
+
+```toml
+[server]
+tls_enabled = true
+tls_port = 443
+tls_cert_file = "/etc/gordon/certs/fullchain.pem"
+tls_key_file = "/etc/gordon/certs/privkey.pem"
+```
+
+With TLS enabled:
+- Gordon terminates HTTPS on `tls_port`
+- Host-based routing still works (apps, `/v2/*`, `/auth/*`, `/admin/*`)
+- `port` remains available for plain HTTP unless you restrict it externally
+- If `tls_cert_file`/`tls_key_file` are empty, Gordon auto-generates a self-signed pair in `{data_dir}/tls/`
 
 ### Registry Port
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Gordon runs on your VPS and provides:
 - Domain pointing to your server
 - Cloudflare account for HTTPS (free tier works)
 
-> **Note:** Gordon does not handle TLS certificates directly. HTTPS is terminated by Cloudflare (or similar proxy) which forwards HTTP traffic to Gordon internally.
+> **Note:** Gordon can run behind Cloudflare/nginx, or terminate TLS directly when `server.tls_enabled = true`.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Add `server.tls_enabled`, `tls_port`, `tls_cert_file`, `tls_key_file` config options for native HTTPS termination
- Auto-generate self-signed ECDSA certificate when TLS is enabled but no cert/key paths are provided
- Start a dedicated TLS server alongside the existing HTTP proxy, sharing the same proxy handler
- Update docs (server, reference, rate-limiting, index) to reflect native TLS capability

## Test plan
- [ ] Verify Gordon starts with `tls_enabled = true` and custom cert/key
- [ ] Verify auto-generated self-signed cert when cert/key paths are empty
- [ ] Verify HTTPS routing works for apps, registry, and admin endpoints
- [ ] Verify HTTP listener still works alongside TLS
- [ ] Verify existing behavior unchanged when `tls_enabled = false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native TLS/HTTPS support with configurable port and certificate management
  * Auto-generates self-signed certificates when TLS is enabled but certificates are not provided

* **Documentation**
  * Updated deployment guidance to clarify TLS termination can occur either directly in the application or behind a reverse proxy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->