### PR TITLE
fix(preview): move network removal after container removal

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -645,8 +645,9 @@ func gcOrphanedPreviews(ctx context.Context, svc *services, previewConfig domain
 		log.Warn().Str("container", c.Name).Str("image", c.Image).Str("domain", orphanDomain).
 			Time("created", c.Created).Msg("orphaned preview container detected, cleaning up")
 
-		// Stop container first, then clean up domain resources while container
-		// still exists (so future scans can rediscover it on failure), then remove.
+		// Order: stop → remove volumes/route → remove container → remove network.
+		// Network removal must happen after container removal because the runtime
+		// refuses to delete a network that still has containers attached.
 		if err := svc.runtime.StopContainer(ctx, c.Name); err != nil {
 			log.Warn().Err(err).Str("container", c.Name).Msg("failed to stop orphan container")
 		}
@@ -663,6 +664,13 @@ func gcOrphanedPreviews(ctx context.Context, svc *services, previewConfig domain
 			log.Warn().Err(err).Str("container", c.Name).Msg("failed to remove orphan container")
 		}
 
+		// Remove network after container is gone.
+		if orphanDomain != "" {
+			if err := removeOrphanNetwork(ctx, svc, strings.ReplaceAll(orphanDomain, ".", "-"), log); err != nil {
+				log.Warn().Err(err).Str("container", c.Name).Msg("failed to remove orphan network after container removal")
+			}
+		}
+
 		log.Info().Str("container", c.Name).Str("domain", orphanDomain).Msg("orphaned preview container cleaned up")
 	}
 }
@@ -676,7 +684,6 @@ func cleanupOrphanDomainResources(ctx context.Context, svc *services, orphanDoma
 	var errs []error
 
 	errs = append(errs, removeOrphanVolumes(ctx, svc, domainSanitized, log)...)
-	errs = append(errs, removeOrphanNetwork(ctx, svc, domainSanitized, log))
 	errs = append(errs, removeOrphanRoute(ctx, svc, orphanDomain, log))
 	svc.proxySvc.InvalidateTarget(ctx, orphanDomain)
 


### PR DESCRIPTION
## Summary
- Fix orphan GC failing because network removal was attempted before container removal
- Podman/Docker refuse to delete a network with attached containers (even stopped)
- Network removal now happens after container removal

## Root cause
The teardown order was: stop → remove volumes/network/route → remove container. But the runtime rejects network deletion while the container is still attached. Logs showed:
```
failed to remove orphan network: "gordon-gordon--main-bnema-dev" has associated containers
orphan resource cleanup failed, deferring container removal to next scan
```

## Fix
Moved network removal out of `cleanupOrphanDomainResources` and into `gcOrphanedPreviews`, after `RemoveContainer`. Order is now: stop → volumes/route → remove container → remove network.

## Test plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [ ] Deploy to VPS, verify orphan containers are cleaned up on next tick

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphaned preview domain cleanup process to ensure resources are properly removed in the correct order, enhancing system reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->