### PR TITLE
fix: remove /admin/ from proxy mux to stop intercepting app routes

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1464,7 +1464,7 @@ func createHTTPHandlers(svc *services, cfg Config, log zerowrap.Logger) (http.Ha
 	proxyMux := http.NewServeMux()
 	proxyMux.Handle("/", proxyWithMiddleware)
 
-	registerAdminRoutes(registryMux, proxyMux, svc, cfg, trustedNets, log)
+	registerAdminRoutes(registryMux, svc, cfg, trustedNets, log)
 
 	return registryMux, proxyMux
 }
@@ -1607,7 +1607,7 @@ func wrapRegistryForLocalMode(registryWithMiddleware http.Handler, cfg Config, l
 	return registryWithMiddleware
 }
 
-func registerAdminRoutes(registryMux, proxyMux *http.ServeMux, svc *services, cfg Config, trustedNets []*net.IPNet, log zerowrap.Logger) {
+func registerAdminRoutes(registryMux *http.ServeMux, svc *services, cfg Config, trustedNets []*net.IPNet, log zerowrap.Logger) {
 	if svc.adminHandler == nil {
 		return
 	}
@@ -1646,54 +1646,6 @@ func registerAdminRoutes(registryMux, proxyMux *http.ServeMux, svc *services, cf
 		"gordon.admin",
 	)
 	registryMux.Handle("/admin/", loopbackOnly(adminWithMiddleware, log))
-	proxyMux.Handle("/admin/", adminHostOnly(adminWithMiddleware, cfg.Server.RegistryDomain, log))
-}
-
-func adminHostOnly(next http.Handler, allowedHost string, log zerowrap.Logger) http.Handler {
-	canonicalAllowedHost := canonicalHost(allowedHost)
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		host := canonicalHost(r.Host)
-		if host == "" {
-			host = canonicalHost(r.URL.Host)
-		}
-
-		if !isLoopbackHost(host) && (canonicalAllowedHost == "" || !strings.EqualFold(host, canonicalAllowedHost)) {
-			log.Warn().
-				Str("path", r.URL.Path).
-				Str("host", r.Host).
-				Str("allowed_host", canonicalAllowedHost).
-				Msg("blocked admin request on unauthorized host")
-			http.NotFound(w, r)
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
-func canonicalHost(rawHost string) string {
-	host := strings.TrimSpace(rawHost)
-	if host == "" {
-		return ""
-	}
-
-	if splitHost, _, err := net.SplitHostPort(host); err == nil {
-		host = splitHost
-	}
-
-	host = strings.TrimPrefix(host, "[")
-	host = strings.TrimSuffix(host, "]")
-	return strings.ToLower(host)
-}
-
-func isLoopbackHost(host string) bool {
-	if host == "localhost" {
-		return true
-	}
-
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }
 
 // runServers starts the HTTP servers and waits for shutdown.

--- a/internal/app/run_http_handlers_test.go
+++ b/internal/app/run_http_handlers_test.go
@@ -67,53 +67,6 @@ func TestCreateHTTPHandlers_LocalMode_RestrictsRegistryToLoopback(t *testing.T) 
 	}
 }
 
-func TestCreateHTTPHandlers_AuthEnabled_ExposesAdminOnProxyForRegistryHost(t *testing.T) {
-	t.Parallel()
-
-	cfg := Config{}
-	cfg.Auth.Enabled = true
-	cfg.Server.RegistryDomain = "gordon.local"
-
-	svc := &services{adminHandler: &adminhttp.Handler{}}
-	_, proxyHandler := createHTTPHandlers(svc, cfg, zerowrap.Default())
-	// services uses an adminHandler stub with authSvc left nil. In createHTTPHandlers,
-	// registerAdminRoutes installs fail-closed middleware for that case, so admin
-	// requests on the allowed host return 503 ServiceUnavailable.
-
-	req := httptest.NewRequest(http.MethodGet, "/admin/status", nil)
-	req.Host = "gordon.local"
-	req.RemoteAddr = "192.0.2.30:12345"
-
-	rec := httptest.NewRecorder()
-	proxyHandler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, rec.Code)
-	}
-}
-
-func TestCreateHTTPHandlers_AuthEnabled_BlocksAdminOnNonRegistryHost(t *testing.T) {
-	t.Parallel()
-
-	cfg := Config{}
-	cfg.Auth.Enabled = true
-	cfg.Server.RegistryDomain = "gordon.local"
-
-	svc := &services{adminHandler: &adminhttp.Handler{}}
-	_, proxyHandler := createHTTPHandlers(svc, cfg, zerowrap.Default())
-
-	req := httptest.NewRequest(http.MethodGet, "/admin/status", nil)
-	req.Host = "app.example.com"
-	req.RemoteAddr = "192.0.2.30:12345"
-
-	rec := httptest.NewRecorder()
-	proxyHandler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
-	}
-}
-
 func TestBuildRegistryCIDRAllowlistMiddleware_InvalidEntries_DenyAll(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Remove `/admin/` handler from `proxyMux` — it intercepted all `/admin/*` requests on app domains, returning 404 instead of forwarding to the container
- Delete dead code: `adminHostOnly`, `canonicalHost`, `isLoopbackHost` helpers (only used by the removed mount)
- Remove two tests that asserted the broken behavior

Admin on the registry host continues to work through the existing proxy handler's host-based forwarding to the registry server where `/admin/` is properly mounted.

Fixes #126

## Verification

- Build: pass
- Lint: 0 issues
- Tests: 2006 passed in 50 packages
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed admin route registration from the proxy path. Admin routes are now only accessible through the registry interface, simplifying the routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->