### PR TITLE
feat(registry): add IP/CIDR allowlist for registry access control

### DIFF
--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -18,6 +18,7 @@ tls_key_file = ""                            # PEM key path (auto-generated if e
 gordon_domain = ""                           # Required: Gordon domain (registry + API)
 data_dir = "~/.gordon"                       # Data directory (varies by install type)
 max_blob_chunk_size = "512MB"                # Max size per registry blob upload chunk
+registry_allowed_ips = []                    # IPs or CIDR ranges allowed to access the registry (empty = allow all)
 
 # =============================================================================
 # AUTHENTICATION (required - Gordon won't start without credentials configured)
@@ -135,6 +136,7 @@ preserve = true                              # Keep volumes when containers are 
 | `server.gordon_domain` | `""` | **Required** - Gordon domain |
 | `server.data_dir` | `~/.gordon` | Data directory |
 | `server.max_blob_chunk_size` | `"512MB"` | Max size per registry blob upload chunk |
+| `server.registry_allowed_ips` | `[]` | IPs or CIDR ranges allowed to access the registry (empty = allow all) |
 | `auth.enabled` | `true` | Enable authentication |
 | `auth.secrets_backend` | `"unsafe"` | Secrets storage |
 | `auth.token_expiry` | `"720h"` | 30 days |

--- a/internal/adapters/in/http/middleware/cidr.go
+++ b/internal/adapters/in/http/middleware/cidr.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+
+	"github.com/bnema/zerowrap"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+)
+
+// localhostNets contains IPv4 and IPv6 loopback ranges that are always allowed.
+var localhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
+
+// RegistryCIDRAllowlist returns middleware that restricts access to the given CIDR ranges.
+// Localhost is always allowed so Gordon can pull from its own registry.
+// An empty allowedNets slice is a no-op (all traffic passes through).
+func RegistryCIDRAllowlist(allowedNets, trustedNets []*net.IPNet, log zerowrap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if len(allowedNets) == 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clientIP := GetClientIP(r, trustedNets)
+
+			// Always allow localhost — Gordon must reach its own registry.
+			if IsTrustedProxy(clientIP, localhostNets) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if IsTrustedProxy(clientIP, allowedNets) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			log.Warn().
+				Str(zerowrap.FieldLayer, "adapter").
+				Str(zerowrap.FieldAdapter, "http").
+				Str(zerowrap.FieldMethod, r.Method).
+				Str(zerowrap.FieldPath, r.URL.Path).
+				Str(zerowrap.FieldClientIP, clientIP).
+				Msg("registry access denied by CIDR allowlist")
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(dto.ErrorResponse{Error: "Forbidden"})
+		})
+	}
+}

--- a/internal/adapters/in/http/middleware/cidr_test.go
+++ b/internal/adapters/in/http/middleware/cidr_test.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryCIDRAllowlist(t *testing.T) {
+	log := testLogger()
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name        string
+		allowedNets []*net.IPNet
+		trustedNets []*net.IPNet
+		remoteAddr  string
+		xff         string
+		wantStatus  int
+	}{
+		{
+			name:        "no CIDRs configured passes through",
+			allowedNets: nil,
+			remoteAddr:  "203.0.113.50:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "empty CIDRs passes through",
+			allowedNets: []*net.IPNet{},
+			remoteAddr:  "203.0.113.50:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "allowed IP returns 200",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			remoteAddr:  "100.100.1.1:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "denied IP returns 403",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			remoteAddr:  "203.0.113.50:1234",
+			wantStatus:  http.StatusForbidden,
+		},
+		{
+			name:        "localhost always allowed even when not in allowlist",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			remoteAddr:  "127.0.0.1:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "127.x.x.x always allowed",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			remoteAddr:  "127.0.0.2:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "IPv6 localhost always allowed",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			remoteAddr:  "[::1]:1234",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "trusted proxy forwards allowed client IP",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			trustedNets: ParseTrustedProxies([]string{"10.0.0.1"}),
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         "100.100.1.1",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "trusted proxy forwards denied client IP",
+			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			trustedNets: ParseTrustedProxies([]string{"10.0.0.1"}),
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         "203.0.113.50",
+			wantStatus:  http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := RegistryCIDRAllowlist(tt.allowedNets, tt.trustedNets, log)(ok)
+
+			req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code)
+
+			if tt.wantStatus == http.StatusForbidden {
+				var errResp dto.ErrorResponse
+				require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+				assert.Equal(t, "Forbidden", errResp.Error)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `server.registry_allowed_ips` config field accepts individual IPs and CIDR ranges
- New `RegistryCIDRAllowlist` middleware denies non-matching requests with 403 before rate limiting/auth
- Localhost (`127.0.0.0/8`, `::1`) is always allowed so Gordon can pull from its own registry
- Empty allowlist = allow all (backward compatible, no behavior change by default)
- Applied to both `/v2/*` and `/auth/*` endpoints

## Config example
```toml
[server]
registry_allowed_ips = ["100.64.0.0/10", "203.0.113.50"]
```

## Test plan
- [x] 7 table-driven tests covering: nil/empty CIDRs, allowed IP, denied IP, localhost IPv4/IPv6
- [x] `go build ./...` compiles
- [x] `go test ./internal/...` all pass
- [x] `go fmt` applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry access can now be restricted by IP address or CIDR range via the new `registry_allowed_ips` configuration option. Localhost is always allowed; non-allowlisted requests return 403 Forbidden.

* **Documentation**
  * Configuration reference and examples added for the new `registry_allowed_ips` option, including TOML samples and common use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->