### PR TITLE
docs: document proxy_allowed_ips requirement for Cloudflare setups

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -258,7 +258,30 @@ Gordon serves HTTP by default. Cloudflare must connect to your origin over HTTP 
 
 Wrong mode causes: **521** (Cloudflare can't connect) or **525** (TLS handshake failed).
 
+> **Important:** You must also set `proxy_allowed_ips` with Cloudflare edge IPs — see [Proxy Origin Allowlist](#proxy-origin-allowlist) below.
+
 > **Rootless note:** Unprivileged users can't bind port 80. Forward port 80→8088 (or your configured port) via firewall — see the firewall section above.
+
+## Proxy Origin Allowlist
+
+When Gordon's internal CA is enabled (default: `tls_port = 8443`), HTTP requests from non-localhost IPs are restricted to certificate onboarding paths only. Cloudflare and other reverse proxies must be listed in `proxy_allowed_ips` to reach your applications.
+
+Add Cloudflare edge IPs to your `gordon.toml`:
+
+```toml
+[server]
+proxy_allowed_ips = [
+  "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22",
+  "103.31.4.0/22", "141.101.64.0/18", "108.162.192.0/18",
+  "190.93.240.0/20", "188.114.96.0/20", "197.234.240.0/22",
+  "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+  "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+]
+```
+
+Without this setting, Cloudflare traffic receives `403 Forbidden: Only certificate onboarding is available over HTTP`.
+
+> **Note:** This is separate from `[api.rate_limit] trusted_proxies`, which controls IP extraction from `X-Forwarded-For`. Both should list your proxy IPs. See [Proxy Origin IP Allowlist](./config/server.md#proxy-origin-ip-allowlist) for details.
 
 ## Verify Installation
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -33,6 +33,23 @@ sudo firewall-cmd --reload
 
 Gordon now includes an internal CA for automatic on-demand TLS. Set `tls_port = 0` to disable. See [Server Configuration](./config/server.md#internal-ca-and-tls) for details.
 
+### Required for Cloudflare/Proxy Setups: `proxy_allowed_ips`
+
+The internal CA's HTTP onboarding gate rejects non-localhost HTTP requests by default. If Gordon sits behind Cloudflare or another reverse proxy, add the proxy's edge IPs to `proxy_allowed_ips`:
+
+```toml
+[server]
+proxy_allowed_ips = [
+  "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22",
+  "103.31.4.0/22", "141.101.64.0/18", "108.162.192.0/18",
+  "190.93.240.0/20", "188.114.96.0/20", "197.234.240.0/22",
+  "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+  "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+]
+```
+
+Without this, all proxied HTTP traffic returns `403 Forbidden`. Set `tls_port = 0` to disable the internal CA and skip this requirement.
+
 ## v2.16.0 to v2.30.0
 
 ### Breaking: Password Authentication Removed


### PR DESCRIPTION
The internal CA onboarding gate (default: `tls_port = 8443`) rejects non-localhost HTTP traffic unless the source IP is in `proxy_allowed_ips`. This is by design — it prevents direct HTTP content access. But Cloudflare users need to know about it.

## Changes

- **installation.md**: Added "Proxy Origin Allowlist" section with Cloudflare CIDRs and the 403 error users will see without it. Cross-reference from the Cloudflare SSL Mode section.
- **upgrading.md**: Added migration note under v2.31.0 explaining the requirement and the `tls_port = 0` escape hatch.

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cloudflare and reverse proxy configuration guidance to installation documentation.
  * Introduced "Proxy Origin Allowlist" section with setup examples and requirements.
  * Updated upgrading guide with proxy configuration prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->