### PR TITLE
fix(preview): move network removal after container removal

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -682,9 +682,10 @@ func gcOrphanedPreviews(ctx context.Context, svc *services, previewConfig domain
 	}
 }
 
-// cleanupOrphanDomainResources removes volumes, network, and route for an
-// orphaned preview domain. Returns an error if any step fails so the caller
-// can defer container removal until the next scan.
+// cleanupOrphanDomainResources removes volumes and route for an orphaned
+// preview domain. Network removal is handled separately in gcOrphanedPreviews
+// after the container is removed. Returns an error if any step fails so the
+// caller can defer container removal until the next scan.
 func cleanupOrphanDomainResources(ctx context.Context, svc *services, orphanDomain string) error {
 	log := zerowrap.FromCtx(ctx)
 	domainSanitized := strings.ReplaceAll(orphanDomain, ".", "-")


### PR DESCRIPTION
## Summary
- Fix orphan GC failing because network removal was attempted before container removal
- Podman/Docker refuse to delete a network with attached containers (even stopped)
- Network removal now happens after container removal
- Add SyncContainers call after orphan GC so stale routes disappear from `routes list`

## Root cause
Two issues found during prod testing:

1. **Network removal order**: The teardown order was stop → remove volumes/network/route → remove container. But the runtime rejects network deletion while the container is still attached.
2. **Stale routes**: After orphan cleanup, `routes list` still showed ghost routes because the in-memory container state was not re-synced.

## Fix
- Moved network removal out of `cleanupOrphanDomainResources` and into `gcOrphanedPreviews`, after `RemoveContainer`
- Added `SyncContainers` call after orphan GC when orphans were found

## Test plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] Deployed to VPS, verified orphan containers are cleaned up
- [x] Verified `routes list` no longer shows ghost routes after GC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan preview cleanup ordering to avoid leftover resources.
  * Ensures stale routes and volumes are removed more reliably during cleanup.
  * Added a post-cleanup resync that further removes lingering routes and logs failures for visibility, improving overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->