### PR TITLE
ci: skip lint and test on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,31 +3,34 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - 'Makefile'
-      - '.github/workflows/**'
-      - '!**.md'
-      - '!docs/**'
-      - '!LICENSE'
   pull_request:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - 'Makefile'
-      - '.github/workflows/**'
-      - '!**.md'
-      - '!docs/**'
-      - '!LICENSE'
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - 'Makefile'
+              - '.github/workflows/**'
+
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -51,6 +54,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The CI workflow used `paths:` filters in `on:` triggers to skip docs-only PRs. When skipped, the workflow never runs and required checks (Lint, Test) stay stuck as "Waiting for status to be reported" — blocking merge.

## Fix

Replace `paths:` filters with `dorny/paths-filter` inside the workflow. A lightweight `changes` job detects whether Go files changed. Lint and Test have `if: needs.changes.outputs.go == 'true'` — when only docs change, they're skipped. GitHub treats skipped required checks as passing (since Feb 2024).

Also updated `bnema/gh-actions` reusable `go-ci.yml` with a `paths-filter` input for other repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow efficiency with conditional job execution based on code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->