### PR TITLE
feat: rotate config backups with timestamped names, keep only 5 most recent

### DIFF
--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -575,7 +576,7 @@ func backupConfigFile(configFile string) error {
 		return fmt.Errorf("failed to read config for backup: %w", err)
 	}
 
-	backupPath := fmt.Sprintf("%s.bak.%d", configFile, time.Now().Unix())
+	backupPath := fmt.Sprintf("%s.bak.%d", configFile, time.Now().UnixNano())
 	if err := os.WriteFile(backupPath, src, 0600); err != nil {
 		return fmt.Errorf("failed to write backup config: %w", err)
 	}
@@ -587,7 +588,7 @@ func backupConfigFile(configFile string) error {
 }
 
 // cleanupOldBackups removes old backup files, keeping only the most recent `keep` backups.
-// It only removes files matching the pattern `<configFile>.bak.<timestamp>`.
+// It only removes files matching the pattern `<configFile>.bak.<numeric-timestamp>`.
 func cleanupOldBackups(configFile string, keep int) error {
 	dir := filepath.Dir(configFile)
 	base := filepath.Base(configFile)
@@ -597,18 +598,29 @@ func cleanupOldBackups(configFile string, keep int) error {
 	}
 
 	prefix := base + ".bak."
-	backups := make([]string, 0)
+	type tsBackup struct {
+		ts   int64
+		name string
+	}
+	var backups []tsBackup
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		if strings.HasPrefix(entry.Name(), prefix) {
-			backups = append(backups, entry.Name())
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
 		}
+		suffix := strings.TrimPrefix(name, prefix)
+		ts, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil {
+			continue
+		}
+		backups = append(backups, tsBackup{ts: ts, name: name})
 	}
 
-	slices.SortFunc(backups, func(a, b string) int {
-		return cmp.Compare(b, a)
+	slices.SortFunc(backups, func(a, b tsBackup) int {
+		return cmp.Compare(b.ts, a.ts)
 	})
 	if len(backups) <= keep {
 		return nil
@@ -616,7 +628,7 @@ func cleanupOldBackups(configFile string, keep int) error {
 
 	var firstErr error
 	for _, backup := range backups[keep:] {
-		backupPath := filepath.Join(dir, backup)
+		backupPath := filepath.Join(dir, backup.name)
 		if err := os.Remove(backupPath); err != nil && firstErr == nil {
 			firstErr = fmt.Errorf("failed to remove old backup %s: %w", backupPath, err)
 		}
@@ -634,23 +646,34 @@ func restoreConfigBackup(configFile string) error {
 	}
 
 	prefix := base + ".bak."
-	backups := make([]string, 0)
+	type tsBackup struct {
+		ts   int64
+		name string
+	}
+	var backups []tsBackup
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-		if strings.HasPrefix(entry.Name(), prefix) {
-			backups = append(backups, entry.Name())
+		name := entry.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
 		}
+		suffix := strings.TrimPrefix(name, prefix)
+		ts, err := strconv.ParseInt(suffix, 10, 64)
+		if err != nil {
+			continue
+		}
+		backups = append(backups, tsBackup{ts: ts, name: name})
 	}
 
-	slices.SortFunc(backups, func(a, b string) int {
-		return cmp.Compare(b, a)
+	slices.SortFunc(backups, func(a, b tsBackup) int {
+		return cmp.Compare(b.ts, a.ts)
 	})
 
 	backupPath := configFile + ".bak"
 	if len(backups) > 0 {
-		backupPath = filepath.Join(dir, backups[0])
+		backupPath = filepath.Join(dir, backups[0].name)
 	}
 
 	src, err := os.ReadFile(backupPath)

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -2,10 +2,13 @@
 package config
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -572,16 +575,84 @@ func backupConfigFile(configFile string) error {
 		return fmt.Errorf("failed to read config for backup: %w", err)
 	}
 
-	backupPath := configFile + ".bak"
+	backupPath := fmt.Sprintf("%s.bak.%d", configFile, time.Now().Unix())
 	if err := os.WriteFile(backupPath, src, 0600); err != nil {
 		return fmt.Errorf("failed to write backup config: %w", err)
+	}
+	if err := cleanupOldBackups(configFile, 5); err != nil {
+		return fmt.Errorf("failed to clean up old backups: %w", err)
 	}
 
 	return nil
 }
 
+// cleanupOldBackups removes old backup files, keeping only the most recent `keep` backups.
+// It only removes files matching the pattern `<configFile>.bak.<timestamp>`.
+func cleanupOldBackups(configFile string, keep int) error {
+	dir := filepath.Dir(configFile)
+	base := filepath.Base(configFile)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	prefix := base + ".bak."
+	backups := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), prefix) {
+			backups = append(backups, entry.Name())
+		}
+	}
+
+	slices.SortFunc(backups, func(a, b string) int {
+		return cmp.Compare(b, a)
+	})
+	if len(backups) <= keep {
+		return nil
+	}
+
+	var firstErr error
+	for _, backup := range backups[keep:] {
+		backupPath := filepath.Join(dir, backup)
+		if err := os.Remove(backupPath); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("failed to remove old backup %s: %w", backupPath, err)
+		}
+	}
+
+	return firstErr
+}
+
 func restoreConfigBackup(configFile string) error {
+	dir := filepath.Dir(configFile)
+	base := filepath.Base(configFile)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read backup directory: %w", err)
+	}
+
+	prefix := base + ".bak."
+	backups := make([]string, 0)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), prefix) {
+			backups = append(backups, entry.Name())
+		}
+	}
+
+	slices.SortFunc(backups, func(a, b string) int {
+		return cmp.Compare(b, a)
+	})
+
 	backupPath := configFile + ".bak"
+	if len(backups) > 0 {
+		backupPath = filepath.Join(dir, backups[0])
+	}
+
 	src, err := os.ReadFile(backupPath)
 	if err != nil {
 		return fmt.Errorf("failed to read backup: %w", err)

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1248,8 +1249,9 @@ backend = ["app.example.com"]
 		assert.Equal(t, "newapp:latest", savedRoutes["new.example.com"])
 		assert.Equal(t, "reg.example.com/myapp:latest", savedRoutes["app.example.com"])
 
-		_, err = os.Stat(configFile + ".bak")
-		assert.NoError(t, err)
+		matches, err := filepath.Glob(configFile + ".bak.*")
+		require.NoError(t, err)
+		assert.NotEmpty(t, matches)
 	})
 
 	t.Run("backup created before write", func(t *testing.T) {
@@ -1279,10 +1281,53 @@ port = 9999
 		err = svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Image: "newapp:latest"})
 		require.NoError(t, err)
 
-		backupData, err := os.ReadFile(configFile + ".bak")
+		matches, err := filepath.Glob(configFile + ".bak.*")
+		require.NoError(t, err)
+		require.NotEmpty(t, matches)
+
+		backupData, err := os.ReadFile(matches[0])
 		require.NoError(t, err)
 		assert.Contains(t, string(backupData), "port = 9999")
 		assert.NotContains(t, string(backupData), "new.example.com")
+	})
+
+	t.Run("old backups are cleaned up keeping 5", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "gordon.toml")
+		initialConfig := `
+[server]
+port = 9999
+
+[routes]
+"app.example.com" = "myapp:latest"
+`
+		err := os.WriteFile(configFile, []byte(initialConfig), 0600)
+		require.NoError(t, err)
+
+		for i := 1000; i < 1007; i++ {
+			backupPath := fmt.Sprintf("%s.bak.%d", configFile, i)
+			err := os.WriteFile(backupPath, []byte("old backup"), 0600)
+			require.NoError(t, err)
+		}
+
+		v := viper.New()
+		v.SetConfigFile(configFile)
+		err = v.ReadInConfig()
+		require.NoError(t, err)
+
+		eventBus := mocks.NewMockEventPublisher(t)
+		svc := NewService(v, eventBus)
+		ctx := testContext()
+		err = svc.Load(ctx)
+		require.NoError(t, err)
+
+		err = svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Image: "newapp:latest"})
+		require.NoError(t, err)
+
+		matches, err := filepath.Glob(configFile + ".bak.*")
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(matches), 5)
+		assert.GreaterOrEqual(t, len(matches), 1)
 	})
 
 	t.Run("network_groups are persisted to disk", func(t *testing.T) {

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -1304,7 +1304,7 @@ port = 9999
 		err := os.WriteFile(configFile, []byte(initialConfig), 0600)
 		require.NoError(t, err)
 
-		for i := 1000; i < 1007; i++ {
+		for i := 1000000000000; i < 1000000000007; i++ {
 			backupPath := fmt.Sprintf("%s.bak.%d", configFile, i)
 			err := os.WriteFile(backupPath, []byte("old backup"), 0600)
 			require.NoError(t, err)
@@ -1326,8 +1326,7 @@ port = 9999
 
 		matches, err := filepath.Glob(configFile + ".bak.*")
 		require.NoError(t, err)
-		assert.LessOrEqual(t, len(matches), 5)
-		assert.GreaterOrEqual(t, len(matches), 1)
+		assert.Equal(t, 5, len(matches))
 	})
 
 	t.Run("network_groups are persisted to disk", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace single-file `.bak` overwrite with timestamped backups (`.bak.<unix>`) and automatic cleanup keeping only the 5 most recent
- Prevent config directory pollution (previously accumulated unlimited backup files)
- `restoreConfigBackup` finds newest `.bak.*` file, falls back to legacy `.bak` for backward compatibility

## Changes
- `backupConfigFile()` — writes `<config>.bak.<unix-timestamp>` instead of overwriting `.bak`
- `cleanupOldBackups()` — new function: scans dir, sorts newest-first, removes excess
- `restoreConfigBackup()` — finds most recent `.bak.*`, falls back to `.bak`
- Updated existing tests + new rotation test (7 pre-existing backups → ≤5 after Save)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration backups now use timestamped filenames and restore prioritizes the newest available backup.
  * Automatic cleanup prunes older backups so only a limited recent set is retained.

* **Tests**
  * Tests updated to detect multiple timestamped backups and verify retention limits after backup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->