### PR TITLE
refactor: add bytesize.Format helper, use human-readable sizes everywhere

### DIFF
--- a/internal/adapters/in/cli/backup.go
+++ b/internal/adapters/in/cli/backup.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/pkg/bytesize"
 	"github.com/spf13/cobra"
 )
 
@@ -120,10 +121,10 @@ func newBackupRunCmd() *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			if _, err := fmt.Fprintln(w, "DOMAIN\tDB\tSTATUS\tSTARTED_AT\tBACKUP_ID\tSIZE_BYTES"); err != nil {
+			if _, err := fmt.Fprintln(w, "DOMAIN\tDB\tSTATUS\tSTARTED_AT\tBACKUP_ID\tSIZE"); err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\n", result.Backup.Domain, result.Backup.DBName, result.Backup.Status, formatBackupTime(result.Backup.StartedAt), result.Backup.ID, result.Backup.SizeBytes); err != nil {
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", result.Backup.Domain, result.Backup.DBName, result.Backup.Status, formatBackupTime(result.Backup.StartedAt), result.Backup.ID, bytesize.Format(result.Backup.SizeBytes)); err != nil {
 				return err
 			}
 			if err := w.Flush(); err != nil {

--- a/internal/adapters/in/cli/images.go
+++ b/internal/adapters/in/cli/images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bnema/gordon/internal/adapters/dto"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/pkg/bytesize"
 )
 
 type imagesClient interface {
@@ -301,7 +302,7 @@ func runImagesList(ctx context.Context, client imagesClient, out io.Writer, json
 		rows = append(rows, []string{
 			img.Repository,
 			img.Tag,
-			formatImageSize(img.Size),
+			bytesize.Format(img.Size),
 			formatImageCreatedAt(img.Created),
 			formatImageID(img.ID),
 			dangling,
@@ -361,7 +362,7 @@ func runImagesPrune(ctx context.Context, client imagesClient, opts imagesPruneOp
 	}
 
 	if pruneDangling {
-		if err := cliWritef(out, "Runtime: deleted=%d space_reclaimed=%d\n", resp.Runtime.DeletedCount, resp.Runtime.SpaceReclaimed); err != nil {
+		if err := cliWritef(out, "Runtime: deleted=%d space_reclaimed=%s\n", resp.Runtime.DeletedCount, bytesize.Format(resp.Runtime.SpaceReclaimed)); err != nil {
 			return err
 		}
 	} else {
@@ -371,7 +372,7 @@ func runImagesPrune(ctx context.Context, client imagesClient, opts imagesPruneOp
 	}
 
 	if pruneRegistry {
-		err = cliWritef(out, "Registry: tags_removed=%d blobs_removed=%d space_reclaimed=%d\n", resp.Registry.TagsRemoved, resp.Registry.BlobsRemoved, resp.Registry.SpaceReclaimed)
+		err = cliWritef(out, "Registry: tags_removed=%d blobs_removed=%d space_reclaimed=%s\n", resp.Registry.TagsRemoved, resp.Registry.BlobsRemoved, bytesize.Format(resp.Registry.SpaceReclaimed))
 		return err
 	}
 
@@ -567,23 +568,6 @@ func formatImageCreatedAt(t time.Time) string {
 		return "-"
 	}
 	return t.UTC().Format("2006-01-02T15:04:05Z")
-}
-
-func formatImageSize(size int64) string {
-	if size <= 0 {
-		return "-"
-	}
-
-	const unit = 1024
-	if size < unit {
-		return fmt.Sprintf("%d B", size)
-	}
-	div, exp := int64(unit), 0
-	for n := size / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(size)/float64(div), "KMGTPE"[exp])
 }
 
 func formatImageID(id string) string {

--- a/internal/adapters/in/cli/images_test.go
+++ b/internal/adapters/in/cli/images_test.go
@@ -168,7 +168,7 @@ func TestRunImagesList_LongDigestLikeValuesAndEmptyFormattedFields(t *testing.T)
 	assert.True(t, strings.HasPrefix(longTag, strings.TrimSuffix(tagField, "...")))
 	assert.True(t, strings.HasPrefix(longImageID, strings.TrimSuffix(imageIDField, "...")))
 
-	assert.Equal(t, "-", sizeField)
+	assert.Equal(t, "0 B", sizeField)
 	assert.Equal(t, "-", createdField)
 	assert.Contains(t, text, "Total images: 1 (dangling: 1)")
 }

--- a/internal/adapters/in/cli/volumes.go
+++ b/internal/adapters/in/cli/volumes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/dto"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/pkg/bytesize"
 )
 
 type volumesClient interface {
@@ -98,7 +99,7 @@ func runVolumesList(ctx context.Context, client volumesClient, out io.Writer, js
 		if len(v.Containers) > 0 {
 			containers = fmt.Sprintf("%v", v.Containers)
 		}
-		if err := cliWritef(out, "  %-30s %-10s %-10s %s\n", v.Name, status, formatImageSize(v.Size), containers); err != nil {
+		if err := cliWritef(out, "  %-30s %-10s %-10s %s\n", v.Name, status, bytesize.Format(v.Size), containers); err != nil {
 			return err
 		}
 	}
@@ -119,11 +120,11 @@ func renderPrunePreview(out io.Writer, resp *dto.VolumePruneResponse) error {
 		return err
 	}
 	for _, v := range resp.Volumes {
-		if err := cliWritef(out, "  %s (%s)\n", v.Name, formatImageSize(v.Size)); err != nil {
+		if err := cliWritef(out, "  %s (%s)\n", v.Name, bytesize.Format(v.Size)); err != nil {
 			return err
 		}
 	}
-	return cliWritef(out, "\n%d volumes, %s total\n", resp.VolumesRemoved, formatImageSize(resp.SpaceReclaimed))
+	return cliWritef(out, "\n%d volumes, %s total\n", resp.VolumesRemoved, bytesize.Format(resp.SpaceReclaimed))
 }
 
 func runVolumesPrune(ctx context.Context, client volumesClient, opts volumesPruneOptions, out io.Writer) error {
@@ -171,5 +172,5 @@ func runVolumesPrune(ctx context.Context, client volumesClient, opts volumesPrun
 		return writeJSON(out, result)
 	}
 
-	return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Removed %d volumes, reclaimed %s", result.VolumesRemoved, formatImageSize(result.SpaceReclaimed))))
+	return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Removed %d volumes, reclaimed %s", result.VolumesRemoved, bytesize.Format(result.SpaceReclaimed))))
 }

--- a/pkg/bytesize/parse.go
+++ b/pkg/bytesize/parse.go
@@ -1,4 +1,4 @@
-// Package bytesize provides human-friendly byte size parsing.
+// Package bytesize provides human-friendly byte size parsing and formatting.
 package bytesize
 
 import (
@@ -15,6 +15,33 @@ var unitMultipliers = map[string]int64{
 	"MB": 1 << 20, // 1048576
 	"GB": 1 << 30, // 1073741824
 	"TB": 1 << 40, // 1099511627776
+}
+
+// Format converts a byte count into a human-friendly string.
+//
+// Uses binary (1024-based) units: B, KB, MB, GB, TB.
+// Returns one decimal place for KB and above.
+//
+// Examples:
+//
+//	Format(512)        // "512 B"
+//	Format(1048576)    // "1.0 MB"
+//	Format(3609629152) // "3.4 GB"
+func Format(bytes int64) string {
+	if bytes <= 0 {
+		return "0 B"
+	}
+	units := []string{"B", "KB", "MB", "GB", "TB"}
+	size := float64(bytes)
+	unitIdx := 0
+	for size >= 1024 && unitIdx < len(units)-1 {
+		size /= 1024
+		unitIdx++
+	}
+	if unitIdx == 0 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	return fmt.Sprintf("%.1f %s", size, units[unitIdx])
 }
 
 // Parse parses a human-friendly byte size string.


### PR DESCRIPTION
## Summary

Add a shared `bytesize.Format()` helper in `pkg/bytesize` for converting raw byte counts to human-readable strings (e.g. `3609629152` → `"3.4 GB"`).

## Changes

- **`pkg/bytesize`**: Add `Format()` function for consistent human-readable byte formatting
- **Images CLI**: Replace private `formatImageSize()` with shared `bytesize.Format()`
- **Images prune**: Fix `space_reclaimed` output to show `"3.4 GB"` instead of raw bytes
- **Volumes list/prune**: Use `bytesize.Format()` for volume size display
- **Backup run**: Change `SIZE_BYTES` column to `SIZE` with human-readable values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Byte sizes across CLI commands now display in human-readable format (KB, MB, GB, TB) instead of raw bytes, including backup sizes, image details, volume information, and space reclaimed metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->