### PR TITLE
feat: redeploy containers when route secrets or env change

### DIFF
--- a/internal/adapters/in/cli/local.go
+++ b/internal/adapters/in/cli/local.go
@@ -90,7 +90,7 @@ func GetLocalServices(configPath string) (*LocalServices, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create domain secret store: %w", err)
 	}
-	secretSvc := secretsSvc.NewService(domainSecretStore, log)
+	secretSvc := secretsSvc.NewService(domainSecretStore, log, nil)
 
 	return &LocalServices{
 		configSvc: configSvc,

--- a/internal/app/kernel.go
+++ b/internal/app/kernel.go
@@ -74,7 +74,7 @@ func NewKernel(configPath string) (*Kernel, error) {
 		return nil, fmt.Errorf("failed to create local secret store: %w", err)
 	}
 
-	secretSvc := secretsusecase.NewService(domainSecretStore, log)
+	secretSvc := secretsusecase.NewService(domainSecretStore, log, nil)
 
 	return &Kernel{
 		authEnabled: cfg.Auth.Enabled,

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -273,7 +273,7 @@ func Run(ctx context.Context, configPath string) error {
 	registryHandler, proxyHandler := createHTTPHandlers(svc, cfg, log)
 
 	// Start servers, wait for listeners to bind, then sync/auto-start containers.
-	return runServers(ctx, v, cfg, registryHandler, proxyHandler, svc.containerSvc, svc.eventBus, svc, cleanupHandlers, log)
+	return runServers(ctx, v, cfg, registryHandler, proxyHandler, svc, cleanupHandlers, log)
 }
 
 func ensureTLSConfig(cfg *Config, log zerowrap.Logger) error {
@@ -1329,7 +1329,7 @@ func registerEventHandlers(ctx context.Context, svc *services, cfg Config) (func
 		return nil, fmt.Errorf("failed to subscribe manual deploy handler: %w", err)
 	}
 
-	secretsChangedHandler := container.NewSecretsChangedHandler(ctx, svc.containerSvc, svc.configSvc, 60*time.Second)
+	secretsChangedHandler := container.NewSecretsChangedHandler(ctx, svc.containerSvc, svc.configSvc, container.DefaultSecretsDebounce)
 	if err := svc.eventBus.Subscribe(secretsChangedHandler); err != nil {
 		return nil, fmt.Errorf("failed to subscribe secrets changed handler: %w", err)
 	}
@@ -1701,7 +1701,7 @@ func isLoopbackHost(host string) bool {
 // - SIGUSR2: Triggers manual deploy for a specific route
 // The deferred signal.Stop calls ensure signal handlers are properly
 // cleaned up before program exit, preventing signal handler leaks.
-func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler, proxyHandler http.Handler, containerSvc *container.Service, eventBus out.EventBus, svc *services, cleanupHandlers func(), log zerowrap.Logger) error {
+func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler, proxyHandler http.Handler, svc *services, cleanupHandlers func(), log zerowrap.Logger) error {
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
@@ -1771,9 +1771,9 @@ func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler
 	// Auto-start after servers are listening (registry port is now bound).
 	syncAndAutoStart(ctx, svc, log)
 
-	waitForShutdown(ctx, errChan, reloadChan, deployChan, eventBus, log)
+	waitForShutdown(ctx, errChan, reloadChan, deployChan, svc.eventBus, log)
 	cleanupHandlers() // Stop debounce timers before draining containers
-	gracefulShutdown(registrySrv, proxySrv, tlsSrv, containerSvc, svc.proxySvc, log)
+	gracefulShutdown(registrySrv, proxySrv, tlsSrv, svc.containerSvc, svc.proxySvc, log)
 	return nil
 }
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -253,9 +253,12 @@ func Run(ctx context.Context, configPath string) error {
 	}
 
 	// Register event handlers
-	if err := registerEventHandlers(ctx, svc, cfg); err != nil {
+	cleanupHandlers, err := registerEventHandlers(ctx, svc, cfg)
+	if err != nil {
 		return err
 	}
+	// cleanupHandlers is passed into runServers so it can stop debounce
+	// timers before graceful shutdown, preventing deploys during drain.
 
 	// Set up config hot reload
 	setupConfigHotReload(ctx, v, svc, log)
@@ -270,7 +273,7 @@ func Run(ctx context.Context, configPath string) error {
 	registryHandler, proxyHandler := createHTTPHandlers(svc, cfg, log)
 
 	// Start servers, wait for listeners to bind, then sync/auto-start containers.
-	return runServers(ctx, v, cfg, registryHandler, proxyHandler, svc.containerSvc, svc.eventBus, svc, log)
+	return runServers(ctx, v, cfg, registryHandler, proxyHandler, svc.containerSvc, svc.eventBus, svc, cleanupHandlers, log)
 }
 
 func ensureTLSConfig(cfg *Config, log zerowrap.Logger) error {
@@ -490,7 +493,7 @@ func createServices(ctx context.Context, v *viper.Viper, cfg Config, log zerowra
 		return nil, err
 	}
 
-	svc.secretSvc = secretsSvc.NewService(domainSecretStore, log)
+	svc.secretSvc = secretsSvc.NewService(domainSecretStore, log, svc.eventBus)
 
 	if svc.containerSvc, err = createContainerService(ctx, v, cfg, svc, log); err != nil {
 		return nil, err
@@ -1298,41 +1301,50 @@ func validateBackupRetention(cfg Config) (domain.RetentionPolicy, error) {
 }
 
 // registerEventHandlers registers all event handlers.
-func registerEventHandlers(ctx context.Context, svc *services, cfg Config) error {
+func registerEventHandlers(ctx context.Context, svc *services, cfg Config) (func(), error) {
 	imagePushedHandler := container.NewImagePushedHandler(ctx, svc.containerSvc, svc.configSvc)
 	if err := svc.eventBus.Subscribe(imagePushedHandler); err != nil {
-		return fmt.Errorf("failed to subscribe image pushed handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe image pushed handler: %w", err)
 	}
 
 	// Auto-route handler for creating routes from image labels
 	autoRouteHandler := container.NewAutoRouteHandler(ctx, svc.configSvc, svc.containerSvc, svc.blobStorage, cfg.Server.RegistryDomain).
 		WithEnvExtractor(svc.runtime, svc.envDir)
 	if err := svc.eventBus.Subscribe(autoRouteHandler); err != nil {
-		return fmt.Errorf("failed to subscribe auto-route handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe auto-route handler: %w", err)
 	}
 
 	configReloadHandler := container.NewConfigReloadHandler(ctx, svc.containerSvc, svc.configSvc)
 	if err := svc.eventBus.Subscribe(configReloadHandler); err != nil {
-		return fmt.Errorf("failed to subscribe config reload handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe config reload handler: %w", err)
 	}
 
 	manualReloadHandler := container.NewManualReloadHandler(ctx, svc.containerSvc, svc.configSvc)
 	if err := svc.eventBus.Subscribe(manualReloadHandler); err != nil {
-		return fmt.Errorf("failed to subscribe manual reload handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe manual reload handler: %w", err)
 	}
 
 	manualDeployHandler := container.NewManualDeployHandler(ctx, svc.containerSvc, svc.configSvc)
 	if err := svc.eventBus.Subscribe(manualDeployHandler); err != nil {
-		return fmt.Errorf("failed to subscribe manual deploy handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe manual deploy handler: %w", err)
+	}
+
+	secretsChangedHandler := container.NewSecretsChangedHandler(ctx, svc.containerSvc, svc.configSvc, 60*time.Second)
+	if err := svc.eventBus.Subscribe(secretsChangedHandler); err != nil {
+		return nil, fmt.Errorf("failed to subscribe secrets changed handler: %w", err)
 	}
 
 	// Proxy cache invalidation on config reload (clears stale targets for removed routes)
 	configReloadProxyHandler := proxy.NewConfigReloadProxyHandler(ctx, svc.proxySvc)
 	if err := svc.eventBus.Subscribe(configReloadProxyHandler); err != nil {
-		return fmt.Errorf("failed to subscribe config reload proxy handler: %w", err)
+		return nil, fmt.Errorf("failed to subscribe config reload proxy handler: %w", err)
 	}
 
-	return nil
+	cleanup := func() {
+		secretsChangedHandler.Stop()
+	}
+
+	return cleanup, nil
 }
 
 // setupConfigHotReload sets up Viper config hot reload.
@@ -1689,7 +1701,7 @@ func isLoopbackHost(host string) bool {
 // - SIGUSR2: Triggers manual deploy for a specific route
 // The deferred signal.Stop calls ensure signal handlers are properly
 // cleaned up before program exit, preventing signal handler leaks.
-func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler, proxyHandler http.Handler, containerSvc *container.Service, eventBus out.EventBus, svc *services, log zerowrap.Logger) error {
+func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler, proxyHandler http.Handler, containerSvc *container.Service, eventBus out.EventBus, svc *services, cleanupHandlers func(), log zerowrap.Logger) error {
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
@@ -1760,6 +1772,7 @@ func runServers(ctx context.Context, v *viper.Viper, cfg Config, registryHandler
 	syncAndAutoStart(ctx, svc, log)
 
 	waitForShutdown(ctx, errChan, reloadChan, deployChan, eventBus, log)
+	cleanupHandlers() // Stop debounce timers before draining containers
 	gracefulShutdown(registrySrv, proxySrv, tlsSrv, containerSvc, svc.proxySvc, log)
 	return nil
 }

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -18,6 +18,7 @@ const (
 	EventContainerStart       EventType = "container.start"
 	EventContainerHealthCheck EventType = "container.health_check"
 	EventContainerDeployed    EventType = "container.deployed"
+	EventSecretsChanged       EventType = "secrets.changed"
 )
 
 // Event represents a domain event that occurred in the system.
@@ -59,6 +60,13 @@ type ConfigReloadPayload struct {
 // ManualDeployPayload contains data for manual.deploy events.
 type ManualDeployPayload struct {
 	Domain string `json:"domain"`
+}
+
+// SecretsChangedPayload contains data for secrets.changed events.
+type SecretsChangedPayload struct {
+	Domain    string   // Route domain whose secrets changed
+	Operation string   // "set" or "delete"
+	Keys      []string // Secret key names (not values)
 }
 
 // Context keys for domain-level concerns.

--- a/internal/domain/labels.go
+++ b/internal/domain/labels.go
@@ -10,6 +10,10 @@ const (
 	LabelAttachment = "gordon.attachment"
 	LabelAttachedTo = "gordon.attached-to"
 	LabelCreated    = "gordon.created"
+	// LabelEnvHash stores a SHA-256 hash of the effective environment
+	// variables at deploy time, used to detect env drift without
+	// exposing secret values.
+	LabelEnvHash = "gordon.env-hash"
 
 	// Image labels (set in Dockerfile)
 	LabelProxyPort = "gordon.proxy.port"

--- a/internal/usecase/container/env_hash.go
+++ b/internal/usecase/container/env_hash.go
@@ -1,0 +1,23 @@
+package container
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
+)
+
+// hashEnvironment computes a stable SHA-256 hash of a set of KEY=VALUE pairs.
+// The input is sorted by key before hashing so map iteration order does not
+// affect the result. The returned string is the hex-encoded digest.
+func hashEnvironment(env []string) string {
+	sorted := make([]string, len(env))
+	copy(sorted, env)
+	slices.Sort(sorted)
+
+	h := sha256.New()
+	for _, kv := range sorted {
+		// Length-prefix each entry so embedded newlines cannot collide.
+		_, _ = fmt.Fprintf(h, "%d:%s\n", len(kv), kv)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/usecase/container/env_hash_test.go
+++ b/internal/usecase/container/env_hash_test.go
@@ -1,0 +1,59 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashEnvironment_Deterministic(t *testing.T) {
+	env1 := []string{"B=2", "A=1", "C=3"}
+	env2 := []string{"A=1", "C=3", "B=2"}
+	assert.Equal(t, hashEnvironment(env1), hashEnvironment(env2))
+}
+
+func TestHashEnvironment_DifferentValues(t *testing.T) {
+	env1 := []string{"A=1", "B=2"}
+	env2 := []string{"A=1", "B=3"}
+	assert.NotEqual(t, hashEnvironment(env1), hashEnvironment(env2))
+}
+
+func TestHashEnvironment_DifferentKeys(t *testing.T) {
+	env1 := []string{"A=1", "B=2"}
+	env2 := []string{"A=1", "C=2"}
+	assert.NotEqual(t, hashEnvironment(env1), hashEnvironment(env2))
+}
+
+func TestHashEnvironment_Empty(t *testing.T) {
+	hash := hashEnvironment(nil)
+	require.NotEmpty(t, hash)
+	assert.Equal(t, hash, hashEnvironment([]string{}))
+}
+
+func TestHashEnvironment_ExtraKey(t *testing.T) {
+	env1 := []string{"A=1"}
+	env2 := []string{"A=1", "B=2"}
+	assert.NotEqual(t, hashEnvironment(env1), hashEnvironment(env2))
+}
+
+func TestHashEnvironment_NewlineInValue(t *testing.T) {
+	env1 := []string{"A=1\nB=2"}
+	env2 := []string{"A=1", "B=2"}
+
+	assert.NotEqual(t, hashEnvironment(env1), hashEnvironment(env2))
+}
+
+func TestMergeEnvironmentVariables_Sorted(t *testing.T) {
+	dockerfile := []string{"Z=26", "A=1"}
+	user := []string{"M=13", "B=2"}
+	result := mergeEnvironmentVariables(dockerfile, user)
+	assert.Equal(t, []string{"A=1", "B=2", "M=13", "Z=26"}, result)
+}
+
+func TestMergeEnvironmentVariables_UserOverridesDockerfile(t *testing.T) {
+	dockerfile := []string{"A=old"}
+	user := []string{"A=new"}
+	result := mergeEnvironmentVariables(dockerfile, user)
+	assert.Equal(t, []string{"A=new"}, result)
+}

--- a/internal/usecase/container/secrets_handler.go
+++ b/internal/usecase/container/secrets_handler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/bnema/gordon/internal/domain"
 )
 
+const DefaultSecretsDebounce = 60 * time.Second
+
 // SecretsChangedHandler handles secrets.changed events with per-domain
 // debouncing. When secrets are modified rapidly (e.g. multiple
 // "gordon secrets set" calls), the handler resets a timer on each

--- a/internal/usecase/container/secrets_handler.go
+++ b/internal/usecase/container/secrets_handler.go
@@ -1,0 +1,153 @@
+package container
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/bnema/zerowrap"
+
+	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// SecretsChangedHandler handles secrets.changed events with per-domain
+// debouncing. When secrets are modified rapidly (e.g. multiple
+// "gordon secrets set" calls), the handler resets a timer on each
+// event and only triggers a deploy once the domain is quiet for
+// the configured delay.
+type SecretsChangedHandler struct {
+	containerSvc  in.ContainerService
+	configSvc     in.ConfigService
+	ctx           context.Context
+	cancel        context.CancelFunc
+	debounceDelay time.Duration
+
+	mu          sync.Mutex
+	timers      map[string]*time.Timer
+	generations map[string]uint64
+}
+
+// NewSecretsChangedHandler creates a new SecretsChangedHandler.
+func NewSecretsChangedHandler(
+	ctx context.Context,
+	containerSvc in.ContainerService,
+	configSvc in.ConfigService,
+	debounceDelay time.Duration,
+) *SecretsChangedHandler {
+	ctx, cancel := context.WithCancel(ctx)
+	return &SecretsChangedHandler{
+		containerSvc:  containerSvc,
+		configSvc:     configSvc,
+		ctx:           ctx,
+		cancel:        cancel,
+		debounceDelay: debounceDelay,
+		timers:        make(map[string]*time.Timer),
+		generations:   make(map[string]uint64),
+	}
+}
+
+// Handle processes a secrets.changed event by resetting the debounce
+// timer for the affected domain. Returns immediately - the deploy
+// runs asynchronously when the timer fires.
+//
+// Uses the handler's long-lived context (h.ctx) rather than the event
+// context because the debounced deploy fires after this method returns;
+// using the event context would cause premature cancellation.
+func (h *SecretsChangedHandler) Handle(_ context.Context, event domain.Event) error {
+	payload, ok := event.Data.(domain.SecretsChangedPayload)
+	if !ok {
+		return nil
+	}
+	if payload.Domain == "" {
+		return nil
+	}
+
+	ctx := zerowrap.CtxWithFields(h.ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldHandler: "SecretsChangedHandler",
+		"domain":              payload.Domain,
+		"operation":           payload.Operation,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	log.Debug().
+		Strs("keys", payload.Keys).
+		Dur("debounce", h.debounceDelay).
+		Msg("secrets changed, resetting debounce timer")
+
+	h.resetTimer(ctx, payload.Domain)
+	return nil
+}
+
+// CanHandle returns true for secrets.changed events.
+func (h *SecretsChangedHandler) CanHandle(eventType domain.EventType) bool {
+	return eventType == domain.EventSecretsChanged
+}
+
+// Stop cancels the handler context and all pending timers.
+// Call before graceful shutdown to prevent deploys during drain.
+func (h *SecretsChangedHandler) Stop() {
+	h.cancel()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for domainName, timer := range h.timers {
+		timer.Stop()
+		delete(h.timers, domainName)
+		delete(h.generations, domainName)
+	}
+}
+
+// resetTimer replaces any existing timer for the domain with a new one.
+func (h *SecretsChangedHandler) resetTimer(ctx context.Context, domainName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if existing, ok := h.timers[domainName]; ok {
+		existing.Stop()
+	}
+
+	h.generations[domainName]++
+	gen := h.generations[domainName]
+
+	h.timers[domainName] = time.AfterFunc(h.debounceDelay, func() {
+		h.fireDeploy(ctx, domainName, gen)
+	})
+}
+
+// fireDeploy looks up the route and triggers a deploy.
+func (h *SecretsChangedHandler) fireDeploy(ctx context.Context, domainName string, generation uint64) {
+	// Bail if the handler has been stopped (shutdown in progress).
+	if h.ctx.Err() != nil {
+		return
+	}
+
+	log := zerowrap.FromCtx(ctx)
+
+	h.mu.Lock()
+	if h.generations[domainName] != generation {
+		h.mu.Unlock()
+		return
+	}
+	delete(h.timers, domainName)
+	delete(h.generations, domainName)
+	h.mu.Unlock()
+
+	route, err := h.configSvc.GetRoute(ctx, domainName)
+	if err != nil {
+		log.WrapErr(err, "failed to get route for secrets-changed deploy")
+		return
+	}
+	if route == nil {
+		log.Debug().Msg("no route configured for domain, skipping secrets-changed deploy")
+		return
+	}
+
+	log.Info().Str("image", route.Image).Msg("debounce fired, deploying after secrets change")
+
+	if _, err := h.containerSvc.Deploy(ctx, *route); err != nil {
+		log.WrapErr(err, "secrets-changed deploy failed")
+	}
+}

--- a/internal/usecase/container/secrets_handler_test.go
+++ b/internal/usecase/container/secrets_handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	"github.com/bnema/gordon/internal/domain"
@@ -55,8 +56,9 @@ func TestSecretsChangedHandler_DebouncesBurstEvents(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	time.Sleep(debounceDelay + 100*time.Millisecond)
-	assert.Equal(t, int32(1), deployCalls.Load())
+	require.Eventually(t, func() bool {
+		return deployCalls.Load() == 1
+	}, debounceDelay+time.Second, 10*time.Millisecond, "expected exactly 1 deploy call after debounce")
 }
 
 func TestSecretsChangedHandler_IndependentDomains(t *testing.T) {
@@ -73,8 +75,15 @@ func TestSecretsChangedHandler_IndependentDomains(t *testing.T) {
 	configSvc.EXPECT().GetRoute(mock.Anything, routeOne.Domain).Return(routeOne, nil).Once()
 	configSvc.EXPECT().GetRoute(mock.Anything, routeTwo.Domain).Return(routeTwo, nil).Once()
 
-	containerSvc.EXPECT().Deploy(mock.Anything, *routeOne).Return(&domain.Container{ID: "container-1"}, nil).Once()
-	containerSvc.EXPECT().Deploy(mock.Anything, *routeTwo).Return(&domain.Container{ID: "container-2"}, nil).Once()
+	var deployCalls atomic.Int32
+	containerSvc.EXPECT().Deploy(mock.Anything, *routeOne).RunAndReturn(func(_ context.Context, _ domain.Route) (*domain.Container, error) {
+		deployCalls.Add(1)
+		return &domain.Container{ID: "container-1"}, nil
+	}).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *routeTwo).RunAndReturn(func(_ context.Context, _ domain.Route) (*domain.Container, error) {
+		deployCalls.Add(1)
+		return &domain.Container{ID: "container-2"}, nil
+	}).Once()
 
 	assert.NoError(t, h.Handle(context.Background(), domain.Event{
 		Type: domain.EventSecretsChanged,
@@ -85,7 +94,9 @@ func TestSecretsChangedHandler_IndependentDomains(t *testing.T) {
 		Data: domain.SecretsChangedPayload{Domain: routeTwo.Domain, Operation: "delete", Keys: []string{"B"}},
 	}))
 
-	time.Sleep(debounceDelay + 100*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return deployCalls.Load() == 2
+	}, debounceDelay+time.Second, 10*time.Millisecond, "expected 2 independent deploy calls")
 }
 
 func TestSecretsChangedHandler_NoRouteFound_NoOp(t *testing.T) {

--- a/internal/usecase/container/secrets_handler_test.go
+++ b/internal/usecase/container/secrets_handler_test.go
@@ -1,0 +1,203 @@
+package container
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestSecretsChangedHandler_CanHandle(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, 200*time.Millisecond)
+	defer h.Stop()
+
+	assert.True(t, h.CanHandle(domain.EventSecretsChanged))
+	assert.False(t, h.CanHandle(domain.EventConfigReload))
+}
+
+func TestSecretsChangedHandler_DebouncesBurstEvents(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	debounceDelay := 200 * time.Millisecond
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, debounceDelay)
+	defer h.Stop()
+
+	route := &domain.Route{Domain: "app.example.com", Image: "app:latest"}
+	configSvc.EXPECT().GetRoute(mock.Anything, route.Domain).Return(route, nil).Once()
+
+	var deployCalls atomic.Int32
+	containerSvc.EXPECT().Deploy(mock.Anything, *route).RunAndReturn(func(_ context.Context, deployedRoute domain.Route) (*domain.Container, error) {
+		deployCalls.Add(1)
+		return &domain.Container{ID: "container-1"}, nil
+	}).Once()
+
+	event := domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: domain.SecretsChangedPayload{
+			Domain:    route.Domain,
+			Operation: "set",
+			Keys:      []string{"A", "B"},
+		},
+	}
+
+	for range 5 {
+		assert.NoError(t, h.Handle(context.Background(), event))
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	time.Sleep(debounceDelay + 100*time.Millisecond)
+	assert.Equal(t, int32(1), deployCalls.Load())
+}
+
+func TestSecretsChangedHandler_IndependentDomains(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	debounceDelay := 100 * time.Millisecond
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, debounceDelay)
+	defer h.Stop()
+
+	routeOne := &domain.Route{Domain: "app1.example.com", Image: "app1:latest"}
+	routeTwo := &domain.Route{Domain: "app2.example.com", Image: "app2:latest"}
+
+	configSvc.EXPECT().GetRoute(mock.Anything, routeOne.Domain).Return(routeOne, nil).Once()
+	configSvc.EXPECT().GetRoute(mock.Anything, routeTwo.Domain).Return(routeTwo, nil).Once()
+
+	containerSvc.EXPECT().Deploy(mock.Anything, *routeOne).Return(&domain.Container{ID: "container-1"}, nil).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *routeTwo).Return(&domain.Container{ID: "container-2"}, nil).Once()
+
+	assert.NoError(t, h.Handle(context.Background(), domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: domain.SecretsChangedPayload{Domain: routeOne.Domain, Operation: "set", Keys: []string{"A"}},
+	}))
+	assert.NoError(t, h.Handle(context.Background(), domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: domain.SecretsChangedPayload{Domain: routeTwo.Domain, Operation: "delete", Keys: []string{"B"}},
+	}))
+
+	time.Sleep(debounceDelay + 100*time.Millisecond)
+}
+
+func TestSecretsChangedHandler_NoRouteFound_NoOp(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	debounceDelay := 100 * time.Millisecond
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, debounceDelay)
+	defer h.Stop()
+
+	configSvc.EXPECT().GetRoute(mock.Anything, "missing.example.com").Return(nil, nil).Once()
+
+	assert.NoError(t, h.Handle(context.Background(), domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: domain.SecretsChangedPayload{Domain: "missing.example.com", Operation: "set", Keys: []string{"A"}},
+	}))
+
+	time.Sleep(debounceDelay + 100*time.Millisecond)
+}
+
+func TestSecretsChangedHandler_InvalidPayload_NoOp(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, 100*time.Millisecond)
+	defer h.Stop()
+
+	err := h.Handle(context.Background(), domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: "wrong-payload",
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestSecretsChangedHandler_FireDeploySkipsStaleGeneration(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, time.Second)
+	defer h.Stop()
+
+	const domainName = "app.example.com"
+
+	// White-box: directly set internal state to simulate a stale generation.
+	// This exercises the generation-based debounce logic that prevents
+	// already-fired timers from triggering duplicate deploys.
+	h.mu.Lock()
+	h.generations[domainName] = 2
+	h.timers[domainName] = time.NewTimer(time.Hour)
+	h.mu.Unlock()
+
+	staleDone := make(chan struct{})
+	go func() {
+		defer close(staleDone)
+		h.fireDeploy(context.Background(), domainName, 1)
+	}()
+
+	select {
+	case <-staleDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale fireDeploy did not return")
+	}
+
+	h.mu.Lock()
+	_, timerExists := h.timers[domainName]
+	gen := h.generations[domainName]
+	h.mu.Unlock()
+
+	assert.True(t, timerExists)
+	assert.Equal(t, uint64(2), gen)
+}
+
+func TestSecretsChangedHandler_FireDeployClearsCurrentGeneration(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, time.Second)
+	defer h.Stop()
+
+	route := &domain.Route{Domain: "app.example.com", Image: "app:latest"}
+	configSvc.EXPECT().GetRoute(mock.Anything, route.Domain).Return(route, nil).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(&domain.Container{ID: "container-1"}, nil).Once()
+
+	h.mu.Lock()
+	h.generations[route.Domain] = 1
+	h.timers[route.Domain] = time.NewTimer(time.Hour)
+	h.mu.Unlock()
+
+	h.fireDeploy(context.Background(), route.Domain, 1)
+
+	h.mu.Lock()
+	_, timerExists := h.timers[route.Domain]
+	_, generationExists := h.generations[route.Domain]
+	h.mu.Unlock()
+
+	assert.False(t, timerExists)
+	assert.False(t, generationExists)
+}
+
+func TestSecretsChangedHandler_StopCancelsPendingDeploy(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+
+	debounceDelay := 50 * time.Millisecond
+	h := NewSecretsChangedHandler(testCtx(), containerSvc, configSvc, debounceDelay)
+
+	assert.NoError(t, h.Handle(context.Background(), domain.Event{
+		Type: domain.EventSecretsChanged,
+		Data: domain.SecretsChangedPayload{Domain: "app.example.com", Operation: "set", Keys: []string{"A"}},
+	}))
+
+	h.Stop()
+	time.Sleep(debounceDelay + 50*time.Millisecond)
+}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -210,7 +210,7 @@ func (s *Service) deploymentContainerName(containerDomain string, existing *doma
 	}
 }
 
-func (s *Service) buildContainerConfig(containerDomain, image, actualImageRef string, exposedPorts []int, envVars []string, volumes map[string]string, networkName string, existing *domain.Container) *domain.ContainerConfig {
+func (s *Service) buildContainerConfig(containerDomain, image, actualImageRef string, exposedPorts []int, envVars []string, envHash string, volumes map[string]string, networkName string, existing *domain.Container) *domain.ContainerConfig {
 	containerName := s.deploymentContainerName(containerDomain, existing)
 
 	return &domain.ContainerConfig{
@@ -223,6 +223,7 @@ func (s *Service) buildContainerConfig(containerDomain, image, actualImageRef st
 		Hostname:    containerDomain,
 		Labels: map[string]string{
 			domain.LabelDomain:  containerDomain,
+			domain.LabelEnvHash: envHash,
 			domain.LabelImage:   image,
 			domain.LabelManaged: "true",
 			domain.LabelRoute:   containerDomain,
@@ -279,7 +280,7 @@ func (s *Service) Deploy(ctx context.Context, route domain.Route) (*domain.Conta
 			existingForSkip = s.containerForRedundantCheck(ctx, existingForSkip)
 		}
 		if existingForSkip.ImageID != "" {
-			if skip, container := s.skipRedundantDeploy(ctx, existingForSkip, resources.actualImageRef); skip {
+			if skip, container := s.skipRedundantDeploy(ctx, existingForSkip, resources.actualImageRef, resources.envHash); skip {
 				return container, nil
 			}
 		}
@@ -351,7 +352,7 @@ func (s *Service) recordDeployMetrics(ctx context.Context, span trace.Span, rout
 // When a push triggers both an event-based deploy and an explicit CLI deploy,
 // the second one arrives after the first has already completed; this avoids
 // a full redundant create-start-readiness cycle.
-func (s *Service) skipRedundantDeploy(ctx context.Context, existing *domain.Container, actualImageRef string) (bool, *domain.Container) {
+func (s *Service) skipRedundantDeploy(ctx context.Context, existing *domain.Container, actualImageRef, envHash string) (bool, *domain.Container) {
 	log := zerowrap.FromCtx(ctx)
 
 	newImageID, err := s.runtime.GetImageID(ctx, actualImageRef)
@@ -367,6 +368,19 @@ func (s *Service) skipRedundantDeploy(ctx context.Context, existing *domain.Cont
 	// Verify the container is actually still running before skipping.
 	running, err := s.runtime.IsContainerRunning(ctx, existing.ID)
 	if err != nil || !running {
+		return false, nil
+	}
+
+	if existing.Labels != nil {
+		existingEnvHash, hasEnvHash := existing.Labels[domain.LabelEnvHash]
+		if !hasEnvHash || existingEnvHash != envHash {
+			log.Info().
+				Str("container_id", existing.ID).
+				Bool("has_env_hash", hasEnvHash).
+				Msg("env changed, proceeding with deploy despite same image")
+			return false, nil
+		}
+	} else {
 		return false, nil
 	}
 
@@ -403,6 +417,7 @@ type deployResources struct {
 	actualImageRef string
 	exposedPorts   []int
 	envVars        []string
+	envHash        string
 	volumes        map[string]string
 }
 
@@ -505,6 +520,7 @@ func (s *Service) prepareDeployResources(ctx context.Context, route domain.Route
 	if err != nil {
 		return nil, err
 	}
+	envHash := hashEnvironment(envVars)
 
 	volumes, err := s.setupVolumes(ctx, route.Domain, actualImageRef)
 	if err != nil {
@@ -516,6 +532,7 @@ func (s *Service) prepareDeployResources(ctx context.Context, route domain.Route
 		actualImageRef: actualImageRef,
 		exposedPorts:   exposedPorts,
 		envVars:        envVars,
+		envHash:        envHash,
 		volumes:        volumes,
 	}, nil
 }
@@ -532,6 +549,7 @@ func (s *Service) createStartedContainer(ctx context.Context, route domain.Route
 		resources.actualImageRef,
 		resources.exposedPorts,
 		resources.envVars,
+		resources.envHash,
 		resources.volumes,
 		resources.networkName,
 		existing,
@@ -2031,35 +2049,26 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 
 	// Check if already running (idempotent)
 	// Try new name first, then fall back to legacy name for backwards compatibility
-	existingContainer := s.findContainerByName(ctx, containerName)
-	if existingContainer == nil {
-		// Try legacy naming scheme for backwards compatibility during upgrades
-		containerNameLegacy := fmt.Sprintf("gordon-%s-%s", sanitizeNameLegacy(ownerDomain), serviceName)
-		existingContainer = s.findContainerByName(ctx, containerNameLegacy)
-		if existingContainer != nil {
-			log.Info().Str("container_name", containerNameLegacy).Msg("found attachment with legacy naming, will be replaced")
-			// Remove the old container and recreate with new name
-			if err := s.runtime.StopContainer(ctx, existingContainer.ID); err != nil {
-				return log.WrapErr(err, "failed to stop legacy attachment container")
-			}
-			if err := s.runtime.RemoveContainer(ctx, existingContainer.ID, true); err != nil {
-				return log.WrapErr(err, "failed to remove legacy attachment container")
-			}
-			existingContainer = nil // Clear so we create new one below
-		}
+	existingContainer, err := s.resolveExistingAttachment(ctx, ownerDomain, serviceName)
+	if err != nil {
+		return err
 	}
 
-	if existingContainer != nil && existingContainer.Status == string(domain.ContainerStatusRunning) {
-		log.Debug().Str("container_name", containerName).Msg("attachment already running, skipping")
-		return nil
-	}
-
-	// Remove existing stopped container if present
 	if existingContainer != nil {
-		log.Info().Str("container_name", containerName).Msg("removing stopped attachment container")
-		if err := s.runtime.RemoveContainer(ctx, existingContainer.ID, true); err != nil {
-			return log.WrapErr(err, "failed to remove existing attachment container")
+		shouldSkip, err := s.handleRunningAttachment(ctx, existingContainer, containerName, serviceImage)
+		if err != nil {
+			return err
 		}
+		if shouldSkip {
+			return nil
+		}
+		if existingContainer.Status == string(domain.ContainerStatusRunning) {
+			existingContainer = nil
+		}
+	}
+
+	if err := s.removeStoppedAttachment(ctx, existingContainer, containerName); err != nil {
+		return err
 	}
 
 	log.Info().Str(zerowrap.FieldService, serviceImage).Msg("deploying attached service")
@@ -2091,6 +2100,7 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 		log.WrapErr(err, "failed to load environment for attachment")
 		envVars = []string{}
 	}
+	envHash := hashEnvironment(envVars)
 
 	// Create container with attachment labels (use actual ref, track original in labels)
 	config := &domain.ContainerConfig{
@@ -2105,6 +2115,7 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 			domain.LabelManaged:    "true",
 			domain.LabelAttachment: "true",
 			domain.LabelAttachedTo: ownerDomain,
+			domain.LabelEnvHash:    envHash,
 			domain.LabelImage:      serviceImage,
 		},
 	}
@@ -2130,6 +2141,87 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 
 	log.Info().Str(zerowrap.FieldEntityID, container.ID).Msg("attachment deployed successfully")
 	return nil
+}
+
+func (s *Service) attachmentEnvDrifted(ctx context.Context, existing *domain.Container, containerName, serviceImage string) (bool, error) {
+	currentEnv, err := s.loadEnvironment(ctx, containerName, s.buildImageRef(serviceImage))
+	if err != nil {
+		return false, err
+	}
+
+	currentHash := hashEnvironment(currentEnv)
+	existingHash, ok := existing.Labels[domain.LabelEnvHash]
+	if ok && existingHash == currentHash {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (s *Service) handleRunningAttachment(ctx context.Context, existing *domain.Container, containerName, serviceImage string) (bool, error) {
+	if existing.Status != string(domain.ContainerStatusRunning) {
+		return false, nil
+	}
+
+	log := zerowrap.FromCtx(ctx)
+	envDrifted, err := s.attachmentEnvDrifted(ctx, existing, containerName, serviceImage)
+	if err != nil {
+		log.WrapErr(err, "failed to check attachment env drift")
+		return true, nil
+	}
+	if !envDrifted {
+		log.Debug().Str("container_name", containerName).Msg("attachment already running with current env, skipping")
+		return true, nil
+	}
+
+	log.Info().Str("container_name", containerName).Msg("attachment env changed, recreating")
+	if err := s.runtime.StopContainer(ctx, existing.ID); err != nil {
+		return false, log.WrapErr(err, "failed to stop attachment for env update")
+	}
+	if err := s.runtime.RemoveContainer(ctx, existing.ID, true); err != nil {
+		return false, log.WrapErr(err, "failed to remove attachment for env update")
+	}
+
+	return false, nil
+}
+
+func (s *Service) removeStoppedAttachment(ctx context.Context, existing *domain.Container, containerName string) error {
+	if existing == nil {
+		return nil
+	}
+
+	log := zerowrap.FromCtx(ctx)
+	log.Info().Str("container_name", containerName).Msg("removing stopped attachment container")
+	if err := s.runtime.RemoveContainer(ctx, existing.ID, true); err != nil {
+		return log.WrapErr(err, "failed to remove existing attachment container")
+	}
+
+	return nil
+}
+
+func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, serviceName string) (*domain.Container, error) {
+	log := zerowrap.FromCtx(ctx)
+	containerName := fmt.Sprintf("gordon-%s-%s", sanitizeName(ownerDomain), serviceName)
+	existingContainer := s.findContainerByName(ctx, containerName)
+	if existingContainer != nil {
+		return existingContainer, nil
+	}
+
+	containerNameLegacy := fmt.Sprintf("gordon-%s-%s", sanitizeNameLegacy(ownerDomain), serviceName)
+	existingContainer = s.findContainerByName(ctx, containerNameLegacy)
+	if existingContainer == nil {
+		return nil, nil
+	}
+
+	log.Info().Str("container_name", containerNameLegacy).Msg("found attachment with legacy naming, will be replaced")
+	if err := s.runtime.StopContainer(ctx, existingContainer.ID); err != nil {
+		return nil, log.WrapErr(err, "failed to stop legacy attachment container")
+	}
+	if err := s.runtime.RemoveContainer(ctx, existingContainer.ID, true); err != nil {
+		return nil, log.WrapErr(err, "failed to remove legacy attachment container")
+	}
+
+	return nil, nil
 }
 
 // Utility functions
@@ -2192,9 +2284,15 @@ func mergeEnvironmentVariables(dockerfileEnv, userEnv []string) []string {
 		}
 	}
 
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
 	result := make([]string, 0, len(envMap))
-	for k, v := range envMap {
-		result = append(result, k+"="+v)
+	for _, k := range keys {
+		result = append(result, k+"="+envMap[k])
 	}
 
 	return result

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -2172,8 +2172,7 @@ func (s *Service) handleRunningAttachment(ctx context.Context, existing *domain.
 	// Check env drift
 	envDrifted, err := s.attachmentEnvDrifted(ctx, existing, containerName, serviceImage)
 	if err != nil {
-		log.WrapErr(err, "failed to check attachment env drift")
-		return true, nil
+		return false, log.WrapErr(err, "failed to check attachment env drift")
 	}
 
 	if !envDrifted && !imageDrifted {

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -2164,22 +2164,35 @@ func (s *Service) handleRunningAttachment(ctx context.Context, existing *domain.
 	}
 
 	log := zerowrap.FromCtx(ctx)
+
+	// Check image drift
+	existingImage := existing.Labels[domain.LabelImage]
+	imageDrifted := existingImage != "" && existingImage != serviceImage
+
+	// Check env drift
 	envDrifted, err := s.attachmentEnvDrifted(ctx, existing, containerName, serviceImage)
 	if err != nil {
 		log.WrapErr(err, "failed to check attachment env drift")
 		return true, nil
 	}
-	if !envDrifted {
-		log.Debug().Str("container_name", containerName).Msg("attachment already running with current env, skipping")
+
+	if !envDrifted && !imageDrifted {
+		log.Debug().Str("container_name", containerName).Msg("attachment already running with current env and image, skipping")
 		return true, nil
 	}
 
-	log.Info().Str("container_name", containerName).Msg("attachment env changed, recreating")
+	if imageDrifted {
+		log.Info().Str("container_name", containerName).Str("existing_image", existingImage).Str("desired_image", serviceImage).Msg("attachment image changed, recreating")
+	}
+	if envDrifted {
+		log.Info().Str("container_name", containerName).Msg("attachment env changed, recreating")
+	}
+
 	if err := s.runtime.StopContainer(ctx, existing.ID); err != nil {
-		return false, log.WrapErr(err, "failed to stop attachment for env update")
+		return false, log.WrapErr(err, "failed to stop attachment for drift update")
 	}
 	if err := s.runtime.RemoveContainer(ctx, existing.ID, true); err != nil {
-		return false, log.WrapErr(err, "failed to remove attachment for env update")
+		return false, log.WrapErr(err, "failed to remove attachment for drift update")
 	}
 
 	return false, nil

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -606,6 +606,7 @@ func TestService_Deploy_SkipRedundantDeploy_GetImageIDError(t *testing.T) {
 	config := testMinDelayConfig()
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
 
 	// Existing container has ImageID, but GetImageID will fail
 	existingContainer := &domain.Container{
@@ -614,6 +615,9 @@ func TestService_Deploy_SkipRedundantDeploy_GetImageIDError(t *testing.T) {
 		Image:   "myapp:latest",
 		ImageID: "sha256:abc123",
 		Status:  "running",
+		Labels: map[string]string{
+			domain.LabelEnvHash: expectedEnvHash,
+		},
 	}
 	svc.containers["test.example.com"] = existingContainer
 
@@ -2378,6 +2382,7 @@ func TestService_Deploy_SkipsRedundantDeploy(t *testing.T) {
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
 
 	// Pre-populate with existing container that has an ImageID (set by InspectContainer).
 	// This simulates the first deploy (from image.pushed event) having already completed.
@@ -2387,6 +2392,9 @@ func TestService_Deploy_SkipsRedundantDeploy(t *testing.T) {
 		Image:   "myapp:latest",
 		ImageID: "sha256:abc123",
 		Status:  "running",
+		Labels: map[string]string{
+			domain.LabelEnvHash: expectedEnvHash,
+		},
 	}
 	svc.containers["test.example.com"] = existingContainer
 
@@ -2432,6 +2440,7 @@ func TestService_Deploy_SkipsRedundantDeploy_WhenTrackedImageIDMissing(t *testin
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
 
 	// Pre-populate with existing container missing ImageID (common after stale in-memory state).
 	existingContainer := &domain.Container{
@@ -2439,6 +2448,9 @@ func TestService_Deploy_SkipsRedundantDeploy_WhenTrackedImageIDMissing(t *testin
 		Name:   "gordon-test.example.com",
 		Image:  "myapp:latest",
 		Status: "running",
+		Labels: map[string]string{
+			domain.LabelEnvHash: expectedEnvHash,
+		},
 	}
 	svc.containers["test.example.com"] = existingContainer
 
@@ -2583,6 +2595,7 @@ func TestService_Deploy_SkipRedundantDeploy_ContainerNotRunning(t *testing.T) {
 	config := testMinDelayConfig()
 	svc := NewService(runtime, envLoader, eventBus, nil, config)
 	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
 
 	// Existing container has same image ID but is NOT running (crashed)
 	existingContainer := &domain.Container{
@@ -2591,6 +2604,9 @@ func TestService_Deploy_SkipRedundantDeploy_ContainerNotRunning(t *testing.T) {
 		Image:   "myapp:latest",
 		ImageID: "sha256:abc123",
 		Status:  "exited",
+		Labels: map[string]string{
+			domain.LabelEnvHash: expectedEnvHash,
+		},
 	}
 	svc.containers["test.example.com"] = existingContainer
 
@@ -2630,6 +2646,180 @@ func TestService_Deploy_SkipRedundantDeploy_ContainerNotRunning(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "new-container", result.ID)
+}
+
+func TestService_Deploy_DoesNotSkip_WhenEnvHashDiffers(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	svc := NewService(runtime, envLoader, eventBus, nil, config)
+	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
+
+	existingContainer := &domain.Container{
+		ID:      "existing-container",
+		Name:    "gordon-test.example.com",
+		Image:   "myapp:latest",
+		ImageID: "sha256:abc123",
+		Status:  "running",
+		Labels: map[string]string{
+			domain.LabelEnvHash: "different-hash",
+		},
+	}
+	svc.containers["test.example.com"] = existingContainer
+
+	route := domain.Route{
+		Domain: "test.example.com",
+		Image:  "myapp:latest",
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{"myapp:latest"}, nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:latest").Return([]int{8080}, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
+
+	runtime.EXPECT().GetImageID(mock.Anything, "myapp:latest").Return("sha256:abc123", nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "existing-container").Return(true, nil)
+
+	newContainer := &domain.Container{ID: "new-container", Name: "gordon-test.example.com-new", Status: "created"}
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.MatchedBy(func(cfg *domain.ContainerConfig) bool {
+		return cfg.Labels[domain.LabelEnvHash] == expectedEnvHash
+	})).Return(newContainer, nil)
+	runtime.EXPECT().StartContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-container").Return(true, nil).Times(3)
+	runtime.EXPECT().InspectContainer(mock.Anything, "new-container").Return(&domain.Container{
+		ID: "new-container", Status: "running",
+	}, nil)
+	eventBus.EXPECT().Publish(domain.EventContainerDeployed, mock.AnythingOfType("*domain.ContainerEventPayload")).Return(nil)
+	runtime.EXPECT().StopContainer(mock.Anything, "existing-container").Return(nil)
+	runtime.EXPECT().RemoveContainer(mock.Anything, "existing-container", true).Return(nil)
+	runtime.EXPECT().RenameContainer(mock.Anything, "new-container", "gordon-test.example.com").Return(nil)
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "new-container", result.ID)
+}
+
+func TestService_Deploy_DoesNotSkip_WhenEnvHashMissing(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	svc := NewService(runtime, envLoader, eventBus, nil, config)
+	ctx := testContext()
+	expectedEnvHash := hashEnvironment([]string{})
+
+	existingContainer := &domain.Container{
+		ID:      "existing-container",
+		Name:    "gordon-test.example.com",
+		Image:   "myapp:latest",
+		ImageID: "sha256:abc123",
+		Status:  "running",
+		Labels:  map[string]string{},
+	}
+	svc.containers["test.example.com"] = existingContainer
+
+	route := domain.Route{
+		Domain: "test.example.com",
+		Image:  "myapp:latest",
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{"myapp:latest"}, nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:latest").Return([]int{8080}, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
+
+	runtime.EXPECT().GetImageID(mock.Anything, "myapp:latest").Return("sha256:abc123", nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "existing-container").Return(true, nil)
+
+	newContainer := &domain.Container{ID: "new-container", Name: "gordon-test.example.com-new", Status: "created"}
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.MatchedBy(func(cfg *domain.ContainerConfig) bool {
+		return cfg.Labels[domain.LabelEnvHash] == expectedEnvHash
+	})).Return(newContainer, nil)
+	runtime.EXPECT().StartContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-container").Return(true, nil).Times(3)
+	runtime.EXPECT().InspectContainer(mock.Anything, "new-container").Return(&domain.Container{
+		ID: "new-container", Status: "running",
+	}, nil)
+	eventBus.EXPECT().Publish(domain.EventContainerDeployed, mock.AnythingOfType("*domain.ContainerEventPayload")).Return(nil)
+	runtime.EXPECT().StopContainer(mock.Anything, "existing-container").Return(nil)
+	runtime.EXPECT().RemoveContainer(mock.Anything, "existing-container", true).Return(nil)
+	runtime.EXPECT().RenameContainer(mock.Anything, "new-container", "gordon-test.example.com").Return(nil)
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "new-container", result.ID)
+}
+
+func TestService_attachmentEnvDrifted_ReturnsFalseWhenHashMatches(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, testMinDelayConfig())
+	ctx := testContext()
+	imageRef := svc.buildImageRef("postgres:16")
+	envVars := []string{"POSTGRES_PASSWORD=secret"}
+	envHash := hashEnvironment(envVars)
+
+	envLoader.EXPECT().LoadEnv(mock.Anything, "gordon-app-example-com-postgres").Return(envVars, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, imageRef).Return([]string{}, nil)
+
+	drifted, err := svc.attachmentEnvDrifted(ctx, &domain.Container{
+		Labels: map[string]string{domain.LabelEnvHash: envHash},
+	}, "gordon-app-example-com-postgres", "postgres:16")
+
+	assert.NoError(t, err)
+	assert.False(t, drifted)
+}
+
+func TestService_attachmentEnvDrifted_ReturnsTrueWhenHashDiffers(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, testMinDelayConfig())
+	ctx := testContext()
+	imageRef := svc.buildImageRef("postgres:16")
+	envVars := []string{"POSTGRES_PASSWORD=secret"}
+
+	envLoader.EXPECT().LoadEnv(mock.Anything, "gordon-app-example-com-postgres").Return(envVars, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, imageRef).Return([]string{}, nil)
+
+	drifted, err := svc.attachmentEnvDrifted(ctx, &domain.Container{
+		Labels: map[string]string{domain.LabelEnvHash: "stale-hash"},
+	}, "gordon-app-example-com-postgres", "postgres:16")
+
+	assert.NoError(t, err)
+	assert.True(t, drifted)
+}
+
+func TestService_attachmentEnvDrifted_ReturnsTrueWhenHashMissing(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, testMinDelayConfig())
+	ctx := testContext()
+	imageRef := svc.buildImageRef("postgres:16")
+	envVars := []string{"POSTGRES_PASSWORD=secret"}
+
+	envLoader.EXPECT().LoadEnv(mock.Anything, "gordon-app-example-com-postgres").Return(envVars, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, imageRef).Return([]string{}, nil)
+
+	drifted, err := svc.attachmentEnvDrifted(ctx, &domain.Container{
+		Labels: map[string]string{},
+	}, "gordon-app-example-com-postgres", "postgres:16")
+
+	assert.NoError(t, err)
+	assert.True(t, drifted)
 }
 
 // TestService_Deploy_OrphanCleanup_NeverKillsRunningCanonical verifies that orphan

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -24,15 +24,35 @@ var (
 
 // Service implements the SecretService interface.
 type Service struct {
-	store out.DomainSecretStore
-	log   zerowrap.Logger
+	store    out.DomainSecretStore
+	log      zerowrap.Logger
+	eventBus out.EventPublisher
 }
 
 // NewService creates a new secrets service.
-func NewService(store out.DomainSecretStore, log zerowrap.Logger) *Service {
+func NewService(store out.DomainSecretStore, log zerowrap.Logger, eventBus out.EventPublisher) *Service {
 	return &Service{
-		store: store,
-		log:   log,
+		store:    store,
+		log:      log,
+		eventBus: eventBus,
+	}
+}
+
+// publishSecretsChanged publishes a secrets.changed event.
+// Failures are logged but do not fail the mutation - secret storage
+// is the source of truth; the event is a best-effort notification.
+func (s *Service) publishSecretsChanged(ctx context.Context, domainName, operation string, keys []string) {
+	if s.eventBus == nil {
+		return
+	}
+	log := zerowrap.FromCtx(ctx)
+	payload := domain.SecretsChangedPayload{
+		Domain:    domainName,
+		Operation: operation,
+		Keys:      keys,
+	}
+	if err := s.eventBus.Publish(domain.EventSecretsChanged, payload); err != nil {
+		log.Warn().Err(err).Str("domain", domainName).Msg("failed to publish secrets.changed event")
 	}
 }
 
@@ -140,6 +160,12 @@ func (s *Service) Set(ctx context.Context, domain string, secrets map[string]str
 		return err
 	}
 
+	keys := make([]string, 0, len(secrets))
+	for k := range secrets {
+		keys = append(keys, k)
+	}
+	s.publishSecretsChanged(ctx, domain, "set", keys)
+
 	log.Info().Int("count", len(secrets)).Msg("secrets set")
 	return nil
 }
@@ -163,6 +189,8 @@ func (s *Service) Delete(ctx context.Context, domain, key string) error {
 		log.Error().Err(err).Msg("failed to delete secret")
 		return err
 	}
+
+	s.publishSecretsChanged(ctx, domain, "delete", []string{key})
 
 	log.Info().Msg("secret deleted")
 	return nil
@@ -195,6 +223,12 @@ func (s *Service) SetAttachment(ctx context.Context, domainName, service string,
 		return err
 	}
 
+	keys := make([]string, 0, len(secrets))
+	for k := range secrets {
+		keys = append(keys, k)
+	}
+	s.publishSecretsChanged(ctx, domainName, "set", keys)
+
 	log.Info().Int("count", len(secrets)).Str("container", containerName).Msg("attachment secrets set")
 	return nil
 }
@@ -226,6 +260,8 @@ func (s *Service) DeleteAttachment(ctx context.Context, domainName, service, key
 		log.Error().Err(err).Msg("failed to delete attachment secret")
 		return err
 	}
+
+	s.publishSecretsChanged(ctx, domainName, "delete", []string{key})
 
 	log.Info().Str("container", containerName).Msg("attachment secret deleted")
 	return nil

--- a/internal/usecase/secrets/service.go
+++ b/internal/usecase/secrets/service.go
@@ -4,6 +4,7 @@ package secrets
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/bnema/zerowrap"
@@ -54,6 +55,16 @@ func (s *Service) publishSecretsChanged(ctx context.Context, domainName, operati
 	if err := s.eventBus.Publish(domain.EventSecretsChanged, payload); err != nil {
 		log.Warn().Err(err).Str("domain", domainName).Msg("failed to publish secrets.changed event")
 	}
+}
+
+// sortedKeys returns the keys of a map in sorted order.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // ListKeys returns the list of secret keys for a domain (not values).
@@ -160,11 +171,7 @@ func (s *Service) Set(ctx context.Context, domain string, secrets map[string]str
 		return err
 	}
 
-	keys := make([]string, 0, len(secrets))
-	for k := range secrets {
-		keys = append(keys, k)
-	}
-	s.publishSecretsChanged(ctx, domain, "set", keys)
+	s.publishSecretsChanged(ctx, domain, "set", sortedKeys(secrets))
 
 	log.Info().Int("count", len(secrets)).Msg("secrets set")
 	return nil
@@ -223,11 +230,7 @@ func (s *Service) SetAttachment(ctx context.Context, domainName, service string,
 		return err
 	}
 
-	keys := make([]string, 0, len(secrets))
-	for k := range secrets {
-		keys = append(keys, k)
-	}
-	s.publishSecretsChanged(ctx, domainName, "set", keys)
+	s.publishSecretsChanged(ctx, domainName, "set", sortedKeys(secrets))
 
 	log.Info().Int("count", len(secrets)).Str("container", containerName).Msg("attachment secrets set")
 	return nil

--- a/internal/usecase/secrets/service_test.go
+++ b/internal/usecase/secrets/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bnema/gordon/internal/boundaries/out"
 	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func testLogger() zerowrap.Logger {
@@ -135,7 +136,7 @@ func TestValidateDomain_DistinguishesSeparatorsForEnvStorage(t *testing.T) {
 
 func TestService_ListKeys_ValidationErrors(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	tests := []struct {
 		name    string
@@ -170,7 +171,7 @@ func TestService_ListKeys_ValidationErrors(t *testing.T) {
 
 func TestService_ListKeys_Success(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	expectedKeys := []string{"API_KEY", "DB_PASSWORD"}
 	store.EXPECT().ListKeys("app.example.com").Return(expectedKeys, nil)
@@ -182,7 +183,7 @@ func TestService_ListKeys_Success(t *testing.T) {
 
 func TestService_ListKeysWithAttachments_ValidationErrors(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	tests := []struct {
 		name    string
@@ -219,7 +220,7 @@ func TestService_ListKeysWithAttachments_ValidationErrors(t *testing.T) {
 func TestService_ListKeysWithAttachments_Success(t *testing.T) {
 	t.Run("returns both domain and attachment secrets", func(t *testing.T) {
 		store := outmocks.NewMockDomainSecretStore(t)
-		svc := NewService(store, testLogger())
+		svc := NewService(store, testLogger(), nil)
 
 		expectedKeys := []string{"API_KEY", "DB_PASSWORD"}
 		expectedAttachments := []out.AttachmentSecrets{
@@ -238,7 +239,7 @@ func TestService_ListKeysWithAttachments_Success(t *testing.T) {
 
 	t.Run("returns empty attachments when none exist", func(t *testing.T) {
 		store := outmocks.NewMockDomainSecretStore(t)
-		svc := NewService(store, testLogger())
+		svc := NewService(store, testLogger(), nil)
 
 		expectedKeys := []string{"API_KEY"}
 
@@ -253,7 +254,7 @@ func TestService_ListKeysWithAttachments_Success(t *testing.T) {
 
 	t.Run("continues without attachments on attachment error", func(t *testing.T) {
 		store := outmocks.NewMockDomainSecretStore(t)
-		svc := NewService(store, testLogger())
+		svc := NewService(store, testLogger(), nil)
 
 		expectedKeys := []string{"API_KEY"}
 		attachmentErr := assert.AnError
@@ -271,7 +272,7 @@ func TestService_ListKeysWithAttachments_Success(t *testing.T) {
 
 func TestService_ListKeysWithAttachments_StoreError(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	storeErr := assert.AnError
 	store.EXPECT().ListKeys("app.example.com").Return(nil, storeErr)
@@ -284,7 +285,7 @@ func TestService_ListKeysWithAttachments_StoreError(t *testing.T) {
 
 func TestService_GetAll_ValidationErrors(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	tests := []struct {
 		name    string
@@ -314,7 +315,7 @@ func TestService_GetAll_ValidationErrors(t *testing.T) {
 
 func TestService_GetAll_Success(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	expectedSecrets := map[string]string{"API_KEY": "secret123", "DB_PASSWORD": "pass456"}
 	store.EXPECT().GetAll("app.example.com").Return(expectedSecrets, nil)
@@ -326,7 +327,7 @@ func TestService_GetAll_Success(t *testing.T) {
 
 func TestService_Set_ValidationErrors(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	secrets := map[string]string{"API_KEY": "secret123"}
 
@@ -357,10 +358,30 @@ func TestService_Set_ValidationErrors(t *testing.T) {
 
 func TestService_Set_Success(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
 
 	secrets := map[string]string{"API_KEY": "secret123"}
 	store.EXPECT().Set("app.example.com", secrets).Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.AnythingOfType("domain.SecretsChangedPayload")).Return(nil)
+
+	err := svc.Set(context.Background(), "app.example.com", secrets)
+	assert.NoError(t, err)
+}
+
+func TestService_Set_PublishesSecretsChangedEvent(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
+
+	secrets := map[string]string{"API_KEY": "secret123", "DB_PASSWORD": "pass456"}
+	store.EXPECT().Set("app.example.com", secrets).Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.MatchedBy(func(payload domain.SecretsChangedPayload) bool {
+		assert.Equal(t, "app.example.com", payload.Domain)
+		assert.Equal(t, "set", payload.Operation)
+		assert.ElementsMatch(t, []string{"API_KEY", "DB_PASSWORD"}, payload.Keys)
+		return true
+	})).Return(nil)
 
 	err := svc.Set(context.Background(), "app.example.com", secrets)
 	assert.NoError(t, err)
@@ -368,7 +389,7 @@ func TestService_Set_Success(t *testing.T) {
 
 func TestService_Delete_ValidationErrors(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	tests := []struct {
 		name    string
@@ -397,17 +418,62 @@ func TestService_Delete_ValidationErrors(t *testing.T) {
 
 func TestService_Delete_Success(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
 
 	store.EXPECT().Delete("app.example.com", "API_KEY").Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.AnythingOfType("domain.SecretsChangedPayload")).Return(nil)
 
 	err := svc.Delete(context.Background(), "app.example.com", "API_KEY")
 	assert.NoError(t, err)
 }
 
+func TestService_Delete_PublishesSecretsChangedEvent(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
+
+	store.EXPECT().Delete("app.example.com", "API_KEY").Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.MatchedBy(func(payload domain.SecretsChangedPayload) bool {
+		assert.Equal(t, "app.example.com", payload.Domain)
+		assert.Equal(t, "delete", payload.Operation)
+		assert.Equal(t, []string{"API_KEY"}, payload.Keys)
+		return true
+	})).Return(nil)
+
+	err := svc.Delete(context.Background(), "app.example.com", "API_KEY")
+	assert.NoError(t, err)
+}
+
+func TestService_Set_SucceedsEvenIfEventPublishFails(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
+
+	secrets := map[string]string{"API_KEY": "secret123"}
+	store.EXPECT().Set("app.example.com", secrets).Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.AnythingOfType("domain.SecretsChangedPayload")).Return(assert.AnError)
+
+	err := svc.Set(context.Background(), "app.example.com", secrets)
+	assert.NoError(t, err)
+}
+
+func TestService_NilEventPublisher_DoesNotPanic(t *testing.T) {
+	store := outmocks.NewMockDomainSecretStore(t)
+	svc := NewService(store, testLogger(), nil)
+
+	secrets := map[string]string{"API_KEY": "secret123"}
+	store.EXPECT().Set("app.example.com", secrets).Return(nil)
+
+	assert.NotPanics(t, func() {
+		err := svc.Set(context.Background(), "app.example.com", secrets)
+		assert.NoError(t, err)
+	})
+}
+
 func TestService_StoreError_PropagatedCorrectly(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	storeErr := assert.AnError
 	store.EXPECT().ListKeys("app.example.com").Return(nil, storeErr)
@@ -450,7 +516,7 @@ func TestPathTraversalVariants(t *testing.T) {
 // TestService_ValidationHappensBeforeStore ensures validation runs before any store calls.
 func TestService_ValidationHappensBeforeStore(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	// With path traversal domain, store methods should never be called
 	// We don't set up any expectations, so if store is called, the test will fail
@@ -473,10 +539,12 @@ func TestService_ValidationHappensBeforeStore(t *testing.T) {
 
 func TestService_SetAttachment(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
 
 	secrets := map[string]string{"POSTGRES_PASSWORD": "secret123"}
 	store.EXPECT().SetAttachment("gordon-app__example__com-postgres", secrets).Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.AnythingOfType("domain.SecretsChangedPayload")).Return(nil)
 
 	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres", secrets)
 	assert.NoError(t, err)
@@ -484,9 +552,11 @@ func TestService_SetAttachment(t *testing.T) {
 
 func TestService_DeleteAttachment(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	eventBus := outmocks.NewMockEventPublisher(t)
+	svc := NewService(store, testLogger(), eventBus)
 
 	store.EXPECT().DeleteAttachment("gordon-app__example__com-postgres", "OLD_KEY").Return(nil)
+	eventBus.EXPECT().Publish(domain.EventSecretsChanged, mock.AnythingOfType("domain.SecretsChangedPayload")).Return(nil)
 
 	err := svc.DeleteAttachment(context.Background(), "app.example.com", "postgres", "OLD_KEY")
 	assert.NoError(t, err)
@@ -494,7 +564,7 @@ func TestService_DeleteAttachment(t *testing.T) {
 
 func TestService_SetAttachment_InvalidDomain(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.SetAttachment(context.Background(), "", "postgres", map[string]string{"KEY": "val"})
 	assert.ErrorIs(t, err, ErrDomainEmpty)
@@ -502,7 +572,7 @@ func TestService_SetAttachment_InvalidDomain(t *testing.T) {
 
 func TestService_SetAttachment_EmptyService(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.SetAttachment(context.Background(), "app.example.com", "", map[string]string{"KEY": "val"})
 	assert.ErrorIs(t, err, ErrServiceEmpty)
@@ -510,7 +580,7 @@ func TestService_SetAttachment_EmptyService(t *testing.T) {
 
 func TestService_DeleteAttachment_InvalidDomain(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.DeleteAttachment(context.Background(), "", "postgres", "SOME_KEY")
 	assert.ErrorIs(t, err, ErrDomainEmpty)
@@ -518,7 +588,7 @@ func TestService_DeleteAttachment_InvalidDomain(t *testing.T) {
 
 func TestService_DeleteAttachment_EmptyService(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.DeleteAttachment(context.Background(), "app.example.com", "", "SOME_KEY")
 	assert.ErrorIs(t, err, ErrServiceEmpty)
@@ -526,7 +596,7 @@ func TestService_DeleteAttachment_EmptyService(t *testing.T) {
 
 func TestService_SetAttachment_InvalidServiceName(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.SetAttachment(context.Background(), "app.example.com", "../evil", map[string]string{"K": "V"})
 	assert.ErrorIs(t, err, ErrInvalidServiceName)
@@ -534,7 +604,7 @@ func TestService_SetAttachment_InvalidServiceName(t *testing.T) {
 
 func TestService_DeleteAttachment_InvalidServiceName(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.DeleteAttachment(context.Background(), "app.example.com", "foo/bar", "SOME_KEY")
 	assert.ErrorIs(t, err, ErrInvalidServiceName)
@@ -542,7 +612,7 @@ func TestService_DeleteAttachment_InvalidServiceName(t *testing.T) {
 
 func TestService_SetAttachment_ServiceNameTooLong(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	// Service name exceeds DNS label limit of 63 characters
 	longService := strings.Repeat("a", 64)
@@ -552,7 +622,7 @@ func TestService_SetAttachment_ServiceNameTooLong(t *testing.T) {
 
 func TestService_SetAttachment_ServiceNameTrailingHyphen(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.SetAttachment(context.Background(), "app.example.com", "postgres-", map[string]string{"K": "V"})
 	assert.ErrorIs(t, err, ErrInvalidServiceName)
@@ -560,7 +630,7 @@ func TestService_SetAttachment_ServiceNameTrailingHyphen(t *testing.T) {
 
 func TestService_DeleteAttachment_ServiceNameTooLong(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	// Service name exceeds DNS label limit of 63 characters
 	longService := strings.Repeat("a", 64)
@@ -570,7 +640,7 @@ func TestService_DeleteAttachment_ServiceNameTooLong(t *testing.T) {
 
 func TestService_DeleteAttachment_ServiceNameTrailingHyphen(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	err := svc.DeleteAttachment(context.Background(), "app.example.com", "redis-", "SOME_KEY")
 	assert.ErrorIs(t, err, ErrInvalidServiceName)
@@ -578,7 +648,7 @@ func TestService_DeleteAttachment_ServiceNameTrailingHyphen(t *testing.T) {
 
 func TestService_AttachmentValidationHappensBeforeStore(t *testing.T) {
 	store := outmocks.NewMockDomainSecretStore(t)
-	svc := NewService(store, testLogger())
+	svc := NewService(store, testLogger(), nil)
 
 	// With invalid service name, store methods should never be called
 	err := svc.SetAttachment(context.Background(), "app.example.com", "../evil", map[string]string{"key": "value"})


### PR DESCRIPTION
## Summary

- **Env-aware redundant deploy detection**: `skipRedundantDeploy` now compares a SHA-256 hash of effective environment variables (stored as `gordon.env-hash` container label) alongside the Docker image ID. If env changed, deploy proceeds even if the image is identical.
- **Automatic redeploy on secret changes**: Secret service publishes `secrets.changed` events after `Set`/`Delete`/`SetAttachment`/`DeleteAttachment`. A debounced `SecretsChangedHandler` batches rapid mutations with a 60-second per-domain timer — each new change resets the timer, so `gordon secrets set` called 5 times results in one deploy 60s after the last call.
- **Race-safe debounce**: Generation counter prevents stale timer callbacks from triggering duplicate deploys. Graceful shutdown cleanup via `registerEventHandlers` cleanup function.

## Test Plan

- 1948 tests pass across 50 packages
- 0 golangci-lint issues
- New tests cover: env hash determinism, sorted merge, env-aware skip (same hash → skip, different hash → deploy, missing hash → deploy), event publishing (success, failure resilience, nil publisher), debounce (burst coalescing, independent domains, no-route no-op, stale generation skip)

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic container redeployments when a domain's secrets change
  * Platform-wide secrets change events published for integrations

* **Improvements**
  * Debounce consolidates rapid secret updates into a single deploy
  * Deployment detects environment changes using a stable env-hash to avoid silent mismatches
  * Cleaner shutdown flow that stops pending secret-related timers

* **Tests**
  * Added extensive tests covering env-hash, debouncing, event publishing, and shutdown behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->