### PR TITLE
Harden auth secret handling and admin caching

### DIFF
--- a/internal/adapters/in/http/admin/middleware.go
+++ b/internal/adapters/in/http/admin/middleware.go
@@ -106,6 +106,11 @@ func AuthMiddleware(
 			ctx = context.WithValue(ctx, domain.ContextKeySubject, claims.Subject)
 			ctx = context.WithValue(ctx, domain.TokenClaimsKey, claims)
 
+			// Prevent intermediaries from storing admin API responses, especially
+			// when a rotated bearer token is returned in X-Gordon-Token.
+			w.Header().Set("Cache-Control", "no-store")
+			w.Header().Set("Pragma", "no-cache")
+
 			// Attempt to slide token expiry. Non-fatal if it fails.
 			// The new token is returned in X-Gordon-Token so the CLI can persist it atomically.
 			if newToken, extErr := authSvc.ExtendToken(ctx, token); extErr != nil {
@@ -163,6 +168,8 @@ func HasAccess(ctx context.Context, resource, action string) bool {
 
 func sendUnauthorized(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="gordon-admin"`)
 	w.WriteHeader(http.StatusUnauthorized)
 	_ = json.NewEncoder(w).Encode(dto.ErrorResponse{Error: message})
@@ -170,6 +177,8 @@ func sendUnauthorized(w http.ResponseWriter, message string) {
 
 func sendForbidden(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusForbidden)
 	_ = json.NewEncoder(w).Encode(dto.ErrorResponse{Error: message})
 }

--- a/internal/adapters/in/http/admin/middleware_test.go
+++ b/internal/adapters/in/http/admin/middleware_test.go
@@ -181,6 +181,8 @@ func TestAuthMiddleware_MissingAuthHeader(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, rec.Body.String(), "missing authorization header")
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Pragma"))
 }
 
 func TestAuthMiddleware_InvalidToken(t *testing.T) {
@@ -390,6 +392,8 @@ func TestAuthMiddleware_ExtendTokenFailureIsNonFatal(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Empty(t, rec.Header().Get("X-Gordon-Token"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Pragma"))
 }
 
 func TestAuthMiddleware_ExtendTokenRotationHeader(t *testing.T) {
@@ -417,6 +421,8 @@ func TestAuthMiddleware_ExtendTokenRotationHeader(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "rotated-token", rec.Header().Get("X-Gordon-Token"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Pragma"))
 }
 
 func TestHasAccess(t *testing.T) {

--- a/internal/adapters/out/domainsecrets/store_test.go
+++ b/internal/adapters/out/domainsecrets/store_test.go
@@ -101,7 +101,7 @@ func TestFileStore_PathContainment(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify file exists inside tmpDir
-	expectedFile := filepath.Join(tmpDir, "example_com.env")
+	expectedFile := filepath.Join(tmpDir, "example__com.env")
 	_, err = os.Stat(expectedFile)
 	assert.NoError(t, err, "expected env file to exist at %s", expectedFile)
 
@@ -114,6 +114,24 @@ func TestFileStore_PathContainment(t *testing.T) {
 			assert.NotContains(t, entry, ".env", "unexpected .env file outside tmpDir: %s", entry)
 		}
 	}
+}
+
+func TestFileStore_DistinctDomainsUseDistinctFiles(t *testing.T) {
+	store, err := NewFileStore(t.TempDir(), testLogger())
+	require.NoError(t, err)
+
+	dotPath, err := store.validateEnvFilePath("app.example.com")
+	require.NoError(t, err)
+
+	portPath, err := store.validateEnvFilePath("app:example:com")
+	require.NoError(t, err)
+
+	pathPath, err := store.validateEnvFilePath("app/example/com")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, dotPath, portPath)
+	assert.NotEqual(t, dotPath, pathPath)
+	assert.NotEqual(t, portPath, pathPath)
 }
 
 func TestSanitizeDomainForContainer(t *testing.T) {
@@ -389,10 +407,10 @@ func TestGetEnvFilePath(t *testing.T) {
 		wantEmpty    bool
 		wantFilename string
 	}{
-		{"example.com", false, "example_com.env"},
-		{"sub.example.com", false, "sub_example_com.env"},
-		{"example.com:8080", false, "example_com_8080.env"},
-		{"example.com/path", false, "example_com_path.env"},
+		{"example.com", false, "example__com.env"},
+		{"sub.example.com", false, "sub__example__com.env"},
+		{"example.com:8080", false, "example__com-_8080.env"},
+		{"example.com/path", false, "example__com--path.env"},
 		{"../evil", true, ""},
 		{"", true, ""},
 	}

--- a/internal/adapters/out/envloader/file.go
+++ b/internal/adapters/out/envloader/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/boundaries/out"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // FileLoader implements the EnvLoader interface using filesystem-based env files.
@@ -222,10 +223,10 @@ func (l *FileLoader) resolveSecrets(ctx context.Context, value string) (string, 
 	return result, nil
 }
 
-func (l *FileLoader) getEnvFilePath(domain string) string {
-	// Create domain-safe filename (replace dots and other chars with underscores)
-	safeDomain := strings.ReplaceAll(domain, ".", "_")
-	safeDomain = strings.ReplaceAll(safeDomain, ":", "_")
-	safeDomain = strings.ReplaceAll(safeDomain, "/", "_")
+func (l *FileLoader) getEnvFilePath(domainName string) string {
+	safeDomain, err := domain.SanitizeDomainForEnvFile(domainName)
+	if err != nil {
+		return filepath.Join(l.envDir, domainName+".env")
+	}
 	return filepath.Join(l.envDir, safeDomain+".env")
 }

--- a/internal/adapters/out/envloader/file_test.go
+++ b/internal/adapters/out/envloader/file_test.go
@@ -121,7 +121,7 @@ func TestFileLoader_LoadEnv(t *testing.T) {
 NODE_ENV=production
 API_URL=https://api.example.com
 `
-		envFile := filepath.Join(tmpDir, "app_example_com.env")
+		envFile := filepath.Join(tmpDir, "app__example__com.env")
 		require.NoError(t, os.WriteFile(envFile, []byte(envContent), 0600))
 
 		envVars, err := loader.LoadEnv(ctx, "app.example.com")
@@ -146,7 +146,7 @@ API_URL=https://api.example.com
 		envContent := `NODE_ENV=production
 API_KEY=${pass:app/api-key}
 `
-		envFile := filepath.Join(tmpDir, "app_example_com.env")
+		envFile := filepath.Join(tmpDir, "app__example__com.env")
 		require.NoError(t, os.WriteFile(envFile, []byte(envContent), 0600))
 
 		envVars, err := loader.LoadEnv(ctx, "app.example.com")
@@ -164,7 +164,7 @@ API_KEY=${pass:app/api-key}
 		envContent := `DOUBLE_QUOTED="hello world"
 SINGLE_QUOTED='hello world'
 `
-		envFile := filepath.Join(tmpDir, "app_example_com.env")
+		envFile := filepath.Join(tmpDir, "app__example__com.env")
 		require.NoError(t, os.WriteFile(envFile, []byte(envContent), 0600))
 
 		envVars, err := loader.LoadEnv(ctx, "app.example.com")
@@ -183,7 +183,7 @@ SINGLE_QUOTED='hello world'
 invalid line without equals
 ALSO_VALID=another
 `
-		envFile := filepath.Join(tmpDir, "app_example_com.env")
+		envFile := filepath.Join(tmpDir, "app__example__com.env")
 		require.NoError(t, os.WriteFile(envFile, []byte(envContent), 0600))
 
 		envVars, err := loader.LoadEnv(ctx, "app.example.com")
@@ -205,9 +205,9 @@ func TestFileLoader_GetEnvFilePath(t *testing.T) {
 		domain   string
 		expected string
 	}{
-		{"app.example.com", "app_example_com.env"},
-		{"api.sub.example.com", "api_sub_example_com.env"},
-		{"localhost:8080", "localhost_8080.env"},
+		{"app.example.com", "app__example__com.env"},
+		{"api.sub.example.com", "api__sub__example__com.env"},
+		{"localhost:8080", "localhost-_8080.env"},
 	}
 
 	for _, tt := range tests {
@@ -216,4 +216,20 @@ func TestFileLoader_GetEnvFilePath(t *testing.T) {
 			assert.Equal(t, filepath.Join(tmpDir, tt.expected), result)
 		})
 	}
+}
+
+func TestFileLoader_GetEnvFilePath_DistinguishesSeparators(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+
+	loader, err := NewFileLoader(tmpDir, log)
+	require.NoError(t, err)
+
+	dotPath := loader.getEnvFilePath("app.example.com")
+	portPath := loader.getEnvFilePath("app:example:com")
+	slashPath := loader.getEnvFilePath("app/example/com")
+
+	assert.NotEqual(t, dotPath, portPath)
+	assert.NotEqual(t, dotPath, slashPath)
+	assert.NotEqual(t, portPath, slashPath)
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -585,7 +585,10 @@ func setupInternalRegistryAuth(svc *services, log zerowrap.Logger) error {
 
 func createDomainSecretStore(cfg Config, log zerowrap.Logger) (string, domain.SecretsBackend, *domainsecrets.PassStore, out.DomainSecretStore, error) {
 	envDir := resolveEnvDir(cfg)
-	backend := resolveSecretsBackend(cfg.Auth.SecretsBackend)
+	backend, err := resolveSecretsBackend(cfg.Auth.SecretsBackend)
+	if err != nil {
+		return "", "", nil, nil, log.WrapErr(err, "failed to resolve secrets backend")
+	}
 
 	switch backend {
 	case domain.SecretsBackendPass:
@@ -896,7 +899,10 @@ func createAuthService(ctx context.Context, cfg Config, log zerowrap.Logger) (ou
 	}
 
 	authType := resolveAuthType(cfg)
-	backend := resolveSecretsBackend(cfg.Auth.SecretsBackend)
+	backend, err := resolveSecretsBackend(cfg.Auth.SecretsBackend)
+	if err != nil {
+		return nil, nil, log.WrapErr(err, "failed to resolve secrets backend")
+	}
 	dataDir := resolveDataDir(cfg.Server.DataDir)
 
 	store, err := createTokenStore(backend, dataDir, log)
@@ -941,16 +947,18 @@ func resolveAuthType(cfg Config) domain.AuthType {
 	return domain.AuthTypeToken
 }
 
-func resolveSecretsBackend(backend string) domain.SecretsBackend {
+func resolveSecretsBackend(backend string) (domain.SecretsBackend, error) {
 	switch backend {
 	case "pass":
-		return domain.SecretsBackendPass
+		return domain.SecretsBackendPass, nil
 	case "sops":
-		return domain.SecretsBackendSops
-	case "unsafe", "":
-		return domain.SecretsBackendUnsafe
+		return domain.SecretsBackendSops, nil
+	case "unsafe":
+		return domain.SecretsBackendUnsafe, nil
+	case "":
+		return "", fmt.Errorf("auth.secrets_backend is required")
 	default:
-		return domain.SecretsBackendUnsafe
+		return "", fmt.Errorf("unsupported auth.secrets_backend %q", backend)
 	}
 }
 

--- a/internal/app/run_auth_config_test.go
+++ b/internal/app/run_auth_config_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/bnema/gordon/internal/domain"
@@ -21,5 +22,25 @@ func TestBuildAuthConfig_UsesConfigEnabledFlag(t *testing.T) {
 	}
 	if authCfg.Enabled {
 		t.Fatalf("expected auth config enabled=false, got true")
+	}
+}
+
+func TestResolveSecretsBackend_RejectsMissingBackend(t *testing.T) {
+	_, err := resolveSecretsBackend("")
+	if err == nil {
+		t.Fatal("expected error for missing secrets backend")
+	}
+	if !strings.Contains(err.Error(), "auth.secrets_backend is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveSecretsBackend_RejectsUnknownBackend(t *testing.T) {
+	_, err := resolveSecretsBackend("vault")
+	if err == nil {
+		t.Fatal("expected error for unsupported secrets backend")
+	}
+	if !strings.Contains(err.Error(), `unsupported auth.secrets_backend "vault"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/domain/env.go
+++ b/internal/domain/env.go
@@ -9,13 +9,15 @@ import (
 
 // envDomainRegex validates domain names used for env secrets.
 // Allows: alphanumeric, dots, hyphens, colons (for ports), and forward slashes (for paths).
-var envDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:/-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
+// Underscores are intentionally disallowed because they would collide with the
+// on-disk filename encoding used for dots/ports/path separators.
+var envDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.:/-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$`)
 var envKeyRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var containerNameRegex = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
 
 // SanitizeDomainForEnvFile validates and sanitizes a domain name for env file storage.
 // Returns a safe domain string suitable for filenames.
-// This function is idempotent: calling it on already-sanitized input returns the same value.
+// Uses distinct replacements to avoid collisions between ".", ":", and "/".
 func SanitizeDomainForEnvFile(domainName string) (string, error) {
 	if domainName == "" {
 		return "", ErrPathTraversal
@@ -29,9 +31,9 @@ func SanitizeDomainForEnvFile(domainName string) (string, error) {
 		return "", ErrPathTraversal
 	}
 
-	safeDomain := strings.ReplaceAll(domainName, ".", "_")
-	safeDomain = strings.ReplaceAll(safeDomain, ":", "_")
-	safeDomain = strings.ReplaceAll(safeDomain, "/", "_")
+	safeDomain := strings.ReplaceAll(domainName, ".", "__")
+	safeDomain = strings.ReplaceAll(safeDomain, ":", "-_")
+	safeDomain = strings.ReplaceAll(safeDomain, "/", "--")
 	return safeDomain, nil
 }
 

--- a/internal/domain/env_test.go
+++ b/internal/domain/env_test.go
@@ -15,12 +15,12 @@ func TestSanitizeDomainForEnvFile(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{name: "simple domain", domain: "example.com", want: "example_com"},
-		{name: "subdomain", domain: "app.example.com", want: "app_example_com"},
-		{name: "domain with port", domain: "example.com:8080", want: "example_com_8080"},
-		{name: "domain with path", domain: "example.com/path", want: "example_com_path"},
+		{name: "simple domain", domain: "example.com", want: "example__com"},
+		{name: "subdomain", domain: "app.example.com", want: "app__example__com"},
+		{name: "domain with port", domain: "example.com:8080", want: "example__com-_8080"},
+		{name: "domain with path", domain: "example.com/path", want: "example__com--path"},
 		{name: "single char", domain: "a", want: "a"},
-		{name: "hyphenated", domain: "my-app.example.com", want: "my-app_example_com"},
+		{name: "hyphenated", domain: "my-app.example.com", want: "my-app__example__com"},
 		{name: "empty", domain: "", wantErr: true},
 		{name: "path traversal", domain: "../etc/passwd", wantErr: true},
 		{name: "double dots", domain: "foo..bar", wantErr: true},
@@ -28,8 +28,7 @@ func TestSanitizeDomainForEnvFile(t *testing.T) {
 		{name: "ends with dot", domain: "trailing.", wantErr: true},
 		{name: "space", domain: "has space", wantErr: true},
 		{name: "special chars", domain: "bad$domain", wantErr: true},
-		{name: "idempotent simple", domain: "example_com", want: "example_com"},
-		{name: "idempotent complex", domain: "my-app_example_com_8080", want: "my-app_example_com_8080"},
+		{name: "underscore rejected to avoid filename collision", domain: "example_com", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -43,6 +42,21 @@ func TestSanitizeDomainForEnvFile(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSanitizeDomainForEnvFile_DistinguishesSeparators(t *testing.T) {
+	gotDot, err := SanitizeDomainForEnvFile("app.example.com")
+	require.NoError(t, err)
+
+	gotPort, err := SanitizeDomainForEnvFile("app:example:com")
+	require.NoError(t, err)
+
+	gotPath, err := SanitizeDomainForEnvFile("app/example/com")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, gotDot, gotPort)
+	assert.NotEqual(t, gotDot, gotPath)
+	assert.NotEqual(t, gotPort, gotPath)
 }
 
 func TestParseEnvData(t *testing.T) {

--- a/internal/usecase/container/autoroute.go
+++ b/internal/usecase/container/autoroute.go
@@ -468,10 +468,10 @@ func parseEnvFile(data []byte) (map[string]string, error) {
 // e.g., "app.mydomain.com" -> "app_mydomain_com.env"
 // Must match the naming convention in envloader.FileLoader.getEnvFilePath
 func domainToEnvFileName(domainName string) string {
-	// Replace special characters with underscores (matches envloader)
-	name := strings.ReplaceAll(domainName, ".", "_")
-	name = strings.ReplaceAll(name, ":", "_")
-	name = strings.ReplaceAll(name, "/", "_")
+	name, err := domain.SanitizeDomainForEnvFile(domainName)
+	if err != nil {
+		return domainName + ".env"
+	}
 	return name + ".env"
 }
 

--- a/internal/usecase/container/autoroute_test.go
+++ b/internal/usecase/container/autoroute_test.go
@@ -28,22 +28,22 @@ func TestDomainToEnvFileName(t *testing.T) {
 		{
 			name:     "simple domain",
 			domain:   "app.example.com",
-			expected: "app_example_com.env",
+			expected: "app__example__com.env",
 		},
 		{
 			name:     "domain with port",
 			domain:   "app.example.com:8080",
-			expected: "app_example_com_8080.env",
+			expected: "app__example__com-_8080.env",
 		},
 		{
 			name:     "domain with path",
 			domain:   "app.example.com/api",
-			expected: "app_example_com_api.env",
+			expected: "app__example__com--api.env",
 		},
 		{
 			name:     "complex domain",
 			domain:   "sub.app.example.com:443/v1",
-			expected: "sub_app_example_com_443_v1.env",
+			expected: "sub__app__example__com-_443--v1.env",
 		},
 		{
 			name:     "single word",

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -278,24 +278,30 @@ func resolveContainerName(domainName, service string) string {
 
 // ValidateDomain validates that a domain is safe to use for secret storage.
 // This prevents path traversal attacks and ensures the domain is valid.
-func ValidateDomain(domain string) error {
+func ValidateDomain(domainName string) error {
 	// Check for empty domain
-	if domain == "" {
+	if domainName == "" {
 		return ErrDomainEmpty
 	}
 
 	// Check domain length (max DNS name length is 253)
-	if len(domain) > 253 {
+	if len(domainName) > 253 {
 		return ErrDomainTooLong
 	}
 
 	// Check for path traversal attempts
-	if strings.Contains(domain, "..") {
+	if strings.Contains(domainName, "..") {
 		return ErrDomainPathTraversal
 	}
 
 	// Check for null bytes (can cause issues in file paths)
-	if strings.ContainsRune(domain, '\x00') {
+	if strings.ContainsRune(domainName, '\x00') {
+		return ErrDomainInvalidChars
+	}
+
+	// Reuse the env-file sanitizer so validation matches the on-disk naming
+	// scheme and rejects ambiguous names that would collide after sanitization.
+	if _, err := domain.SanitizeDomainForEnvFile(domainName); err != nil {
 		return ErrDomainInvalidChars
 	}
 

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -108,6 +108,11 @@ func TestValidateDomain(t *testing.T) {
 			domain:  "\x00example.com",
 			wantErr: ErrDomainInvalidChars,
 		},
+		{
+			name:    "underscore rejected to avoid env filename collision",
+			domain:  "app_example.com",
+			wantErr: ErrDomainInvalidChars,
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,6 +124,12 @@ func TestValidateDomain(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestValidateDomain_DistinguishesSeparatorsForEnvStorage(t *testing.T) {
+	for _, domain := range []string{"app.example.com", "app:example:com", "app/example/com"} {
+		assert.NoError(t, ValidateDomain(domain), "expected %q to remain valid", domain)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fail closed when auth.secrets_backend is missing or invalid instead of silently falling back to the unsafe backend
- add no-store cache headers to admin auth responses, including rotated token responses
- make env secret file naming collision-resistant and align validation/autoroute with the same mapping

## Testing
- go test ./...
- added targeted unit coverage for backend validation, admin cache headers, and env-file naming collisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added cache-control headers to admin responses to enhance security and prevent unauthorized caching of sensitive data
  * Strengthened domain validation to reject invalid characters and improve system reliability
  * Improved error reporting for missing or unsupported authentication backend configurations during startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->