### PR TITLE
Surface structured deploy failures in CLI and admin API

### DIFF
--- a/internal/adapters/dto/admin_deploy_error.go
+++ b/internal/adapters/dto/admin_deploy_error.go
@@ -1,0 +1,9 @@
+package dto
+
+// DeployErrorResponse represents a structured deployment failure response.
+type DeployErrorResponse struct {
+	Error string   `json:"error"`
+	Cause string   `json:"cause,omitempty"`
+	Hint  string   `json:"hint,omitempty"`
+	Logs  []string `json:"logs,omitempty"`
+}

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -44,7 +44,7 @@ Examples:
 						}
 						return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
 					}
-					return fmt.Errorf("failed to deploy: %w", err)
+					return formatDeployFailure(err)
 				}
 				containerID := result.ContainerID
 				if len(containerID) > 12 {

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -51,23 +51,12 @@ Examples:
 func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDomain string, out io.Writer, jsonOut bool) error {
 	result, err := deployer.Deploy(ctx, deployDomain)
 	if err != nil {
+		if formatted, ok := structuredDeployFailure(err); ok {
+			return formatted
+		}
+
 		if isRemote && shouldFallbackToLocal(err) {
-			domain, localErr := sendDeploySignal(deployDomain)
-			if localErr == nil {
-				warning := fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)
-				if jsonOut {
-					return writeJSON(out, map[string]string{
-						"warning": warning,
-						"domain":  domain,
-						"status":  "success",
-					})
-				}
-				if writeErr := cliWriteLine(out, cliRenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err))); writeErr != nil {
-					return writeErr
-				}
-				return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
-			}
-			return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
+			return handleLocalDeployFallback(err, deployDomain, out, jsonOut)
 		}
 
 		return formatDeployFailure(err)
@@ -103,4 +92,26 @@ func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDoma
 		}
 		return cliWriteLine(out, cliRenderInfo(msg))
 	}
+}
+
+func handleLocalDeployFallback(err error, deployDomain string, out io.Writer, jsonOut bool) error {
+	domain, localErr := sendDeploySignal(deployDomain)
+	if localErr != nil {
+		return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
+	}
+
+	warning := fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)
+	if jsonOut {
+		return writeJSON(out, map[string]string{
+			"warning": warning,
+			"domain":  domain,
+			"status":  "success",
+		})
+	}
+
+	if writeErr := cliWriteLine(out, cliRenderWarning(warning)); writeErr != nil {
+		return writeErr
+	}
+
+	return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
 }

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -6,9 +6,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 	"github.com/bnema/gordon/internal/app"
 )
+
+type deployer interface {
+	Deploy(ctx context.Context, deployDomain string) (*remote.DeployResult, error)
+}
 
 // newDeployCmd creates the deploy command.
 func newDeployCmd() *cobra.Command {
@@ -27,40 +32,37 @@ Examples:
   gordon deploy myapp.example.com --remote https://gordon.mydomain.com --token $TOKEN`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			deployDomain := args[0]
-
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				// Remote deployment via admin API
-				result, err := client.Deploy(ctx, deployDomain)
-				if err != nil {
-					if shouldFallbackToLocal(err) {
-						domain, localErr := app.SendDeploySignal(deployDomain)
-						if localErr == nil {
-							fmt.Println(styles.RenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)))
-							fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
-							return nil
-						}
-						return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
-					}
-					return formatDeployFailure(err)
-				}
-				containerID := result.ContainerID
-				if len(containerID) > 12 {
-					containerID = containerID[:12]
-				}
-				fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deployed %s (container: %s)", deployDomain, containerID)))
-				return nil
-			}
-
-			// Local deployment via signal
-			domain, err := app.SendDeploySignal(deployDomain)
+			handle, err := resolveControlPlane(configPath)
 			if err != nil {
 				return err
 			}
-			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
-			return nil
+			defer handle.close()
+
+			return runDeploy(cmd.Context(), handle.plane, handle.isRemote, args[0])
 		},
 	}
+}
+
+func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDomain string) error {
+	result, err := deployer.Deploy(ctx, deployDomain)
+	if err != nil {
+		if isRemote && shouldFallbackToLocal(err) {
+			domain, localErr := app.SendDeploySignal(deployDomain)
+			if localErr == nil {
+				fmt.Println(styles.RenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)))
+				fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
+				return nil
+			}
+			return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
+		}
+
+		return formatDeployFailure(err)
+	}
+
+	containerID := result.ContainerID
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+	fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deployed %s (container: %s)", deployDomain, containerID)))
+	return nil
 }

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -97,10 +97,10 @@ func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDoma
 func handleLocalDeployFallback(err error, deployDomain string, out io.Writer, jsonOut bool) error {
 	domain, localErr := sendDeploySignal(deployDomain)
 	if localErr != nil {
-		return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
+		return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %w", err, localErr)
 	}
 
-	warning := fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)
+	warning := sanitizeDeployLogLine(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err))
 	if jsonOut {
 		return writeJSON(out, map[string]string{
 			"warning": warning,

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -15,6 +15,8 @@ type deployer interface {
 	Deploy(ctx context.Context, deployDomain string) (*remote.DeployResult, error)
 }
 
+var sendDeploySignal = app.SendDeploySignal
+
 // newDeployCmd creates the deploy command.
 func newDeployCmd() *cobra.Command {
 	var jsonOut bool
@@ -50,8 +52,16 @@ func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDoma
 	result, err := deployer.Deploy(ctx, deployDomain)
 	if err != nil {
 		if isRemote && shouldFallbackToLocal(err) {
-			domain, localErr := app.SendDeploySignal(deployDomain)
+			domain, localErr := sendDeploySignal(deployDomain)
 			if localErr == nil {
+				warning := fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)
+				if jsonOut {
+					return writeJSON(out, map[string]string{
+						"warning": warning,
+						"domain":  domain,
+						"status":  "success",
+					})
+				}
 				if writeErr := cliWriteLine(out, cliRenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err))); writeErr != nil {
 					return writeErr
 				}

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
 	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
-	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 	"github.com/bnema/gordon/internal/app"
 )
 
@@ -17,7 +17,8 @@ type deployer interface {
 
 // newDeployCmd creates the deploy command.
 func newDeployCmd() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "deploy <domain>",
 		Short: "Manually deploy or redeploy a route",
 		Long: `Triggers a deployment for the specified route domain.
@@ -38,20 +39,23 @@ Examples:
 			}
 			defer handle.close()
 
-			return runDeploy(cmd.Context(), handle.plane, handle.isRemote, args[0])
+			return runDeploy(cmd.Context(), handle.plane, handle.isRemote, args[0], cmd.OutOrStdout(), jsonOut)
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
 }
 
-func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDomain string) error {
+func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDomain string, out io.Writer, jsonOut bool) error {
 	result, err := deployer.Deploy(ctx, deployDomain)
 	if err != nil {
 		if isRemote && shouldFallbackToLocal(err) {
 			domain, localErr := app.SendDeploySignal(deployDomain)
 			if localErr == nil {
-				fmt.Println(styles.RenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err)))
-				fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
-				return nil
+				if writeErr := cliWriteLine(out, cliRenderWarning(fmt.Sprintf("Remote deploy failed (%v), used local signal fallback", err))); writeErr != nil {
+					return writeErr
+				}
+				return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Deploy signal sent for domain: %s", domain)))
 			}
 			return fmt.Errorf("failed to deploy: remote error: %w; local fallback also failed: %v", err, localErr)
 		}
@@ -59,10 +63,34 @@ func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDoma
 		return formatDeployFailure(err)
 	}
 
+	if jsonOut {
+		return writeJSON(out, result)
+	}
+
+	messageDomain := deployDomain
+	if result.Domain != "" {
+		messageDomain = result.Domain
+	}
+
 	containerID := result.ContainerID
-	if len(containerID) > 12 {
+	if containerID != "" && len(containerID) > 12 {
 		containerID = containerID[:12]
 	}
-	fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deployed %s (container: %s)", deployDomain, containerID)))
-	return nil
+
+	switch result.Status {
+	case "deployed":
+		msg := fmt.Sprintf("Deployed %s", messageDomain)
+		if containerID != "" {
+			msg += fmt.Sprintf(" (container: %s)", containerID)
+		}
+		return cliWriteLine(out, cliRenderSuccess(msg))
+	case "queued":
+		return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Deploy queued for domain: %s", messageDomain)))
+	default:
+		msg := fmt.Sprintf("Deploy status for %s: %s", messageDomain, result.Status)
+		if containerID != "" {
+			msg += fmt.Sprintf(" (container: %s)", containerID)
+		}
+		return cliWriteLine(out, cliRenderInfo(msg))
+	}
 }

--- a/internal/adapters/in/cli/deploy_error.go
+++ b/internal/adapters/in/cli/deploy_error.go
@@ -16,12 +16,12 @@ var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 func formatDeployFailure(err error) error {
 	var deployErr *domain.DeployFailureError
 	if errors.As(err, &deployErr) {
-		return errors.New(renderDeployFailure(deployErr.Summary, deployErr.Cause, deployErr.Hint, deployErr.Logs))
+		return fmt.Errorf("%s: %w", renderDeployFailure(deployErr.Summary, deployErr.Cause, deployErr.Hint, deployErr.Logs), deployErr)
 	}
 
 	var httpErr *remote.HTTPError
 	if errors.As(err, &httpErr) && (httpErr.Structured || httpErr.Cause != "" || httpErr.Hint != "" || len(httpErr.Logs) > 0) {
-		return errors.New(renderDeployFailure(httpErr.Body, httpErr.Cause, httpErr.Hint, httpErr.Logs))
+		return fmt.Errorf("%s: %w", renderDeployFailure(httpErr.Body, httpErr.Cause, httpErr.Hint, httpErr.Logs), httpErr)
 	}
 
 	return fmt.Errorf("failed to deploy: %w", err)

--- a/internal/adapters/in/cli/deploy_error.go
+++ b/internal/adapters/in/cli/deploy_error.go
@@ -3,11 +3,15 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
 	"github.com/bnema/gordon/internal/domain"
 )
+
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
 func formatDeployFailure(err error) error {
 	var deployErr *domain.DeployFailureError
@@ -44,13 +48,34 @@ func renderDeployFailure(summary, cause, hint string, logs []string) string {
 		b.WriteString("\nHint: ")
 		b.WriteString(hint)
 	}
-	if len(logs) > 0 {
+	cleanedLogs := make([]string, 0, len(logs))
+	for _, line := range logs {
+		if cleanedLine := sanitizeDeployLogLine(line); cleanedLine != "" {
+			cleanedLogs = append(cleanedLogs, cleanedLine)
+		}
+	}
+	if len(cleanedLogs) > 0 {
 		b.WriteString("\n\nRecent container logs:")
-		for _, line := range logs {
+		for _, cleanedLine := range cleanedLogs {
 			b.WriteString("\n  ")
-			b.WriteString(line)
+			b.WriteString(cleanedLine)
 		}
 	}
 
 	return b.String()
+}
+
+func sanitizeDeployLogLine(line string) string {
+	line = ansiEscapePattern.ReplaceAllString(line, "")
+	line = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return r
+		case !unicode.IsPrint(r):
+			return -1
+		default:
+			return r
+		}
+	}, line)
+	return strings.TrimSpace(line)
 }

--- a/internal/adapters/in/cli/deploy_error.go
+++ b/internal/adapters/in/cli/deploy_error.go
@@ -13,18 +13,45 @@ import (
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
+type renderedDeployFailureError struct {
+	message string
+	err     error
+}
+
+func (e *renderedDeployFailureError) Error() string {
+	return e.message
+}
+
+func (e *renderedDeployFailureError) Unwrap() error {
+	return e.err
+}
+
 func formatDeployFailure(err error) error {
+	if formatted, ok := structuredDeployFailure(err); ok {
+		return formatted
+	}
+
+	return fmt.Errorf("failed to deploy: %w", err)
+}
+
+func structuredDeployFailure(err error) (error, bool) {
 	var deployErr *domain.DeployFailureError
 	if errors.As(err, &deployErr) {
-		return fmt.Errorf("%s: %w", renderDeployFailure(deployErr.Summary, deployErr.Cause, deployErr.Hint, deployErr.Logs), deployErr)
+		return &renderedDeployFailureError{
+			message: renderDeployFailure(deployErr.Summary, deployErr.Cause, deployErr.Hint, deployErr.Logs),
+			err:     deployErr,
+		}, true
 	}
 
 	var httpErr *remote.HTTPError
 	if errors.As(err, &httpErr) && (httpErr.Structured || httpErr.Cause != "" || httpErr.Hint != "" || len(httpErr.Logs) > 0) {
-		return fmt.Errorf("%s: %w", renderDeployFailure(httpErr.Body, httpErr.Cause, httpErr.Hint, httpErr.Logs), httpErr)
+		return &renderedDeployFailureError{
+			message: renderDeployFailure(httpErr.Body, httpErr.Cause, httpErr.Hint, httpErr.Logs),
+			err:     httpErr,
+		}, true
 	}
 
-	return fmt.Errorf("failed to deploy: %w", err)
+	return nil, false
 }
 
 func renderDeployFailure(summary, cause, hint string, logs []string) string {

--- a/internal/adapters/in/cli/deploy_error.go
+++ b/internal/adapters/in/cli/deploy_error.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func formatDeployFailure(err error) error {
+	var deployErr *domain.DeployFailureError
+	if errors.As(err, &deployErr) {
+		return errors.New(renderDeployFailure(deployErr.Summary, deployErr.Cause, deployErr.Hint, deployErr.Logs))
+	}
+
+	var httpErr *remote.HTTPError
+	if errors.As(err, &httpErr) && (httpErr.Structured || httpErr.Cause != "" || httpErr.Hint != "" || len(httpErr.Logs) > 0) {
+		return errors.New(renderDeployFailure(httpErr.Body, httpErr.Cause, httpErr.Hint, httpErr.Logs))
+	}
+
+	return fmt.Errorf("failed to deploy: %w", err)
+}
+
+func renderDeployFailure(summary, cause, hint string, logs []string) string {
+	if summary == "" {
+		summary = "failed to deploy"
+	}
+
+	var b strings.Builder
+	if summary == "failed to deploy" {
+		b.WriteString(summary)
+	} else {
+		b.WriteString("failed to deploy: ")
+		b.WriteString(summary)
+	}
+
+	if cause != "" {
+		b.WriteString("\nCause: ")
+		b.WriteString(cause)
+	}
+	if hint != "" {
+		b.WriteString("\nHint: ")
+		b.WriteString(hint)
+	}
+	if len(logs) > 0 {
+		b.WriteString("\n\nRecent container logs:")
+		for _, line := range logs {
+			b.WriteString("\n  ")
+			b.WriteString(line)
+		}
+	}
+
+	return b.String()
+}

--- a/internal/adapters/in/cli/deploy_error_test.go
+++ b/internal/adapters/in/cli/deploy_error_test.go
@@ -65,7 +65,6 @@ func TestFormatDeployFailure_SkipsEmptySanitizedLogsSection(t *testing.T) {
 	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed")
-	assert.NotContains(t, err.Error(), "Recent container logs:")
+	assert.Equal(t, "failed to deploy\nCause: health check failed", err.Error())
 	assert.ErrorIs(t, err, root)
 }

--- a/internal/adapters/in/cli/deploy_error_test.go
+++ b/internal/adapters/in/cli/deploy_error_test.go
@@ -26,7 +26,7 @@ func TestFormatDeployFailure_RemoteStructuredError(t *testing.T) {
 	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused")
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
 	assert.ErrorIs(t, err, root)
 }
 
@@ -43,7 +43,7 @@ func TestFormatDeployFailure_LocalTypedError(t *testing.T) {
 	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused")
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
 	assert.ErrorIs(t, err, root)
 }
 

--- a/internal/adapters/in/cli/deploy_error_test.go
+++ b/internal/adapters/in/cli/deploy_error_test.go
@@ -51,3 +51,14 @@ func TestFormatDeployFailure_GenericFallback(t *testing.T) {
 	assert.Equal(t, "failed to deploy: boom", err.Error())
 	assert.ErrorIs(t, err, root)
 }
+
+func TestFormatDeployFailure_SkipsEmptySanitizedLogsSection(t *testing.T) {
+	err := formatDeployFailure(&domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "health check failed",
+		Logs:    []string{"\x1b[31m\x1b[0m", "\n\r\t"},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy\nCause: health check failed", err.Error())
+}

--- a/internal/adapters/in/cli/deploy_error_test.go
+++ b/internal/adapters/in/cli/deploy_error_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFormatDeployFailure_RemoteStructuredError(t *testing.T) {
-	err := formatDeployFailure(&remote.HTTPError{
+	root := &remote.HTTPError{
 		StatusCode: 500,
 		Status:     "500 Internal Server Error",
 		Body:       "failed to deploy",
@@ -22,14 +22,16 @@ func TestFormatDeployFailure_RemoteStructuredError(t *testing.T) {
 			"booting app",
 			"connection refused",
 		},
-	})
+	}
+	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused")
+	assert.ErrorIs(t, err, root)
 }
 
 func TestFormatDeployFailure_LocalTypedError(t *testing.T) {
-	err := formatDeployFailure(&domain.DeployFailureError{
+	root := &domain.DeployFailureError{
 		Summary: "failed to deploy",
 		Cause:   "health check failed",
 		Hint:    "check DATABASE_URL",
@@ -37,10 +39,12 @@ func TestFormatDeployFailure_LocalTypedError(t *testing.T) {
 			"booting app",
 			"connection refused",
 		},
-	})
+	}
+	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused")
+	assert.ErrorIs(t, err, root)
 }
 
 func TestFormatDeployFailure_GenericFallback(t *testing.T) {
@@ -53,12 +57,15 @@ func TestFormatDeployFailure_GenericFallback(t *testing.T) {
 }
 
 func TestFormatDeployFailure_SkipsEmptySanitizedLogsSection(t *testing.T) {
-	err := formatDeployFailure(&domain.DeployFailureError{
+	root := &domain.DeployFailureError{
 		Summary: "failed to deploy",
 		Cause:   "health check failed",
 		Logs:    []string{"\x1b[31m\x1b[0m", "\n\r\t"},
-	})
+	}
+	err := formatDeployFailure(root)
 
 	require.Error(t, err)
-	assert.Equal(t, "failed to deploy\nCause: health check failed", err.Error())
+	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed")
+	assert.NotContains(t, err.Error(), "Recent container logs:")
+	assert.ErrorIs(t, err, root)
 }

--- a/internal/adapters/in/cli/deploy_error_test.go
+++ b/internal/adapters/in/cli/deploy_error_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestFormatDeployFailure_RemoteStructuredError(t *testing.T) {
+	err := formatDeployFailure(&remote.HTTPError{
+		StatusCode: 500,
+		Status:     "500 Internal Server Error",
+		Body:       "failed to deploy",
+		Cause:      "health check failed",
+		Hint:       "check DATABASE_URL",
+		Logs: []string{
+			"booting app",
+			"connection refused",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+}
+
+func TestFormatDeployFailure_LocalTypedError(t *testing.T) {
+	err := formatDeployFailure(&domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "health check failed",
+		Hint:    "check DATABASE_URL",
+		Logs: []string{
+			"booting app",
+			"connection refused",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+}
+
+func TestFormatDeployFailure_GenericFallback(t *testing.T) {
+	root := errors.New("boom")
+	err := formatDeployFailure(root)
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy: boom", err.Error())
+	assert.ErrorIs(t, err, root)
+}

--- a/internal/adapters/in/cli/deploy_test.go
+++ b/internal/adapters/in/cli/deploy_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -26,8 +27,21 @@ func TestRunDeploy_LocalTypedErrorUsesDeployFormatter(t *testing.T) {
 		Cause:   "health check failed",
 		Hint:    "check DATABASE_URL",
 		Logs:    []string{"booting app", "connection refused"},
-	}}, false, "app.example.com")
+	}}, false, "app.example.com", &bytes.Buffer{}, false)
 
 	require.Error(t, err)
 	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+}
+
+func TestRunDeploy_UsesResultDomainWhenPresent(t *testing.T) {
+	var out bytes.Buffer
+	err := runDeploy(context.Background(), &deployTestDeployer{result: &remote.DeployResult{
+		Status:      "deployed",
+		Domain:      "actual.example.com",
+		ContainerID: "1234567890abcdef",
+	}}, false, "requested.example.com", &out, false)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Deployed actual.example.com (container: 1234567890ab)")
+	assert.NotContains(t, out.String(), "requested.example.com")
 }

--- a/internal/adapters/in/cli/deploy_test.go
+++ b/internal/adapters/in/cli/deploy_test.go
@@ -36,6 +36,30 @@ func TestRunDeploy_LocalTypedErrorUsesDeployFormatter(t *testing.T) {
 	assert.ErrorIs(t, err, root)
 }
 
+func TestRunDeploy_StructuredRemoteNoFallbackReturnsFormattedError(t *testing.T) {
+	originalSendDeploySignal := sendDeploySignal
+	sendDeploySignal = func(string) (string, error) {
+		t.Fatalf("sendDeploySignal should not be called for structured deploy failures")
+		return "", nil
+	}
+	defer func() { sendDeploySignal = originalSendDeploySignal }()
+
+	root := &remote.HTTPError{
+		StatusCode: 503,
+		Status:     "503 Service Unavailable",
+		Body:       "failed to deploy",
+		Cause:      "health check failed",
+		Hint:       "check DATABASE_URL",
+		Logs:       []string{"booting app", "connection refused"},
+		Structured: true,
+	}
+	err := runDeploy(context.Background(), &deployTestDeployer{err: root}, true, "app.example.com", &bytes.Buffer{}, false)
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+	assert.ErrorIs(t, err, root)
+}
+
 func TestRunDeploy_UsesResultDomainWhenPresent(t *testing.T) {
 	var out bytes.Buffer
 	err := runDeploy(context.Background(), &deployTestDeployer{result: &remote.DeployResult{

--- a/internal/adapters/in/cli/deploy_test.go
+++ b/internal/adapters/in/cli/deploy_test.go
@@ -86,3 +86,34 @@ func TestRunDeploy_RemoteFallbackUsesJSONWhenRequested(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"domain":"app.example.com","status":"success","warning":"Remote deploy failed (503 Service Unavailable: Registry Unavailable), used local signal fallback"}`, out.String())
 }
+
+func TestHandleLocalDeployFallback_WrapsRemoteAndLocalErrors(t *testing.T) {
+	originalSendDeploySignal := sendDeploySignal
+	localErr := errors.New("local signal failed")
+	sendDeploySignal = func(string) (string, error) {
+		return "", localErr
+	}
+	defer func() { sendDeploySignal = originalSendDeploySignal }()
+
+	remoteErr := errors.New("remote deploy failed")
+	err := handleLocalDeployFallback(remoteErr, "app.example.com", &bytes.Buffer{}, false)
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy: remote error: remote deploy failed; local fallback also failed: local signal failed", err.Error())
+	assert.ErrorIs(t, err, remoteErr)
+	assert.ErrorIs(t, err, localErr)
+}
+
+func TestRunDeploy_RemoteFallbackSanitizesWarning(t *testing.T) {
+	originalSendDeploySignal := sendDeploySignal
+	sendDeploySignal = func(string) (string, error) {
+		return "app.example.com", nil
+	}
+	defer func() { sendDeploySignal = originalSendDeploySignal }()
+
+	var out bytes.Buffer
+	err := runDeploy(context.Background(), &deployTestDeployer{err: errors.New("503 Service Unavailable:\n\x1b[31mRegistry Unavailable\x1b[0m")}, true, "app.example.com", &out, true)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"domain":"app.example.com","status":"success","warning":"Remote deploy failed (503 Service Unavailable:Registry Unavailable), used local signal fallback"}`, out.String())
+}

--- a/internal/adapters/in/cli/deploy_test.go
+++ b/internal/adapters/in/cli/deploy_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,15 +23,17 @@ func (d *deployTestDeployer) Deploy(context.Context, string) (*remote.DeployResu
 }
 
 func TestRunDeploy_LocalTypedErrorUsesDeployFormatter(t *testing.T) {
-	err := runDeploy(context.Background(), &deployTestDeployer{err: &domain.DeployFailureError{
+	root := &domain.DeployFailureError{
 		Summary: "failed to deploy",
 		Cause:   "health check failed",
 		Hint:    "check DATABASE_URL",
 		Logs:    []string{"booting app", "connection refused"},
-	}}, false, "app.example.com", &bytes.Buffer{}, false)
+	}
+	err := runDeploy(context.Background(), &deployTestDeployer{err: root}, false, "app.example.com", &bytes.Buffer{}, false)
 
 	require.Error(t, err)
-	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+	assert.Contains(t, err.Error(), "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused")
+	assert.ErrorIs(t, err, root)
 }
 
 func TestRunDeploy_UsesResultDomainWhenPresent(t *testing.T) {
@@ -44,4 +47,18 @@ func TestRunDeploy_UsesResultDomainWhenPresent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "Deployed actual.example.com (container: 1234567890ab)")
 	assert.NotContains(t, out.String(), "requested.example.com")
+}
+
+func TestRunDeploy_RemoteFallbackUsesJSONWhenRequested(t *testing.T) {
+	originalSendDeploySignal := sendDeploySignal
+	sendDeploySignal = func(string) (string, error) {
+		return "app.example.com", nil
+	}
+	defer func() { sendDeploySignal = originalSendDeploySignal }()
+
+	var out bytes.Buffer
+	err := runDeploy(context.Background(), &deployTestDeployer{err: errors.New("503 Service Unavailable: Registry Unavailable")}, true, "app.example.com", &out, true)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"domain":"app.example.com","status":"success","warning":"Remote deploy failed (503 Service Unavailable: Registry Unavailable), used local signal fallback"}`, out.String())
 }

--- a/internal/adapters/in/cli/deploy_test.go
+++ b/internal/adapters/in/cli/deploy_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/domain"
+)
+
+type deployTestDeployer struct {
+	result *remote.DeployResult
+	err    error
+}
+
+func (d *deployTestDeployer) Deploy(context.Context, string) (*remote.DeployResult, error) {
+	return d.result, d.err
+}
+
+func TestRunDeploy_LocalTypedErrorUsesDeployFormatter(t *testing.T) {
+	err := runDeploy(context.Background(), &deployTestDeployer{err: &domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "health check failed",
+		Hint:    "check DATABASE_URL",
+		Logs:    []string{"booting app", "connection refused"},
+	}}, false, "app.example.com")
+
+	require.Error(t, err)
+	assert.Equal(t, "failed to deploy\nCause: health check failed\nHint: check DATABASE_URL\n\nRecent container logs:\n  booting app\n  connection refused", err.Error())
+}

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -679,7 +679,7 @@ func deployAfterPush(ctx context.Context, cp ControlPlane, pushDomain string, no
 		result, err = cp.Deploy(ctx, pushDomain)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to deploy: %w", err)
+		return formatDeployFailure(err)
 	}
 	containerID := result.ContainerID
 	if len(containerID) > 12 {

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -343,7 +343,7 @@ func parseErrorResponse(resp *http.Response, body []byte) error {
 		Logs  []string `json:"logs"`
 	}
 	if err := json.Unmarshal(body, &errResp); err == nil {
-		structured = errResp.Error != "" || errResp.Cause != "" || errResp.Hint != "" || len(errResp.Logs) > 0
+		structured = errResp.Cause != "" || errResp.Hint != "" || len(errResp.Logs) > 0
 		if errResp.Error != "" {
 			msg = errResp.Error
 		}

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -323,6 +323,10 @@ type HTTPError struct {
 	StatusCode int
 	Status     string
 	Body       string
+	Cause      string
+	Hint       string
+	Logs       []string
+	Structured bool
 }
 
 func (e *HTTPError) Error() string {
@@ -331,16 +335,27 @@ func (e *HTTPError) Error() string {
 
 func parseErrorResponse(resp *http.Response, body []byte) error {
 	msg := string(body)
+	structured := false
 	var errResp struct {
-		Error string `json:"error"`
+		Error string   `json:"error"`
+		Cause string   `json:"cause"`
+		Hint  string   `json:"hint"`
+		Logs  []string `json:"logs"`
 	}
-	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error != "" {
-		msg = errResp.Error
+	if err := json.Unmarshal(body, &errResp); err == nil {
+		structured = errResp.Error != "" || errResp.Cause != "" || errResp.Hint != "" || len(errResp.Logs) > 0
+		if errResp.Error != "" {
+			msg = errResp.Error
+		}
 	}
 	return &HTTPError{
 		StatusCode: resp.StatusCode,
 		Status:     resp.Status,
 		Body:       msg,
+		Cause:      errResp.Cause,
+		Hint:       errResp.Hint,
+		Logs:       errResp.Logs,
+		Structured: structured,
 	}
 }
 

--- a/internal/adapters/in/cli/remote/client_test.go
+++ b/internal/adapters/in/cli/remote/client_test.go
@@ -334,6 +334,23 @@ func TestParseErrorResponse_ReturnsHTTPError(t *testing.T) {
 	assert.Equal(t, "insufficient scope", httpErr.Body)
 }
 
+func TestParseErrorResponse_DeployFailureFields(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 500,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	err := parseErrorResponse(resp, []byte(`{"error":"container exited during startup","cause":"health check failed","hint":"check DATABASE_URL","logs":["booting app","connection refused"]}`))
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, 500, httpErr.StatusCode)
+	assert.Equal(t, "container exited during startup", httpErr.Body)
+	assert.Equal(t, "health check failed", httpErr.Cause)
+	assert.Equal(t, "check DATABASE_URL", httpErr.Hint)
+	assert.Equal(t, []string{"booting app", "connection refused"}, httpErr.Logs)
+}
+
 func TestParseErrorResponse_NonJSON(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: 500,

--- a/internal/adapters/in/cli/remote/client_test.go
+++ b/internal/adapters/in/cli/remote/client_test.go
@@ -351,6 +351,23 @@ func TestParseErrorResponse_DeployFailureFields(t *testing.T) {
 	assert.Equal(t, []string{"booting app", "connection refused"}, httpErr.Logs)
 }
 
+func TestParseErrorResponse_ErrorOnlyJSONNotStructured(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 500,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	err := parseErrorResponse(resp, []byte(`{"error":"failed to deploy container"}`))
+
+	var httpErr *HTTPError
+	require.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, "failed to deploy container", httpErr.Body)
+	assert.False(t, httpErr.Structured)
+	assert.Empty(t, httpErr.Cause)
+	assert.Empty(t, httpErr.Hint)
+	assert.Empty(t, httpErr.Logs)
+}
+
 func TestParseErrorResponse_NonJSON(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: 500,

--- a/internal/adapters/in/cli/remote/client_test.go
+++ b/internal/adapters/in/cli/remote/client_test.go
@@ -346,6 +346,7 @@ func TestParseErrorResponse_DeployFailureFields(t *testing.T) {
 	require.True(t, errors.As(err, &httpErr))
 	assert.Equal(t, 500, httpErr.StatusCode)
 	assert.Equal(t, "container exited during startup", httpErr.Body)
+	assert.True(t, httpErr.Structured)
 	assert.Equal(t, "health check failed", httpErr.Cause)
 	assert.Equal(t, "check DATABASE_URL", httpErr.Hint)
 	assert.Equal(t, []string{"booting app", "connection refused"}, httpErr.Logs)

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -1280,6 +1280,16 @@ func (h *Handler) handleDeploy(w http.ResponseWriter, r *http.Request, path stri
 	container, err := h.containerSvc.Deploy(domain.WithInternalDeploy(ctx), *route)
 	if err != nil {
 		log.Error().Err(err).Str("domain", deployDomain).Msg("failed to deploy container")
+		var deployErr *domain.DeployFailureError
+		if errors.As(err, &deployErr) {
+			h.sendJSON(w, http.StatusInternalServerError, dto.DeployErrorResponse{
+				Error: deployErr.Error(),
+				Cause: deployErr.Cause,
+				Hint:  deployErr.Hint,
+				Logs:  deployErr.Logs,
+			})
+			return
+		}
 		h.sendError(w, http.StatusInternalServerError, "failed to deploy container")
 		return
 	}

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1369,19 +1370,25 @@ func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
 		d.ContainerSvc = containerSvc
 		d.SecretSvc = secretSvc
 	})
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r.WithContext(ctxWithScopes("admin:config:write")))
+	}))
+	defer s.Close()
 
 	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
 	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
 
-	req := httptest.NewRequest("POST", "/admin/deploy/app.example.com", nil)
-	req = req.WithContext(ctxWithScopes("admin:config:write"))
-	rec := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.URL+"/admin/deploy/app.example.com", nil)
+	assert.NoError(t, err)
+	resp, err := s.Client().Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
-	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying","logs":["pulling manifest","manifest unknown"]}`, rec.Body.String())
-	assert.NotContains(t, rec.Body.String(), "internal registry detail")
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying","logs":["pulling manifest","manifest unknown"]}`, string(body))
+	assert.NotContains(t, string(body), "internal registry detail")
 }
 
 func TestHandler_Deploy_GenericErrorStillUsesLegacyBody(t *testing.T) {
@@ -1398,19 +1405,25 @@ func TestHandler_Deploy_GenericErrorStillUsesLegacyBody(t *testing.T) {
 		d.ContainerSvc = containerSvc
 		d.SecretSvc = secretSvc
 	})
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(w, r.WithContext(ctxWithScopes("admin:config:write")))
+	}))
+	defer s.Close()
 
 	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
 	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
 
-	req := httptest.NewRequest("POST", "/admin/deploy/app.example.com", nil)
-	req = req.WithContext(ctxWithScopes("admin:config:write"))
-	rec := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.URL+"/admin/deploy/app.example.com", nil)
+	assert.NoError(t, err)
+	resp, err := s.Client().Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
-	assert.JSONEq(t, `{"error":"failed to deploy container"}`, rec.Body.String())
-	assert.NotContains(t, rec.Body.String(), "internal registry detail")
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.JSONEq(t, `{"error":"failed to deploy container"}`, string(body))
+	assert.NotContains(t, string(body), "internal registry detail")
 }
 
 func TestHandler_Restart_ContainerNotFound(t *testing.T) {

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -1346,6 +1346,73 @@ func TestHandler_Restart_InvalidDomain(t *testing.T) {
 	}
 }
 
+func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+	route := &domain.Route{Domain: "app.example.com", Image: "registry.local/myapp:latest"}
+	deployErr := &domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "image pull failed",
+		Hint:    "push the image before retrying",
+		Logs: []string{
+			"pulling manifest",
+			"manifest unknown",
+		},
+		Err: errors.New("manifest unknown: internal registry detail"),
+	}
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+	})
+
+	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
+
+	req := httptest.NewRequest("POST", "/admin/deploy/app.example.com", nil)
+	req = req.WithContext(ctxWithScopes("admin:config:write"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying","logs":["pulling manifest","manifest unknown"]}`, rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "internal registry detail")
+}
+
+func TestHandler_Deploy_GenericErrorStillUsesLegacyBody(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+	route := &domain.Route{Domain: "app.example.com", Image: "registry.local/myapp:latest"}
+	deployErr := errors.New("manifest unknown: internal registry detail")
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+	})
+
+	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
+
+	req := httptest.NewRequest("POST", "/admin/deploy/app.example.com", nil)
+	req = req.WithContext(ctxWithScopes("admin:config:write"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.JSONEq(t, `{"error":"failed to deploy container"}`, rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "internal registry detail")
+}
+
 func TestHandler_Restart_ContainerNotFound(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	authSvc := inmocks.NewMockAuthService(t)

--- a/internal/domain/deploy_failure.go
+++ b/internal/domain/deploy_failure.go
@@ -1,0 +1,30 @@
+package domain
+
+// DeployFailureError describes a surfaced deployment failure.
+type DeployFailureError struct {
+	Summary       string
+	Cause         string
+	Hint          string
+	Logs          []string
+	ContainerName string
+	ContainerID   string
+	Err           error
+}
+
+// Error returns the deploy failure summary.
+func (e *DeployFailureError) Error() string {
+	if e == nil || e.Summary == "" {
+		return "failed to deploy"
+	}
+
+	return e.Summary
+}
+
+// Unwrap returns the wrapped error.
+func (e *DeployFailureError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -2,9 +2,12 @@
 package container
 
 import (
+	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"slices"
 	"strconv"
@@ -69,6 +72,7 @@ const (
 	// negatives during short startup flaps.
 	readinessRecoveryWindow = 30 * time.Second
 	internalPullMaxAttempts = 3
+	deployFailureLogLimit   = 20
 )
 
 // Service implements the ContainerService interface.
@@ -315,6 +319,9 @@ func (s *Service) Deploy(ctx context.Context, route domain.Route) (*domain.Conta
 
 	resources, err := s.prepareDeployResources(ctx, route, existing)
 	if err != nil {
+		if deployErr := s.wrapPullDeployFailure(route, existing, err); deployErr != nil {
+			return nil, deployErr
+		}
 		return nil, err
 	}
 
@@ -630,8 +637,9 @@ func (s *Service) createStartedContainer(ctx context.Context, route domain.Route
 	}
 	if !domain.IsSkipReadiness(ctx) {
 		if err := s.waitForReady(ctx, newContainer.ID, containerConfig); err != nil {
+			deployErr := s.newDeployFailure(newContainer, "container failed readiness check", err, s.captureRecentContainerLogs(ctx, newContainer.ID))
 			s.cleanupFailedContainer(ctx, newContainer.ID)
-			return nil, log.WrapErr(err, "container failed readiness check")
+			return nil, deployErr
 		}
 	}
 
@@ -642,6 +650,194 @@ func (s *Service) createStartedContainer(ctx context.Context, route domain.Route
 	}
 
 	return inspected, nil
+}
+
+func (s *Service) newDeployFailure(container *domain.Container, cause string, err error, logs []string) error {
+	deployErr := &domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   cause,
+		Hint:    inferDeployFailureHint(err),
+		Logs:    logs,
+		Err:     err,
+	}
+	if container != nil {
+		deployErr.ContainerName = container.Name
+		deployErr.ContainerID = container.ID
+	}
+
+	return deployErr
+}
+
+func (s *Service) wrapPullDeployFailure(route domain.Route, existing *domain.Container, err error) error {
+	if !isPullFailure(err) {
+		return nil
+	}
+
+	return s.newDeployFailure(&domain.Container{Name: s.deploymentContainerName(route.Domain, existing)}, "failed to pull image", err, nil)
+}
+
+func (s *Service) captureRecentContainerLogs(ctx context.Context, containerID string) []string {
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	logStream, err := s.runtime.GetContainerLogs(ctx, containerID, false)
+	if err != nil {
+		return nil
+	}
+	defer func() {
+		_ = logStream.Close()
+	}()
+
+	logs, err := parseDockerLogLines(logStream, deployFailureLogLimit)
+	if err != nil {
+		return nil
+	}
+
+	return logs
+}
+
+func parseDockerLogLines(r io.Reader, maxLines int) ([]string, error) {
+	reader := bufio.NewReader(r)
+	collector := newLogLineCollector(maxLines)
+
+	header, err := reader.Peek(8)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return nil, err
+	}
+
+	if len(header) >= 8 && looksLikeDockerLogStream(header) {
+		return parseDockerFramedLogLines(reader, collector)
+	}
+
+	return parsePlainLogLines(reader, collector)
+}
+
+func parseDockerFramedLogLines(reader *bufio.Reader, collector *logLineCollector) ([]string, error) {
+	for {
+		frameHeader := make([]byte, 8)
+		if _, err := io.ReadFull(reader, frameHeader); err != nil {
+			if isLogStreamEOF(err) {
+				collector.flush()
+				return collector.lines, nil
+			}
+			return nil, err
+		}
+
+		size := int(binary.BigEndian.Uint32(frameHeader[4:8]))
+		if size <= 0 {
+			continue
+		}
+
+		payload, err := readLogPayload(reader, size)
+		if err != nil {
+			collector.addChunk(string(payload))
+			collector.flush()
+			if isLogStreamEOF(err) {
+				return collector.lines, nil
+			}
+			return nil, err
+		}
+
+		collector.addChunk(string(payload))
+	}
+}
+
+func parsePlainLogLines(reader *bufio.Reader, collector *logLineCollector) ([]string, error) {
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		collector.addLine(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	collector.flush()
+	return collector.lines, nil
+}
+
+func readLogPayload(reader *bufio.Reader, size int) ([]byte, error) {
+	payload := make([]byte, size)
+	_, err := io.ReadFull(reader, payload)
+	return payload, err
+}
+
+func isLogStreamEOF(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+}
+
+func looksLikeDockerLogStream(data []byte) bool {
+	return len(data) >= 8 && data[1] == 0 && data[2] == 0 && data[3] == 0
+}
+
+type logLineCollector struct {
+	lines    []string
+	pending  string
+	maxLines int
+}
+
+func newLogLineCollector(maxLines int) *logLineCollector {
+	return &logLineCollector{maxLines: maxLines}
+}
+
+func (c *logLineCollector) addChunk(chunk string) {
+	for _, part := range strings.SplitAfter(chunk, "\n") {
+		c.pending += part
+		if strings.HasSuffix(part, "\n") {
+			c.flush()
+		}
+	}
+}
+
+func (c *logLineCollector) addLine(line string) {
+	line = strings.TrimRight(line, "\r")
+	if line == "" {
+		return
+	}
+	c.lines = append(c.lines, line)
+	if c.maxLines > 0 && len(c.lines) > c.maxLines {
+		c.lines = c.lines[len(c.lines)-c.maxLines:]
+	}
+}
+
+func (c *logLineCollector) flush() {
+	if c.pending == "" {
+		return
+	}
+	c.addLine(strings.TrimRight(c.pending, "\r\n"))
+	c.pending = ""
+}
+
+func inferDeployFailureHint(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "healthcheck timeout"):
+		return "check startup logs and confirm the health endpoint becomes ready within the configured timeout"
+	case strings.Contains(msg, "unhealthy"):
+		return "inspect recent app logs and verify the healthcheck command reflects actual readiness"
+	case strings.Contains(msg, "no healthcheck detected"):
+		return "add a Docker healthcheck or switch readiness mode"
+	case isPullFailure(err), strings.Contains(msg, "access denied"), strings.Contains(msg, "unauthorized"):
+		return "verify registry auth and confirm the image exists at the requested tag"
+	default:
+		return ""
+	}
+}
+
+func isPullFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "failed to pull image") ||
+		strings.Contains(msg, "pull access denied") ||
+		strings.Contains(msg, "unauthorized")
 }
 
 func (s *Service) activateDeployedContainer(ctx context.Context, domainName string, container *domain.Container) bool {
@@ -2827,6 +3023,9 @@ func (s *Service) waitForHealthy(ctx context.Context, containerID string, timeou
 		}
 		if status == "healthy" {
 			return nil
+		}
+		if status == "unhealthy" {
+			return errors.New("container reported unhealthy")
 		}
 		lastStatus = status
 

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -320,7 +320,8 @@ func (s *Service) Deploy(ctx context.Context, route domain.Route) (*domain.Conta
 	resources, err := s.prepareDeployResources(ctx, route, existing)
 	if err != nil {
 		if deployErr := s.wrapPullDeployFailure(route, existing, err); deployErr != nil {
-			return nil, deployErr
+			err = deployErr
+			return nil, err
 		}
 		return nil, err
 	}

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1,10 +1,14 @@
 package container
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +29,20 @@ import (
 
 func testContext() context.Context {
 	return zerowrap.WithCtx(context.Background(), zerowrap.Default())
+}
+
+func dockerLogFrames(stream byte, lines ...string) io.ReadCloser {
+	var buf bytes.Buffer
+	for _, line := range lines {
+		payload := []byte(line)
+		header := make([]byte, 8)
+		header[0] = stream
+		binary.BigEndian.PutUint32(header[4:], uint32(len(payload)))
+		_, _ = buf.Write(header)
+		_, _ = buf.Write(payload)
+	}
+
+	return io.NopCloser(bytes.NewReader(buf.Bytes()))
 }
 
 // testMinDelayConfig returns a Config with all timing delays set to 1ms,
@@ -474,7 +492,132 @@ func TestService_Deploy_ImagePullFailure(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "failed to pull image")
+	var deployErr *domain.DeployFailureError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "failed to deploy", deployErr.Error())
+	assert.Equal(t, "failed to pull image", deployErr.Cause)
+	assert.Equal(t, "verify registry auth and confirm the image exists at the requested tag", deployErr.Hint)
+	assert.Equal(t, "gordon-test.example.com", deployErr.ContainerName)
+	assert.Empty(t, deployErr.ContainerID)
+	assert.ErrorContains(t, deployErr.Err, "failed to pull image")
+}
+
+func TestService_CaptureRecentContainerLogs_SkipsCanceledContext(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{}, nil)
+
+	ctx, cancel := context.WithCancel(testContext())
+	cancel()
+
+	logs := svc.captureRecentContainerLogs(ctx, "container-123")
+
+	assert.Nil(t, logs)
+}
+
+func TestService_Deploy_ReadinessFailureReturnsDeployFailureWithLogs(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := Config{
+		ReadinessMode:        "docker-health",
+		HealthTimeout:        10 * time.Millisecond,
+		ReadinessDelay:       time.Millisecond,
+		DrainDelay:           time.Millisecond,
+		DrainDelayConfigured: true,
+	}
+
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+	ctx := testContext()
+
+	route := domain.Route{Domain: "test.example.com", Image: "myapp:latest"}
+
+	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{}, nil)
+	runtime.EXPECT().PullImage(mock.Anything, "myapp:latest").Return(nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:latest").Return([]int{8080}, nil)
+	runtime.EXPECT().GetImageLabels(mock.Anything, "myapp:latest").Return(nil, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
+
+	newContainer := &domain.Container{ID: "new-container", Name: "gordon-test.example.com", Status: "created"}
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.Anything).Return(newContainer, nil)
+	runtime.EXPECT().StartContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-container").Return(true, nil).Once()
+	runtime.EXPECT().GetContainerHealthStatus(mock.Anything, "new-container").Return("starting", true, nil).Twice()
+
+	logLines := make([]string, 0, 25)
+	for i := 1; i <= 25; i++ {
+		logLines = append(logLines, fmt.Sprintf("line-%02d\n", i))
+	}
+	runtime.EXPECT().GetContainerLogs(mock.Anything, "new-container", false).Return(dockerLogFrames(1, logLines...), nil)
+	runtime.EXPECT().StopContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().RemoveContainer(mock.Anything, "new-container", true).Return(nil)
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.Nil(t, result)
+	var deployErr *domain.DeployFailureError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "failed to deploy", deployErr.Summary)
+	assert.Equal(t, "container failed readiness check", deployErr.Cause)
+	assert.Equal(t, "check startup logs and confirm the health endpoint becomes ready within the configured timeout", deployErr.Hint)
+	assert.Equal(t, "gordon-test.example.com", deployErr.ContainerName)
+	assert.Equal(t, "new-container", deployErr.ContainerID)
+	require.Len(t, deployErr.Logs, 20)
+	assert.Equal(t, "line-06", deployErr.Logs[0])
+	assert.Equal(t, "line-25", deployErr.Logs[19])
+	assert.True(t, strings.Contains(err.Error(), "failed to deploy"))
+	assert.ErrorContains(t, deployErr.Err, "last status: starting")
+}
+
+func TestService_Deploy_StrictHealthModeWithoutHealthcheckReturnsHint(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := Config{
+		ReadinessMode:        "docker-health",
+		ReadinessDelay:       time.Millisecond,
+		DrainDelay:           time.Millisecond,
+		DrainDelayConfigured: true,
+	}
+
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+	ctx := testContext()
+
+	route := domain.Route{Domain: "test.example.com", Image: "myapp:latest"}
+
+	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{}, nil)
+	runtime.EXPECT().PullImage(mock.Anything, "myapp:latest").Return(nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:latest").Return([]int{8080}, nil)
+	runtime.EXPECT().GetImageLabels(mock.Anything, "myapp:latest").Return(nil, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
+
+	newContainer := &domain.Container{ID: "new-container", Name: "gordon-test.example.com", Status: "created"}
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.Anything).Return(newContainer, nil)
+	runtime.EXPECT().StartContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-container").Return(true, nil).Once()
+	runtime.EXPECT().GetContainerHealthStatus(mock.Anything, "new-container").Return("", false, nil).Once()
+	runtime.EXPECT().GetContainerLogs(mock.Anything, "new-container", false).Return(dockerLogFrames(1, "booting\n"), nil)
+	runtime.EXPECT().StopContainer(mock.Anything, "new-container").Return(nil)
+	runtime.EXPECT().RemoveContainer(mock.Anything, "new-container", true).Return(nil)
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.Nil(t, result)
+	var deployErr *domain.DeployFailureError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "container failed readiness check", deployErr.Cause)
+	assert.Equal(t, "add a Docker healthcheck or switch readiness mode", deployErr.Hint)
+	assert.Equal(t, []string{"booting"}, deployErr.Logs)
+	assert.Equal(t, "gordon-test.example.com", deployErr.ContainerName)
+	assert.Equal(t, "new-container", deployErr.ContainerID)
+	assert.ErrorContains(t, deployErr.Err, "no healthcheck detected")
 }
 
 func TestService_PullImage_UsesServiceTokenForExternalPull(t *testing.T) {
@@ -3601,6 +3744,7 @@ func TestService_Deploy_ZeroDowntime_ReadinessFailure_OldUntouched(t *testing.T)
 	// Recovery window poll: return error to fail fast instead of waiting 30s
 	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-container").
 		Return(false, errors.New("container exited")).Once()
+	runtime.EXPECT().GetContainerLogs(mock.Anything, "new-container", false).Return(dockerLogFrames(1, "crash line\n"), nil)
 
 	// cleanupFailedContainer: stop and remove the failed new container
 	runtime.EXPECT().StopContainer(mock.Anything, "new-container").Return(nil)
@@ -3615,7 +3759,14 @@ func TestService_Deploy_ZeroDowntime_ReadinessFailure_OldUntouched(t *testing.T)
 	// Deploy should return an error (readiness failure)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "readiness check")
+	var deployErr *domain.DeployFailureError
+	require.ErrorAs(t, err, &deployErr)
+	assert.Equal(t, "failed to deploy", deployErr.Error())
+	assert.Equal(t, "container failed readiness check", deployErr.Cause)
+	assert.Equal(t, []string{"crash line"}, deployErr.Logs)
+	assert.Equal(t, "gordon-test.example.com-new", deployErr.ContainerName)
+	assert.Equal(t, "new-container", deployErr.ContainerID)
+	assert.ErrorContains(t, deployErr.Err, "container exited")
 
 	// Old container must still be tracked — completely untouched
 	tracked, exists := svc.Get(ctx, "test.example.com")


### PR DESCRIPTION
## Summary
- add a typed deploy failure model in the container use case, including hints and recent logs for failed deploys
- return structured deploy failure JSON from the admin API and parse it in the remote CLI client
- render the same deploy failure output for local and remote CLI deploy paths while preserving generic fallback behavior

## Test Plan
- [x] go test ./internal/usecase/container ./internal/adapters/in/http/admin ./internal/adapters/in/cli/remote ./internal/adapters/in/cli
- [x] go test ./...
- [x] golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured deployment failures now include summary, cause, hint and recent sanitized container logs (capped).
  * CLI deploy adds --json output, status-aware success messages (deployed/queued/other), truncated container IDs, and emits warnings when falling back to local deploy.
  * Admin API returns structured JSON on deployment failures.

* **Bug Fixes**
  * Improved readiness and image-pull failure handling and safer log sanitization; clearer remote→local fallback reporting.

* **Tests**
  * Added tests for formatted failures, JSON error parsing, deploy flows and fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->