### PR TITLE
refactor: resolve pre-release release polish findings

### DIFF
--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -232,6 +232,15 @@ Examples:
 	return cmd
 }
 
+func resolveRequiredRemote(flagToken string) (*remote.ResolvedRemote, error) {
+	resolved, isRemote := remote.Resolve(remoteFlag, flagToken, insecureTLSFlag)
+	if !isRemote {
+		return nil, fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	}
+
+	return resolved, nil
+}
+
 func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) error {
 	token = strings.TrimSpace(token)
 	if token == "" {
@@ -239,9 +248,9 @@ func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) err
 	}
 
 	// Resolve remote — but use the new token (not the stored one) for verification.
-	resolved, isRemote := remote.Resolve(remoteFlag, "", insecureTLSFlag)
-	if !isRemote {
-		return fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	resolved, err := resolveRequiredRemote("")
+	if err != nil {
+		return err
 	}
 
 	client := remote.NewClient(resolved.URL, remoteClientOptions(token, resolved.InsecureTLS)...)
@@ -271,9 +280,9 @@ func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) err
 }
 
 func runAuthLoginVerify(ctx context.Context, out io.Writer) error {
-	resolved, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
-	if !isRemote {
-		return fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	resolved, err := resolveRequiredRemote(tokenFlag)
+	if err != nil {
+		return err
 	}
 	if resolved.Token == "" {
 		return fmt.Errorf("no token stored for remote '%s'; use: gordon auth login --token <token>", resolved.DisplayName())
@@ -317,9 +326,9 @@ Examples:
 }
 
 func runAuthShowToken(out io.Writer) error {
-	resolved, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
-	if !isRemote {
-		return fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	resolved, err := resolveRequiredRemote(tokenFlag)
+	if err != nil {
+		return err
 	}
 	if resolved.Token == "" {
 		return fmt.Errorf("no token found for remote '%s'", resolved.DisplayName())
@@ -355,9 +364,9 @@ Examples:
 }
 
 func runAuthLogout(out io.Writer) error {
-	resolved, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
-	if !isRemote {
-		return fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	resolved, err := resolveRequiredRemote(tokenFlag)
+	if err != nil {
+		return err
 	}
 	if resolved.Name == "" {
 		return fmt.Errorf("cannot logout from ad-hoc URL. Use 'gordon remotes add' to save this remote first")
@@ -700,9 +709,9 @@ Examples:
 
 // runAuthStatus checks authentication status for the active remote.
 func runAuthStatus(ctx context.Context) error {
-	resolved, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
-	if !isRemote {
-		return fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
+	resolved, err := resolveRequiredRemote(tokenFlag)
+	if err != nil {
+		return err
 	}
 
 	client := remote.NewClient(resolved.URL, remoteClientOptions(resolved.Token, resolved.InsecureTLS)...)

--- a/internal/adapters/in/cli/backup.go
+++ b/internal/adapters/in/cli/backup.go
@@ -7,9 +7,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/bnema/gordon/internal/adapters/dto"
 	"github.com/bnema/gordon/pkg/bytesize"
-	"github.com/spf13/cobra"
 )
 
 // newBackupCmd creates the backup command group.

--- a/internal/adapters/in/cli/ca.go
+++ b/internal/adapters/in/cli/ca.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	pkiadapter "github.com/bnema/gordon/internal/adapters/out/pki"
+	boundaryout "github.com/bnema/gordon/internal/boundaries/out"
 )
 
 func newCACmd() *cobra.Command {
@@ -108,7 +109,7 @@ func resolveCADataDir() (string, error) {
 // loadCAFromDataDir creates a CA adapter directly (bypassing the usecase layer).
 // This is intentional: CLI commands like 'ca export' and 'ca info' are standalone
 // admin utilities that run outside the server lifecycle and don't need business logic.
-func loadCAFromDataDir(dataDir string) (*pkiadapter.CA, error) {
+func loadCAFromDataDir(dataDir string) (boundaryout.CertificateAuthority, error) {
 	ca, err := pkiadapter.NewCA(dataDir, cliLogger())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load CA from %s: %w", dataDir, err)
@@ -155,7 +156,7 @@ func runCAInstall(_ context.Context, out io.Writer, dataDir string, uninstall, j
 	}
 
 	if uninstall {
-		if err := pkiadapter.UninstallRoot(cert); err != nil {
+		if err := ca.UninstallRoot(cert); err != nil {
 			return fmt.Errorf("failed to uninstall root CA: %w", err)
 		}
 		if jsonOut {
@@ -164,7 +165,7 @@ func runCAInstall(_ context.Context, out io.Writer, dataDir string, uninstall, j
 		return cliWriteLine(out, cliRenderSuccess("Root CA removed from system trust stores"))
 	}
 
-	if err := pkiadapter.InstallRoot(cert); err != nil {
+	if err := ca.InstallRoot(cert); err != nil {
 		return fmt.Errorf("failed to install root CA: %w", err)
 	}
 	if jsonOut {

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -71,10 +71,7 @@ func runDeploy(ctx context.Context, deployer deployer, isRemote bool, deployDoma
 		messageDomain = result.Domain
 	}
 
-	containerID := result.ContainerID
-	if containerID != "" && len(containerID) > 12 {
-		containerID = containerID[:12]
-	}
+	containerID := shortContainerID(result.ContainerID)
 
 	switch result.Status {
 	case "deployed":

--- a/internal/adapters/in/cli/deploy_error.go
+++ b/internal/adapters/in/cli/deploy_error.go
@@ -56,14 +56,15 @@ func structuredDeployFailure(err error) (error, bool) {
 
 func renderDeployFailure(summary, cause, hint string, logs []string) string {
 	if summary == "" {
-		summary = "failed to deploy"
+		summary = domain.DefaultDeployFailureSummary
 	}
 
 	var b strings.Builder
-	if summary == "failed to deploy" {
+	if summary == domain.DefaultDeployFailureSummary {
 		b.WriteString(summary)
 	} else {
-		b.WriteString("failed to deploy: ")
+		b.WriteString(domain.DefaultDeployFailureSummary)
+		b.WriteString(": ")
 		b.WriteString(summary)
 	}
 

--- a/internal/adapters/in/cli/parity_matrix_test.go
+++ b/internal/adapters/in/cli/parity_matrix_test.go
@@ -17,11 +17,6 @@ type uiAdoptionExpectation struct {
 
 var uiAdoptionExpectations = []uiAdoptionExpectation{
 	{
-		family:    "server",
-		file:      "serve.go",
-		functions: []string{"newStartCmd"},
-	},
-	{
 		family:    "root/server",
 		file:      "root.go",
 		functions: []string{"newVersionCmd", "runReloadRemote", "runLogsRemote", "streamLogsRemote", "showContainerLogsLocal"},

--- a/internal/adapters/in/cli/presentation.go
+++ b/internal/adapters/in/cli/presentation.go
@@ -63,3 +63,11 @@ func cliRenderWarning(msg string) string {
 func cliRenderInfo(msg string) string {
 	return styles.RenderInfo(msg)
 }
+
+func shortContainerID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+
+	return id
+}

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -681,10 +681,7 @@ func deployAfterPush(ctx context.Context, cp ControlPlane, pushDomain string, no
 	if err != nil {
 		return formatDeployFailure(err)
 	}
-	containerID := result.ContainerID
-	if len(containerID) > 12 {
-		containerID = containerID[:12]
-	}
+	containerID := shortContainerID(result.ContainerID)
 	fmt.Println(styles.RenderSuccess(fmt.Sprintf("Deployed %s (container: %s)", pushDomain, containerID)))
 	return nil
 }

--- a/internal/adapters/in/cli/remote/config.go
+++ b/internal/adapters/in/cli/remote/config.go
@@ -110,7 +110,9 @@ func migrateClientConfig(config *ClientConfig) {
 		config.Active = "default"
 	}
 
-	_ = SaveRemotes("", config)
+	if err := SaveRemotes("", config); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to save migrated remotes: %v\n", err)
+	}
 }
 
 func defaultGordonTomlPath() string {

--- a/internal/adapters/in/cli/remote/config.go
+++ b/internal/adapters/in/cli/remote/config.go
@@ -97,7 +97,9 @@ func migrateClientConfig(config *ClientConfig) {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "Notice: migrated [client] config from gordon.toml to 'default' remote. The [client] section is deprecated; use 'gordon remotes' instead.\n")
+	if _, err := fmt.Fprintf(os.Stderr, "Notice: migrated [client] config from gordon.toml to 'default' remote. The [client] section is deprecated; use 'gordon remotes' instead.\n"); err != nil {
+		_, _ = os.Stderr.WriteString("Warning: failed to write remote migration notice\n")
+	}
 
 	config.Remotes["default"] = RemoteEntry{
 		URL:         legacy.Client.Remote,
@@ -111,7 +113,9 @@ func migrateClientConfig(config *ClientConfig) {
 	}
 
 	if err := SaveRemotes("", config); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to save migrated remotes: %v\n", err)
+		if _, writeErr := fmt.Fprintf(os.Stderr, "Warning: failed to save migrated remotes: %v\n", err); writeErr != nil {
+			_, _ = os.Stderr.WriteString("Warning: failed to write remote migration warning\n")
+		}
 	}
 }
 

--- a/internal/adapters/in/cli/rollback.go
+++ b/internal/adapters/in/cli/rollback.go
@@ -244,10 +244,7 @@ func deploySelectedTag(ctx context.Context, cp ControlPlane, route *domain.Route
 		}
 		return fmt.Errorf("failed to deploy (route reverted): %w", err)
 	}
-	containerID := result.ContainerID
-	if len(containerID) > 12 {
-		containerID = containerID[:12]
-	}
+	containerID := shortContainerID(result.ContainerID)
 	fmt.Println(styles.RenderSuccess(fmt.Sprintf("Rolled back %s to %s (container: %s)", rollbackDomain, selectedTag, containerID)))
 	return nil
 }

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -68,10 +68,6 @@ Commands are organized by where they run:
 	serveCmd.GroupID = groupServer
 	rootCmd.AddCommand(serveCmd)
 
-	startCmd := newStartCmd() // Deprecated alias for serve
-	startCmd.GroupID = groupServer
-	rootCmd.AddCommand(startCmd)
-
 	authCmd := newAuthCmd()
 	authCmd.GroupID = groupServer
 	rootCmd.AddCommand(authCmd)

--- a/internal/adapters/in/cli/serve.go
+++ b/internal/adapters/in/cli/serve.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/bnema/gordon/internal/app"
 
@@ -23,30 +22,6 @@ func newServeCmd() *cobra.Command {
 	}
 
 	// Add flags
-	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to config file")
-
-	return cmd
-}
-
-// newStartCmd creates a deprecated alias for serve.
-func newStartCmd() *cobra.Command {
-	var configPath string
-
-	cmd := &cobra.Command{
-		Use:        "start",
-		Short:      "Start the Gordon server (deprecated: use 'serve')",
-		Long:       `Start the Gordon server. This command is deprecated, please use 'gordon serve' instead.`,
-		Deprecated: "use 'gordon serve' instead",
-		Hidden:     true, // Hide from help but still works
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cliWriteLine(os.Stderr, cliRenderWarning("Warning: 'gordon start' is deprecated, use 'gordon serve' instead")); err != nil {
-				return err
-			}
-			return app.Run(context.Background(), configPath)
-		},
-	}
-
-	// Add flags (same as serve)
 	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to config file")
 
 	return cmd

--- a/internal/adapters/in/http/admin/middleware_test.go
+++ b/internal/adapters/in/http/admin/middleware_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
 	"github.com/bnema/gordon/internal/domain"
@@ -78,7 +78,7 @@ func TestAuthMiddleware_TrustedProxy(t *testing.T) {
 	ipLimiter := outmocks.NewMockRateLimiter(t)
 
 	// Request from trusted proxy, should use X-Forwarded-For IP
-	trustedNets := middleware.ParseTrustedProxies([]string{"127.0.0.1"})
+	trustedNets := httphelper.ParseTrustedProxies([]string{"127.0.0.1"})
 
 	globalLimiter.EXPECT().Allow(context.Background(), "global").Return(true)
 	ipLimiter.EXPECT().Allow(context.Background(), "ip:203.0.113.50").Return(true)

--- a/internal/adapters/in/http/auth/handler.go
+++ b/internal/adapters/in/http/auth/handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
-	"github.com/bnema/gordon/internal/adapters/in/http/httputil"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/boundaries/in"
 	"github.com/bnema/gordon/internal/domain"
 )
@@ -166,7 +166,7 @@ func (h *Handler) handleToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) authenticateTokenCredentials(ctx context.Context, r *http.Request, username, password string, log zerowrap.Logger) (bool, *domain.TokenClaims) {
-	if httputil.IsLocalhostRequest(r) && h.isInternalAuth(username, password) {
+	if httphelper.IsLocalhostRequest(r) && h.isInternalAuth(username, password) {
 		log.Debug().Str("username", username).Msg("internal registry auth accepted")
 		return true, &domain.TokenClaims{
 			Subject: username,

--- a/internal/adapters/in/http/auth/handler_test.go
+++ b/internal/adapters/in/http/auth/handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/httputil"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/boundaries/in/mocks"
 	"github.com/bnema/gordon/internal/domain"
 )
@@ -358,7 +358,7 @@ func TestIsLocalhostRequest(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/auth/token", nil)
 			req.RemoteAddr = tt.remoteAddr
 
-			result := httputil.IsLocalhostRequest(req)
+			result := httphelper.IsLocalhostRequest(req)
 
 			assert.Equal(t, tt.want, result)
 		})

--- a/internal/adapters/in/http/httphelper/localhost.go
+++ b/internal/adapters/in/http/httphelper/localhost.go
@@ -1,4 +1,4 @@
-package httputil
+package httphelper
 
 import (
 	"net"

--- a/internal/adapters/in/http/httphelper/localhost_test.go
+++ b/internal/adapters/in/http/httphelper/localhost_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
@@ -25,9 +27,8 @@ func TestIsLocalhostRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.RemoteAddr = tt.remoteAddr
-			if got := httphelper.IsLocalhostRequest(req); got != tt.want {
-				t.Errorf("IsLocalhostRequest(%q) = %v, want %v", tt.remoteAddr, got, tt.want)
-			}
+			got := httphelper.IsLocalhostRequest(req)
+			assert.Equal(t, tt.want, got, "IsLocalhostRequest(%q)", tt.remoteAddr)
 		})
 	}
 }

--- a/internal/adapters/in/http/httphelper/localhost_test.go
+++ b/internal/adapters/in/http/httphelper/localhost_test.go
@@ -1,11 +1,11 @@
-package httputil_test
+package httphelper_test
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/httputil"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
 func TestIsLocalhostRequest(t *testing.T) {
@@ -25,7 +25,7 @@ func TestIsLocalhostRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.RemoteAddr = tt.remoteAddr
-			if got := httputil.IsLocalhostRequest(req); got != tt.want {
+			if got := httphelper.IsLocalhostRequest(req); got != tt.want {
 				t.Errorf("IsLocalhostRequest(%q) = %v, want %v", tt.remoteAddr, got, tt.want)
 			}
 		})

--- a/internal/adapters/in/http/httphelper/trust.go
+++ b/internal/adapters/in/http/httphelper/trust.go
@@ -16,6 +16,11 @@ var localhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
 func ParseTrustedProxies(proxies []string) []*net.IPNet {
 	var nets []*net.IPNet
 	for _, proxy := range proxies {
+		proxy = strings.TrimSpace(proxy)
+		if proxy == "" {
+			continue
+		}
+
 		// Try parsing as CIDR
 		_, ipNet, err := net.ParseCIDR(proxy)
 		if err == nil {

--- a/internal/adapters/in/http/httphelper/trust.go
+++ b/internal/adapters/in/http/httphelper/trust.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// localhostNets contains IPv4 and IPv6 loopback ranges.
-var localhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
+// LocalhostNets contains IPv4 and IPv6 loopback ranges.
+var LocalhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
 
 // ParseTrustedProxies converts a list of IP addresses and CIDR ranges to [net.IPNet].
 // It accepts both single IPs (e.g., "10.0.0.1") and CIDR notation (e.g., "10.0.0.0/8").
@@ -62,7 +62,7 @@ func IsTrustedProxy(ip string, trustedNets []*net.IPNet) bool {
 // IsTrustedOrLocal reports whether an IP belongs to localhost or the given
 // trusted proxy networks.
 func IsTrustedOrLocal(ip string, proxyNets []*net.IPNet) bool {
-	return IsTrustedProxy(ip, localhostNets) || IsTrustedProxy(ip, proxyNets)
+	return IsTrustedProxy(ip, LocalhostNets) || IsTrustedProxy(ip, proxyNets)
 }
 
 // ExtractRemoteIP returns the IP portion of an [http.Request.RemoteAddr],

--- a/internal/adapters/in/http/httphelper/trust.go
+++ b/internal/adapters/in/http/httphelper/trust.go
@@ -1,0 +1,110 @@
+package httphelper
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// localhostNets contains IPv4 and IPv6 loopback ranges.
+var localhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
+
+// ParseTrustedProxies converts a list of IP addresses and CIDR ranges to [net.IPNet].
+// It accepts both single IPs (e.g., "10.0.0.1") and CIDR notation (e.g., "10.0.0.0/8").
+// Single IPs are converted to /32 (IPv4) or /128 (IPv6) CIDR blocks.
+func ParseTrustedProxies(proxies []string) []*net.IPNet {
+	var nets []*net.IPNet
+	for _, proxy := range proxies {
+		// Try parsing as CIDR
+		_, ipNet, err := net.ParseCIDR(proxy)
+		if err == nil {
+			nets = append(nets, ipNet)
+			continue
+		}
+		// Try parsing as single IP
+		ip := net.ParseIP(proxy)
+		if ip != nil {
+			// Convert single IP to /32 or /128 CIDR
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+		}
+	}
+	return nets
+}
+
+// IsTrustedProxy reports whether the given IP address falls within any of the
+// trusted networks. Returns false if trustedNets is empty or the IP cannot be parsed.
+func IsTrustedProxy(ip string, trustedNets []*net.IPNet) bool {
+	if len(trustedNets) == 0 {
+		return false
+	}
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false
+	}
+	for _, ipNet := range trustedNets {
+		if ipNet.Contains(parsedIP) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTrustedOrLocal reports whether an IP belongs to localhost or the given
+// trusted proxy networks.
+func IsTrustedOrLocal(ip string, proxyNets []*net.IPNet) bool {
+	return IsTrustedProxy(ip, localhostNets) || IsTrustedProxy(ip, proxyNets)
+}
+
+// ExtractRemoteIP returns the IP portion of an [http.Request.RemoteAddr],
+// stripping the port. When RemoteAddr lacks a port (e.g. Unix sockets or
+// certain proxy setups), it is returned as-is.
+func ExtractRemoteIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}
+
+// IsTrustedSource reports whether the request's remote address is in trustedNets.
+// When RemoteAddr lacks a port, IPv6 brackets are stripped before checking.
+func IsTrustedSource(r *http.Request, trustedNets []*net.IPNet) bool {
+	if len(trustedNets) == 0 {
+		return false
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr may be a bare IP without a port (e.g. from Unix sockets
+		// or certain proxy setups). Fall back to using it directly.
+		host = strings.TrimSuffix(strings.TrimPrefix(r.RemoteAddr, "["), "]")
+	}
+	return IsTrustedProxy(host, trustedNets)
+}
+
+// HTTPSAuthority converts an incoming Host header plus httpPort/tlsPort into
+// the correct HTTPS authority (host or host:port).
+//
+// Rules:
+//   - No port in Host: omit TLS port (public reverse-proxy assumed on :443).
+//   - Host port == httpPort: map to tlsPort.
+//   - Any other explicit port: preserve it.
+func HTTPSAuthority(host string, httpPort, tlsPort int) string {
+	hostname, portStr, err := net.SplitHostPort(host)
+	if err != nil {
+		// No port in Host header — omit TLS port from URL.
+		return host
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err == nil && port == httpPort {
+		return net.JoinHostPort(hostname, strconv.Itoa(tlsPort))
+	}
+
+	// Unknown explicit port — preserve it.
+	return net.JoinHostPort(hostname, portStr)
+}

--- a/internal/adapters/in/http/middleware/accesslog.go
+++ b/internal/adapters/in/http/middleware/accesslog.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	out "github.com/bnema/gordon/internal/boundaries/out"
 )
 
@@ -45,7 +46,7 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 			// cidr.go (same package) — no separate loopback definition needed.
 			if excludeHealthChecks {
 				if strings.HasPrefix(r.UserAgent(), out.HealthCheckUserAgentPrefix) ||
-					IsTrustedProxy(clientIP, localhostNets) {
+					httphelper.IsTrustedProxy(clientIP, localhostNets) {
 					return
 				}
 			}

--- a/internal/adapters/in/http/middleware/accesslog.go
+++ b/internal/adapters/in/http/middleware/accesslog.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -60,7 +61,7 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 				Method:     r.Method,
 				Host:       r.Host,
 				Path:       r.URL.Path,
-				Query:      r.URL.RawQuery,
+				Query:      sanitizeLoggedQuery(r.URL.RawQuery),
 				Status:     rw.StatusCode(),
 				BytesSent:  rw.BytesWritten(),
 				DurationMS: durationMS,
@@ -83,5 +84,45 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 					Msg("access log write failed")
 			}
 		})
+	}
+}
+
+func sanitizeLoggedQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+
+	parts := strings.Split(rawQuery, "&")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		key, _, found := strings.Cut(part, "=")
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			decodedKey = key
+		}
+
+		if !isSensitiveQueryKey(decodedKey) {
+			continue
+		}
+
+		if found {
+			parts[i] = key + "=[REDACTED]"
+		} else {
+			parts[i] = key
+		}
+	}
+
+	return strings.Join(parts, "&")
+}
+
+func isSensitiveQueryKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "access_token", "auth", "code", "key", "password", "refresh_token", "reset", "secret", "sig", "signature", "token":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/adapters/in/http/middleware/accesslog.go
+++ b/internal/adapters/in/http/middleware/accesslog.go
@@ -42,11 +42,10 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 			// Apply health-check exclusion after the response so the request
 			// always completes — we just skip writing the log entry.
 			// UA check uses the shared domain constant so the prober and this
-			// filter can never drift. Loopback check reuses localhostNets from
-			// cidr.go (same package) — no separate loopback definition needed.
+			// filter can never drift. Loopback check uses the shared helper list.
 			if excludeHealthChecks {
 				if strings.HasPrefix(r.UserAgent(), out.HealthCheckUserAgentPrefix) ||
-					httphelper.IsTrustedProxy(clientIP, localhostNets) {
+					httphelper.IsTrustedProxy(clientIP, httphelper.LocalhostNets) {
 					return
 				}
 			}
@@ -121,7 +120,7 @@ func sanitizeLoggedQuery(rawQuery string) string {
 
 func isSensitiveQueryKey(key string) bool {
 	switch strings.ToLower(key) {
-	case "access_token", "auth", "code", "key", "password", "refresh_token", "reset", "secret", "sig", "signature", "token":
+	case "access_token", "api_key", "apikey", "auth", "bearer", "code", "credential", "credentials", "key", "password", "private_key", "refresh_token", "reset", "secret", "session", "session_id", "sig", "signature", "token":
 		return true
 	default:
 		return false

--- a/internal/adapters/in/http/middleware/accesslog_test.go
+++ b/internal/adapters/in/http/middleware/accesslog_test.go
@@ -58,6 +58,23 @@ func TestAccessLogger_EmitsEntryPerRequest(t *testing.T) {
 	assert.Equal(t, "192.168.1.100", e.ClientIP)
 }
 
+func TestAccessLogger_RedactsSensitiveQueryParams(t *testing.T) {
+	mock := &mockAccessLogWriter{}
+	log := testLogger()
+
+	handler := AccessLogger(mock, false, log, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=secret-code&state=ok&token=secret-token", nil)
+	rw := httptest.NewRecorder()
+
+	handler.ServeHTTP(rw, req)
+
+	require.Len(t, mock.entries, 1)
+	assert.Equal(t, "code=[REDACTED]&state=ok&token=[REDACTED]", mock.entries[0].Query)
+}
+
 func TestAccessLogger_RequestIDReused(t *testing.T) {
 	mock := &mockAccessLogWriter{}
 	log := testLogger()

--- a/internal/adapters/in/http/middleware/accesslog_test.go
+++ b/internal/adapters/in/http/middleware/accesslog_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,11 +66,16 @@ func TestAccessLogger_RedactsSensitiveQueryParams(t *testing.T) {
 	handler := AccessLogger(mock, false, log, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+	server := httptest.NewServer(handler)
+	defer server.Close()
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=secret-code&state=ok&token=secret-token", nil)
-	rw := httptest.NewRecorder()
-
-	handler.ServeHTTP(rw, req)
+	resp, err := http.Get(server.URL + "/oauth/callback?code=secret-code&state=ok&token=secret-token")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
 
 	require.Len(t, mock.entries, 1)
 	assert.Equal(t, "code=[REDACTED]&state=ok&token=[REDACTED]", mock.entries[0].Query)

--- a/internal/adapters/in/http/middleware/accesslog_test.go
+++ b/internal/adapters/in/http/middleware/accesslog_test.go
@@ -69,7 +69,7 @@ func TestAccessLogger_RedactsSensitiveQueryParams(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/oauth/callback?code=secret-code&state=ok&token=secret-token")
+	resp, err := http.Get(server.URL + "/oauth/callback?code=secret-code&state=ok&token=secret-token&api_key=top-secret&session_id=session-secret")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, resp.Body.Close())
@@ -78,7 +78,7 @@ func TestAccessLogger_RedactsSensitiveQueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, mock.entries, 1)
-	assert.Equal(t, "code=[REDACTED]&state=ok&token=[REDACTED]", mock.entries[0].Query)
+	assert.Equal(t, "code=[REDACTED]&state=ok&token=[REDACTED]&api_key=[REDACTED]&session_id=[REDACTED]", mock.entries[0].Query)
 }
 
 func TestAccessLogger_RequestIDReused(t *testing.T) {

--- a/internal/adapters/in/http/middleware/auth.go
+++ b/internal/adapters/in/http/middleware/auth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
-	"github.com/bnema/gordon/internal/adapters/in/http/httputil"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/boundaries/in"
 	"github.com/bnema/gordon/internal/domain"
 )
@@ -59,7 +59,7 @@ func RegistryAuthV2(authSvc in.AuthService, internalAuth InternalRegistryAuth, t
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Allow localhost requests only with internal instance credentials.
-			if httputil.IsLocalhostRequest(r) && isInternalRegistryAuth(r, internalAuth) {
+			if httphelper.IsLocalhostRequest(r) && isInternalRegistryAuth(r, internalAuth) {
 				log.Debug().
 					Str(zerowrap.FieldLayer, "adapter").
 					Str(zerowrap.FieldAdapter, "http").
@@ -72,7 +72,7 @@ func RegistryAuthV2(authSvc in.AuthService, internalAuth InternalRegistryAuth, t
 			}
 
 			// Warn if not using TLS (skip for localhost — internal proxy traffic)
-			if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !httputil.IsLocalhostRequest(r) {
+			if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" && !httphelper.IsLocalhostRequest(r) {
 				log.Warn().
 					Str(zerowrap.FieldLayer, "adapter").
 					Str(zerowrap.FieldAdapter, "http").

--- a/internal/adapters/in/http/middleware/cidr.go
+++ b/internal/adapters/in/http/middleware/cidr.go
@@ -27,12 +27,12 @@ func cidrAllowlist(allowedNets []*net.IPNet, ipExtractor func(*http.Request) str
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			clientIP := ipExtractor(r)
 
-			if IsTrustedProxy(clientIP, localhostNets) {
+			if httphelper.IsTrustedProxy(clientIP, localhostNets) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			if IsTrustedProxy(clientIP, allowedNets) {
+			if httphelper.IsTrustedProxy(clientIP, allowedNets) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -49,31 +49,6 @@ func cidrAllowlist(allowedNets []*net.IPNet, ipExtractor func(*http.Request) str
 			_ = json.NewEncoder(w).Encode(dto.ErrorResponse{Error: "Forbidden"})
 		})
 	}
-}
-
-// ExtractRemoteIP returns the IP portion of a RemoteAddr, stripping the port.
-//
-// Deprecated: use httphelper.ExtractRemoteIP directly. This wrapper preserves
-// the existing middleware API for callers that have not migrated yet.
-func ExtractRemoteIP(remoteAddr string) string {
-	return httphelper.ExtractRemoteIP(remoteAddr)
-}
-
-// IsTrustedOrLocal reports whether an IP belongs to localhost or trusted proxy nets.
-//
-// Deprecated: use httphelper.IsTrustedOrLocal directly. This wrapper preserves
-// the existing middleware API for callers that have not migrated yet.
-func IsTrustedOrLocal(ip string, proxyNets []*net.IPNet) bool {
-	return httphelper.IsTrustedOrLocal(ip, proxyNets)
-}
-
-// HTTPSAuthority converts an incoming Host header plus httpPort/tlsPort into the
-// correct HTTPS authority (host or host:port).
-//
-// Deprecated: use httphelper.HTTPSAuthority directly. This wrapper preserves
-// the existing middleware API for callers that have not migrated yet.
-func HTTPSAuthority(host string, httpPort, tlsPort int) string {
-	return httphelper.HTTPSAuthority(host, httpPort, tlsPort)
 }
 
 // RegistryCIDRAllowlist returns middleware that restricts access to the given CIDR ranges.
@@ -109,8 +84,8 @@ func HTTPSRedirect(proxyNets []*net.IPNet, httpPort, tlsPort int, forceAll bool,
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !forceAll {
-				remoteIP := ExtractRemoteIP(r.RemoteAddr)
-				if IsTrustedOrLocal(remoteIP, proxyNets) {
+				remoteIP := httphelper.ExtractRemoteIP(r.RemoteAddr)
+				if httphelper.IsTrustedOrLocal(remoteIP, proxyNets) {
 					next.ServeHTTP(w, r)
 					return
 				}
@@ -134,7 +109,7 @@ func httpsRedirectTarget(host, requestURI string, httpPort, tlsPort int) string 
 		path = "/"
 	}
 
-	return fmt.Sprintf("https://%s%s", HTTPSAuthority(host, httpPort, tlsPort), path)
+	return fmt.Sprintf("https://%s%s", httphelper.HTTPSAuthority(host, httpPort, tlsPort), path)
 }
 
 // ProxyCIDRAllowlist returns middleware that restricts proxy access to the given CIDR ranges.
@@ -143,6 +118,6 @@ func httpsRedirectTarget(host, requestURI string, httpPort, tlsPort int) string 
 // An empty allowedNets slice is a no-op (all traffic passes through).
 func ProxyCIDRAllowlist(allowedNets []*net.IPNet, log zerowrap.Logger) func(http.Handler) http.Handler {
 	return cidrAllowlist(allowedNets, func(r *http.Request) string {
-		return ExtractRemoteIP(r.RemoteAddr)
+		return httphelper.ExtractRemoteIP(r.RemoteAddr)
 	}, "proxy origin", log)
 }

--- a/internal/adapters/in/http/middleware/cidr.go
+++ b/internal/adapters/in/http/middleware/cidr.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
 // localhostNets contains IPv4 and IPv6 loopback ranges that are always allowed.
-var localhostNets = ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
+var localhostNets = httphelper.ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
 
 // cidrAllowlist is the shared implementation for CIDR-based access control middleware.
 // ipExtractor determines how the client IP is obtained from the request.
@@ -52,40 +52,28 @@ func cidrAllowlist(allowedNets []*net.IPNet, ipExtractor func(*http.Request) str
 }
 
 // ExtractRemoteIP returns the IP portion of a RemoteAddr, stripping the port.
+//
+// Deprecated: use httphelper.ExtractRemoteIP directly. This wrapper preserves
+// the existing middleware API for callers that have not migrated yet.
 func ExtractRemoteIP(remoteAddr string) string {
-	host, _, err := net.SplitHostPort(remoteAddr)
-	if err != nil {
-		return remoteAddr
-	}
-	return host
+	return httphelper.ExtractRemoteIP(remoteAddr)
 }
 
 // IsTrustedOrLocal reports whether an IP belongs to localhost or trusted proxy nets.
+//
+// Deprecated: use httphelper.IsTrustedOrLocal directly. This wrapper preserves
+// the existing middleware API for callers that have not migrated yet.
 func IsTrustedOrLocal(ip string, proxyNets []*net.IPNet) bool {
-	return IsTrustedProxy(ip, localhostNets) || IsTrustedProxy(ip, proxyNets)
+	return httphelper.IsTrustedOrLocal(ip, proxyNets)
 }
 
 // HTTPSAuthority converts an incoming Host header plus httpPort/tlsPort into the
 // correct HTTPS authority (host or host:port).
 //
-// Rules:
-//   - No port in Host → omit TLS port (public reverse-proxy assumed on :443).
-//   - Host port == httpPort → map to tlsPort.
-//   - Any other explicit port → preserve it.
+// Deprecated: use httphelper.HTTPSAuthority directly. This wrapper preserves
+// the existing middleware API for callers that have not migrated yet.
 func HTTPSAuthority(host string, httpPort, tlsPort int) string {
-	hostname, portStr, err := net.SplitHostPort(host)
-	if err != nil {
-		// No port in Host header — omit TLS port from URL.
-		return host
-	}
-
-	port, err := strconv.Atoi(portStr)
-	if err == nil && port == httpPort {
-		return net.JoinHostPort(hostname, strconv.Itoa(tlsPort))
-	}
-
-	// Unknown explicit port — preserve it.
-	return net.JoinHostPort(hostname, portStr)
+	return httphelper.HTTPSAuthority(host, httpPort, tlsPort)
 }
 
 // RegistryCIDRAllowlist returns middleware that restricts access to the given CIDR ranges.

--- a/internal/adapters/in/http/middleware/cidr.go
+++ b/internal/adapters/in/http/middleware/cidr.go
@@ -13,9 +13,6 @@ import (
 	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
-// localhostNets contains IPv4 and IPv6 loopback ranges that are always allowed.
-var localhostNets = httphelper.ParseTrustedProxies([]string{"127.0.0.0/8", "::1"})
-
 // cidrAllowlist is the shared implementation for CIDR-based access control middleware.
 // ipExtractor determines how the client IP is obtained from the request.
 // logLabel is used in the deny log message (e.g. "registry", "proxy origin").
@@ -27,7 +24,7 @@ func cidrAllowlist(allowedNets []*net.IPNet, ipExtractor func(*http.Request) str
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			clientIP := ipExtractor(r)
 
-			if httphelper.IsTrustedProxy(clientIP, localhostNets) {
+			if httphelper.IsTrustedProxy(clientIP, httphelper.LocalhostNets) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/adapters/in/http/middleware/cidr_test.go
+++ b/internal/adapters/in/http/middleware/cidr_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,46 +42,46 @@ func TestRegistryCIDRAllowlist(t *testing.T) {
 		},
 		{
 			name:        "allowed IP returns 200",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
 			remoteAddr:  "100.100.1.1:1234",
 			wantStatus:  http.StatusOK,
 		},
 		{
 			name:        "denied IP returns 403",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
 			remoteAddr:  "203.0.113.50:1234",
 			wantStatus:  http.StatusForbidden,
 		},
 		{
 			name:        "localhost always allowed even when not in allowlist",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
 			remoteAddr:  "127.0.0.1:1234",
 			wantStatus:  http.StatusOK,
 		},
 		{
 			name:        "127.x.x.x always allowed",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
 			remoteAddr:  "127.0.0.2:1234",
 			wantStatus:  http.StatusOK,
 		},
 		{
 			name:        "IPv6 localhost always allowed",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
 			remoteAddr:  "[::1]:1234",
 			wantStatus:  http.StatusOK,
 		},
 		{
 			name:        "trusted proxy forwards allowed client IP",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
-			trustedNets: ParseTrustedProxies([]string{"10.0.0.1"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			trustedNets: httphelper.ParseTrustedProxies([]string{"10.0.0.1"}),
 			remoteAddr:  "10.0.0.1:1234",
 			xff:         "100.100.1.1",
 			wantStatus:  http.StatusOK,
 		},
 		{
 			name:        "trusted proxy forwards denied client IP",
-			allowedNets: ParseTrustedProxies([]string{"100.64.0.0/10"}),
-			trustedNets: ParseTrustedProxies([]string{"10.0.0.1"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"100.64.0.0/10"}),
+			trustedNets: httphelper.ParseTrustedProxies([]string{"10.0.0.1"}),
 			remoteAddr:  "10.0.0.1:1234",
 			xff:         "203.0.113.50",
 			wantStatus:  http.StatusForbidden,
@@ -227,25 +228,25 @@ func TestProxyCIDRAllowlist(t *testing.T) {
 		},
 		{
 			name:        "allowed IP gets redirect",
-			allowedNets: ParseTrustedProxies([]string{"173.245.48.0/20"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"173.245.48.0/20"}),
 			remoteAddr:  "173.245.48.1:1234",
 			wantStatus:  http.StatusPermanentRedirect,
 		},
 		{
 			name:        "blocked IP gets 403",
-			allowedNets: ParseTrustedProxies([]string{"173.245.48.0/20"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"173.245.48.0/20"}),
 			remoteAddr:  "203.0.113.50:1234",
 			wantStatus:  http.StatusForbidden,
 		},
 		{
 			name:        "localhost always allowed",
-			allowedNets: ParseTrustedProxies([]string{"173.245.48.0/20"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"173.245.48.0/20"}),
 			remoteAddr:  "127.0.0.1:1234",
 			wantStatus:  http.StatusPermanentRedirect,
 		},
 		{
 			name:        "ignores XFF (uses RemoteAddr only)",
-			allowedNets: ParseTrustedProxies([]string{"173.245.48.0/20"}),
+			allowedNets: httphelper.ParseTrustedProxies([]string{"173.245.48.0/20"}),
 			remoteAddr:  "203.0.113.50:1234",
 			wantStatus:  http.StatusForbidden,
 		},

--- a/internal/adapters/in/http/middleware/clientip.go
+++ b/internal/adapters/in/http/middleware/clientip.go
@@ -4,12 +4,14 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
 // cloudflareNets contains Cloudflare's published IPv4 and IPv6 ranges.
 // Cf-Connecting-Ip is only trusted when the immediate upstream matches these.
 // Source: https://www.cloudflare.com/ips/
-var cloudflareNets = ParseTrustedProxies([]string{
+var cloudflareNets = httphelper.ParseTrustedProxies([]string{
 	// IPv4
 	"173.245.48.0/20",
 	"103.21.244.0/22",
@@ -57,45 +59,20 @@ func normalizeIP(raw string) string {
 // ParseTrustedProxies converts a list of IP addresses and CIDR ranges to net.IPNet.
 // It accepts both single IPs (e.g., "10.0.0.1") and CIDR notation (e.g., "10.0.0.0/8").
 // Single IPs are converted to /32 (IPv4) or /128 (IPv6) CIDR blocks.
+//
+// Deprecated: use httphelper.ParseTrustedProxies directly. This wrapper preserves
+// the existing middleware API for callers that have not migrated yet.
 func ParseTrustedProxies(proxies []string) []*net.IPNet {
-	var nets []*net.IPNet
-	for _, proxy := range proxies {
-		// Try parsing as CIDR
-		_, ipNet, err := net.ParseCIDR(proxy)
-		if err == nil {
-			nets = append(nets, ipNet)
-			continue
-		}
-		// Try parsing as single IP
-		ip := net.ParseIP(proxy)
-		if ip != nil {
-			// Convert single IP to /32 or /128 CIDR
-			bits := 32
-			if ip.To4() == nil {
-				bits = 128
-			}
-			nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
-		}
-	}
-	return nets
+	return httphelper.ParseTrustedProxies(proxies)
 }
 
 // IsTrustedProxy checks if the given IP address is from a trusted proxy.
 // Returns false if trustedNets is empty or the IP cannot be parsed.
+//
+// Deprecated: use httphelper.IsTrustedProxy directly. This wrapper preserves
+// the existing middleware API for callers that have not migrated yet.
 func IsTrustedProxy(ip string, trustedNets []*net.IPNet) bool {
-	if len(trustedNets) == 0 {
-		return false
-	}
-	parsedIP := net.ParseIP(ip)
-	if parsedIP == nil {
-		return false
-	}
-	for _, ipNet := range trustedNets {
-		if ipNet.Contains(parsedIP) {
-			return true
-		}
-	}
-	return false
+	return httphelper.IsTrustedProxy(ip, trustedNets)
 }
 
 // GetClientIP extracts the client IP address from the request.

--- a/internal/adapters/in/http/middleware/clientip.go
+++ b/internal/adapters/in/http/middleware/clientip.go
@@ -56,25 +56,6 @@ func normalizeIP(raw string) string {
 	return parsed.String()
 }
 
-// ParseTrustedProxies converts a list of IP addresses and CIDR ranges to net.IPNet.
-// It accepts both single IPs (e.g., "10.0.0.1") and CIDR notation (e.g., "10.0.0.0/8").
-// Single IPs are converted to /32 (IPv4) or /128 (IPv6) CIDR blocks.
-//
-// Deprecated: use httphelper.ParseTrustedProxies directly. This wrapper preserves
-// the existing middleware API for callers that have not migrated yet.
-func ParseTrustedProxies(proxies []string) []*net.IPNet {
-	return httphelper.ParseTrustedProxies(proxies)
-}
-
-// IsTrustedProxy checks if the given IP address is from a trusted proxy.
-// Returns false if trustedNets is empty or the IP cannot be parsed.
-//
-// Deprecated: use httphelper.IsTrustedProxy directly. This wrapper preserves
-// the existing middleware API for callers that have not migrated yet.
-func IsTrustedProxy(ip string, trustedNets []*net.IPNet) bool {
-	return httphelper.IsTrustedProxy(ip, trustedNets)
-}
-
 // GetClientIP extracts the client IP address from the request.
 // It only honors X-Forwarded-For and X-Real-IP headers when the request
 // originates from a trusted proxy. This prevents attackers from spoofing
@@ -90,12 +71,12 @@ func GetClientIP(r *http.Request, trustedNets []*net.IPNet) string {
 	}
 
 	// Only honor proxy headers if the request comes from a trusted proxy
-	if IsTrustedProxy(remoteIP, trustedNets) {
+	if httphelper.IsTrustedProxy(remoteIP, trustedNets) {
 		// Cf-Connecting-IP is set by Cloudflare to the true client IP.
 		// Only trust it when the immediate upstream is a known Cloudflare IP,
 		// not any generic trusted proxy (e.g. local LB/nginx), because a
 		// non-Cloudflare proxy would blindly forward a spoofed header.
-		if IsTrustedProxy(remoteIP, cloudflareNets) {
+		if httphelper.IsTrustedProxy(remoteIP, cloudflareNets) {
 			if cfIP := r.Header.Get("Cf-Connecting-Ip"); cfIP != "" {
 				if ip := normalizeIP(cfIP); ip != "" {
 					return ip
@@ -117,7 +98,7 @@ func GetClientIP(r *http.Request, trustedNets []*net.IPNet) string {
 			}
 
 			for i := len(validChain) - 1; i >= 0; i-- {
-				if !IsTrustedProxy(validChain[i], trustedNets) {
+				if !httphelper.IsTrustedProxy(validChain[i], trustedNets) {
 					return validChain[i]
 				}
 			}

--- a/internal/adapters/in/http/middleware/clientip_test.go
+++ b/internal/adapters/in/http/middleware/clientip_test.go
@@ -6,15 +6,16 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetClientIP(t *testing.T) {
 	// Parse trusted proxies for tests
-	trustedNets := ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8"})
+	trustedNets := httphelper.ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8"})
 	noTrustedNets := []*net.IPNet{}
 	// Include a Cloudflare IP in trusted proxies to test Cf-Connecting-Ip
-	trustedWithCF := ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8", "173.245.48.0/20"})
+	trustedWithCF := httphelper.ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8", "173.245.48.0/20"})
 
 	tests := []struct {
 		name        string
@@ -216,8 +217,8 @@ func TestParseTrustedProxies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nets := ParseTrustedProxies(tt.proxies)
-			got := IsTrustedProxy(tt.testIP, nets)
+			nets := httphelper.ParseTrustedProxies(tt.proxies)
+			got := httphelper.IsTrustedProxy(tt.testIP, nets)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -245,20 +246,20 @@ func TestIsTrustedProxy(t *testing.T) {
 		{
 			name:        "invalid IP",
 			ip:          "not-an-ip",
-			trustedNets: ParseTrustedProxies([]string{"192.168.1.0/24"}),
+			trustedNets: httphelper.ParseTrustedProxies([]string{"192.168.1.0/24"}),
 			want:        false,
 		},
 		{
 			name:        "empty IP",
 			ip:          "",
-			trustedNets: ParseTrustedProxies([]string{"192.168.1.0/24"}),
+			trustedNets: httphelper.ParseTrustedProxies([]string{"192.168.1.0/24"}),
 			want:        false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsTrustedProxy(tt.ip, tt.trustedNets)
+			got := httphelper.IsTrustedProxy(tt.ip, tt.trustedNets)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/adapters/in/http/middleware/logging.go
+++ b/internal/adapters/in/http/middleware/logging.go
@@ -130,7 +130,7 @@ func RequestLogger(log zerowrap.Logger, trustedNets ...[]*net.IPNet) func(http.H
 				Str("request_id", requestID).
 				Str(zerowrap.FieldMethod, r.Method).
 				Str(zerowrap.FieldPath, r.URL.Path).
-				Str("query", r.URL.RawQuery).
+				Str("query", sanitizeLoggedQuery(r.URL.RawQuery)).
 				Str(zerowrap.FieldHost, r.Host).
 				Str("user_agent", r.UserAgent()).
 				Str("referer", r.Referer()).

--- a/internal/adapters/in/http/onboarding/handler.go
+++ b/internal/adapters/in/http/onboarding/handler.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 )
 
 // Handler serves CA onboarding endpoints for direct/Tailnet clients.
@@ -49,7 +49,7 @@ func (h *Handler) ServeMobileconfig(w http.ResponseWriter, _ *http.Request) {
 // publicHTTPSURL derives the public HTTPS URL from the request Host header.
 // The result is HTML-escaped to prevent XSS via a crafted Host header.
 func (h *Handler) publicHTTPSURL(r *http.Request) string {
-	authority := middleware.HTTPSAuthority(r.Host, h.httpPort, h.tlsPort)
+	authority := httphelper.HTTPSAuthority(r.Host, h.httpPort, h.tlsPort)
 	return html.EscapeString("https://" + authority + "/")
 }
 

--- a/internal/adapters/in/http/proxy/forwarder.go
+++ b/internal/adapters/in/http/proxy/forwarder.go
@@ -202,7 +202,7 @@ func newReverseProxy(targetURL *url.URL, originalHost string, transport http.Rou
 			// SetXForwarded() unconditionally sets it based on the incoming scheme
 			// (HTTP between proxies), but when a trusted proxy already sent the
 			// real client proto, we must honor it.
-			if existingProto != "" && isTrustedSource(incomingReq, trustedNets) {
+			if existingProto != "" && gordonhttp.IsTrustedSource(incomingReq, trustedNets) {
 				pr.Out.Header.Set("X-Forwarded-Proto", existingProto)
 			}
 		},
@@ -210,11 +210,6 @@ func newReverseProxy(targetURL *url.URL, originalHost string, transport http.Rou
 		ErrorHandler:   errorHandler,
 		ModifyResponse: modifyResp,
 	}
-}
-
-// isTrustedSource reports whether the request's remote address is in trustedNets.
-func isTrustedSource(r *http.Request, trustedNets []*net.IPNet) bool {
-	return gordonhttp.IsTrustedSource(r, trustedNets)
 }
 
 // modifyResponse returns a function that adds proxy headers and enforces response size limits.

--- a/internal/adapters/in/http/proxy/forwarder.go
+++ b/internal/adapters/in/http/proxy/forwarder.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	gordonhttp "github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/domain"
 )
 
@@ -214,16 +214,7 @@ func newReverseProxy(targetURL *url.URL, originalHost string, transport http.Rou
 
 // isTrustedSource reports whether the request's remote address is in trustedNets.
 func isTrustedSource(r *http.Request, trustedNets []*net.IPNet) bool {
-	if len(trustedNets) == 0 {
-		return false
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		// RemoteAddr may be a bare IP without a port (e.g. from Unix sockets
-		// or certain proxy setups). Fall back to using it directly.
-		host = strings.TrimSuffix(strings.TrimPrefix(r.RemoteAddr, "["), "]")
-	}
-	return middleware.IsTrustedProxy(host, trustedNets)
+	return gordonhttp.IsTrustedSource(r, trustedNets)
 }
 
 // modifyResponse returns a function that adds proxy headers and enforces response size limits.

--- a/internal/adapters/in/http/proxy/forwarder_test.go
+++ b/internal/adapters/in/http/proxy/forwarder_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
+	gordonhttp "github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/boundaries/in"
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	"github.com/bnema/gordon/internal/domain"
@@ -201,7 +201,7 @@ func TestForwardToTarget_ProxyHeaderSet(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 func TestNewReverseProxy_XForwardedProto(t *testing.T) {
-	trustedNets := middleware.ParseTrustedProxies([]string{"10.0.0.0/8"})
+	trustedNets := gordonhttp.ParseTrustedProxies([]string{"10.0.0.0/8"})
 
 	tests := []struct {
 		name          string
@@ -250,7 +250,7 @@ func TestNewReverseProxy_XForwardedProto(t *testing.T) {
 			remoteAddr:    "[::1]",
 			incomingProto: "https",
 			wantProto:     "https",
-			nets:          middleware.ParseTrustedProxies([]string{"::1/128"}),
+			nets:          gordonhttp.ParseTrustedProxies([]string{"::1/128"}),
 		},
 		{
 			name:          "bare IPv4 no port untrusted source strips proto",

--- a/internal/adapters/in/http/registry/ratelimit.go
+++ b/internal/adapters/in/http/registry/ratelimit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
 	"github.com/bnema/gordon/internal/boundaries/out"
 )
@@ -29,7 +30,7 @@ func RateLimitMiddleware(
 	}
 
 	// Parse trusted proxy CIDRs once at middleware creation
-	trustedNets := middleware.ParseTrustedProxies(trustedProxies)
+	trustedNets := httphelper.ParseTrustedProxies(trustedProxies)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapters/in/http/registry/ratelimit_test.go
+++ b/internal/adapters/in/http/registry/ratelimit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
 	"github.com/bnema/gordon/internal/adapters/out/ratelimit"
 	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
@@ -221,7 +222,7 @@ func TestRateLimitMiddleware_Integration(t *testing.T) {
 
 func TestGetClientIP(t *testing.T) {
 	// Parse trusted proxies for tests
-	trustedNets := middleware.ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8"})
+	trustedNets := httphelper.ParseTrustedProxies([]string{"127.0.0.1", "10.0.0.0/8"})
 	noTrustedNets := []*net.IPNet{}
 
 	tests := []struct {
@@ -373,8 +374,8 @@ func TestParseTrustedProxies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nets := middleware.ParseTrustedProxies(tt.proxies)
-			got := middleware.IsTrustedProxy(tt.testIP, nets)
+			nets := httphelper.ParseTrustedProxies(tt.proxies)
+			got := httphelper.IsTrustedProxy(tt.testIP, nets)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/adapters/out/accesslog/writer_test.go
+++ b/internal/adapters/out/accesslog/writer_test.go
@@ -72,7 +72,8 @@ func TestNew_FileOutput_CreatesDirectory(t *testing.T) {
 func TestWriter_Stdout_JSON(t *testing.T) {
 	// Replace stdout to capture output.
 	orig := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 	os.Stdout = w
 
 	writer, err := New(Config{Format: "json", Output: "stdout"})
@@ -97,7 +98,8 @@ func TestWriter_Stdout_JSON(t *testing.T) {
 
 func TestWriter_Stdout_CLF(t *testing.T) {
 	orig := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 	os.Stdout = w
 
 	writer, err := New(Config{Format: "clf", Output: "stdout"})
@@ -119,7 +121,8 @@ func TestWriter_Stdout_CLF(t *testing.T) {
 
 func TestWriter_Stdout_Combined(t *testing.T) {
 	orig := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 	os.Stdout = w
 
 	writer, err := New(Config{Format: "combined", Output: "stdout"})

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -468,7 +468,7 @@ func (r *Runtime) PullImage(ctx context.Context, imageRef string) error {
 
 	reader, err := r.client.ImagePull(ctx, imageRef, image.PullOptions{})
 	if err != nil {
-		return log.WrapErr(err, "failed to pull image")
+		return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image")
 	}
 	defer reader.Close()
 
@@ -528,7 +528,7 @@ func (r *Runtime) PullImageWithAuth(ctx context.Context, imageRef, username, pas
 		RegistryAuth: authStr,
 	})
 	if err != nil {
-		return log.WrapErr(err, "failed to pull image with auth")
+		return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image with auth")
 	}
 	defer reader.Close()
 

--- a/internal/adapters/out/pki/ca.go
+++ b/internal/adapters/out/pki/ca.go
@@ -449,6 +449,16 @@ func (ca *CA) IntermediateLifetime() time.Duration {
 	return intermediateLifetime
 }
 
+// InstallRoot installs the root CA certificate into the system trust store.
+func (ca *CA) InstallRoot(cert *x509.Certificate) error {
+	return InstallRoot(cert)
+}
+
+// UninstallRoot removes the root CA certificate from the system trust store.
+func (ca *CA) UninstallRoot(cert *x509.Certificate) error {
+	return UninstallRoot(cert)
+}
+
 func randomSerial() (*big.Int, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {

--- a/internal/adapters/out/pki/mobileconfig.go
+++ b/internal/adapters/out/pki/mobileconfig.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"html"
+	"strings"
+	"unicode"
 
 	"github.com/google/uuid"
 )
@@ -16,6 +18,7 @@ func GenerateMobileconfig(rootDER []byte, rootCN string) []byte {
 	certUUID := uuid.New().String()
 
 	safeCN := html.EscapeString(rootCN)
+	identifierCN := payloadIdentifierComponent(rootCN)
 	profile := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -53,8 +56,39 @@ func GenerateMobileconfig(rootDER []byte, rootCN string) []byte {
 	<string>%s</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
-</dict>
-</plist>`, b64Cert, safeCN, certUUID, certUUID, profileUUID)
+	</dict>
+</plist>`, b64Cert, safeCN, identifierCN, certUUID, profileUUID)
 
 	return []byte(profile)
+}
+
+func payloadIdentifierComponent(rootCN string) string {
+	var b strings.Builder
+	lastHyphen := false
+
+	for _, r := range rootCN {
+		r = unicode.ToLower(r)
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == '-':
+			if !lastHyphen {
+				b.WriteRune(r)
+				lastHyphen = true
+			}
+		default:
+			if !lastHyphen {
+				b.WriteRune('-')
+				lastHyphen = true
+			}
+		}
+	}
+
+	identifier := strings.Trim(b.String(), "-.")
+	if identifier == "" {
+		return "gordon-ca"
+	}
+
+	return identifier
 }

--- a/internal/adapters/out/pki/mobileconfig_test.go
+++ b/internal/adapters/out/pki/mobileconfig_test.go
@@ -21,3 +21,12 @@ func TestGenerateMobileconfig(t *testing.T) {
 	assert.Contains(t, string(mc), "<key>PayloadType</key>")
 	assert.Contains(t, string(mc), "com.apple.security.root")
 }
+
+func TestGenerateMobileconfig_UsesIdentifierSafePayloadIdentifier(t *testing.T) {
+	mc := pki.GenerateMobileconfig([]byte("cert"), `Gordon Internal CA <prod>`)
+
+	assert.Contains(t, string(mc), "<string>Gordon Internal CA &lt;prod&gt;</string>")
+	assert.Contains(t, string(mc), "<string>dev.gordon.ca.gordon-internal-ca-prod</string>")
+	assert.NotContains(t, string(mc), "dev.gordon.ca.Gordon Internal CA")
+	assert.NotContains(t, string(mc), "dev.gordon.ca.gordon-internal-ca-&lt;prod&gt;")
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -89,7 +89,6 @@ type Config struct {
 		Port                 int      `mapstructure:"port"`
 		RegistryPort         int      `mapstructure:"registry_port"`
 		GordonDomain         string   `mapstructure:"gordon_domain"`
-		RegistryDomain       string   `mapstructure:"registry_domain"` // Deprecated: use gordon_domain
 		TLSPort              int      `mapstructure:"tls_port"`
 		TLSCertFile          string   `mapstructure:"tls_cert_file"`
 		TLSKeyFile           string   `mapstructure:"tls_key_file"`
@@ -313,11 +312,6 @@ func initConfig(configPath string) (*viper.Viper, Config, error) {
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, Config{}, fmt.Errorf("failed to unmarshal config: %w", err)
-	}
-
-	// Normalize domain config: prefer gordon_domain over registry_domain
-	if cfg.Server.GordonDomain != "" {
-		cfg.Server.RegistryDomain = cfg.Server.GordonDomain
 	}
 
 	return v, cfg, nil
@@ -1386,7 +1380,7 @@ func buildProxyConfig(cfg Config, log zerowrap.Logger) (*proxyConfigResult, erro
 
 	return &proxyConfigResult{
 		proxyConfig: proxy.Config{
-			RegistryDomain:     cfg.Server.RegistryDomain,
+			RegistryDomain:     cfg.Server.GordonDomain,
 			RegistryPort:       cfg.Server.RegistryPort,
 			MaxBodySize:        maxProxyBodySize,
 			MaxResponseSize:    maxProxyResponseSize,
@@ -1421,9 +1415,11 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 		defaultNanoCPUs = int64(cfg.Containers.CPULimit * 1e9)
 	}
 
+	attachmentConfig := svc.configSvc.GetAttachmentConfig()
+
 	containerConfig := container.Config{
 		RegistryAuthEnabled:        cfg.Auth.Enabled,
-		RegistryDomain:             cfg.Server.RegistryDomain,
+		RegistryDomain:             cfg.Server.GordonDomain,
 		RegistryPort:               cfg.Server.RegistryPort,
 		InternalRegistryUsername:   svc.internalRegUser,
 		InternalRegistryPassword:   svc.internalRegPass,
@@ -1433,8 +1429,8 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 		VolumePreserve:             v.GetBool("volumes.preserve"),
 		NetworkIsolation:           v.GetBool("network_isolation.enabled"),
 		NetworkPrefix:              v.GetString("network_isolation.network_prefix"),
-		NetworkGroups:              svc.configSvc.GetNetworkGroups(),
-		Attachments:                svc.configSvc.GetAttachments(),
+		NetworkGroups:              attachmentConfig.NetworkGroups,
+		Attachments:                attachmentConfig.Attachments,
 		ReadinessDelay:             v.GetDuration("deploy.readiness_delay"),
 		ReadinessMode:              v.GetString("deploy.readiness_mode"),
 		HealthTimeout:              v.GetDuration("deploy.health_timeout"),
@@ -1547,7 +1543,7 @@ func registerEventHandlers(ctx context.Context, svc *services, cfg Config) (func
 	}
 
 	// Auto-route handler for creating routes from image labels
-	autoRouteHandler := container.NewAutoRouteHandler(ctx, svc.configSvc, svc.containerSvc, svc.blobStorage, cfg.Server.RegistryDomain).
+	autoRouteHandler := container.NewAutoRouteHandler(ctx, svc.configSvc, svc.containerSvc, svc.blobStorage, cfg.Server.GordonDomain).
 		WithEnvExtractor(svc.runtime, svc.envDir)
 
 	// Preview handler for creating preview environments from tagged images
@@ -1616,9 +1612,6 @@ func setupConfigHotReload(ctx context.Context, v *viper.Viper, svc *services, lo
 		if err := v.Unmarshal(&reloadCfg); err != nil {
 			log.Error().Err(err).Msg("failed to unmarshal config on reload")
 			return
-		}
-		if reloadCfg.Server.GordonDomain != "" {
-			reloadCfg.Server.RegistryDomain = reloadCfg.Server.GordonDomain
 		}
 		reloadedProxy, err := buildProxyConfig(reloadCfg, log)
 		if err != nil {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -46,6 +46,7 @@ import (
 	"github.com/bnema/gordon/internal/adapters/dto"
 	"github.com/bnema/gordon/internal/adapters/in/http/admin"
 	authhandler "github.com/bnema/gordon/internal/adapters/in/http/auth"
+	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
 	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
 	"github.com/bnema/gordon/internal/adapters/in/http/onboarding"
 	proxyadapter "github.com/bnema/gordon/internal/adapters/in/http/proxy"
@@ -1680,7 +1681,7 @@ func loopbackOnly(next http.Handler, log zerowrap.Logger) http.Handler {
 func createHTTPHandlers(svc *services, cfg Config, log zerowrap.Logger, accessWriter out.AccessLogWriter) (http.Handler, http.Handler, http.Handler) {
 	// Parse trusted proxies once for all middleware chains.
 	// This ensures consistent IP extraction across logging, rate limiting, and auth.
-	trustedNets := middleware.ParseTrustedProxies(cfg.API.RateLimit.TrustedProxies)
+	trustedNets := httphelper.ParseTrustedProxies(cfg.API.RateLimit.TrustedProxies)
 
 	// Registry handler (unchanged)
 	registryHandler := registry.NewHandler(svc.registrySvc, log, svc.maxBlobChunkSize)
@@ -1812,8 +1813,8 @@ func directHTTPOnboardingGate(ob *onboarding.Handler, proxyNets []*net.IPNet, pr
 	)(onboardingMux)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		remoteIP := middleware.ExtractRemoteIP(r.RemoteAddr)
-		if middleware.IsTrustedOrLocal(remoteIP, proxyNets) {
+		remoteIP := httphelper.ExtractRemoteIP(r.RemoteAddr)
+		if httphelper.IsTrustedOrLocal(remoteIP, proxyNets) {
 			proxyChain.ServeHTTP(w, r)
 			return
 		}
@@ -1868,10 +1869,10 @@ func parseCIDRAllowlist(ips []string, label string, log zerowrap.Logger) ([]*net
 		return nil, false
 	}
 
-	allowedNets := middleware.ParseTrustedProxies(ips)
+	allowedNets := httphelper.ParseTrustedProxies(ips)
 	if len(allowedNets) != len(ips) {
 		for _, entry := range ips {
-			if nets := middleware.ParseTrustedProxies([]string{entry}); len(nets) == 0 {
+			if nets := httphelper.ParseTrustedProxies([]string{entry}); len(nets) == 0 {
 				log.Warn().Str("entry", entry).Msgf("ignoring invalid %s entry", label)
 			}
 		}

--- a/internal/boundaries/out/attachment_config.go
+++ b/internal/boundaries/out/attachment_config.go
@@ -20,9 +20,6 @@ type AttachmentConfigProvider interface {
 	// network groups, read under a single lock to prevent cross-field races.
 	GetAttachmentConfig() AttachmentConfigSnapshot
 
-	// GetAttachments returns a deep copy of the current attachment config: domain/group -> []image.
-	GetAttachments() map[string][]string
-
 	// GetNetworkGroups returns a deep copy of the current network group config: group -> []domain.
 	GetNetworkGroups() map[string][]string
 }

--- a/internal/boundaries/out/mocks/mock_attachment_config_provider.go
+++ b/internal/boundaries/out/mocks/mock_attachment_config_provider.go
@@ -80,52 +80,6 @@ func (_c *MockAttachmentConfigProvider_GetAttachmentConfig_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetAttachments provides a mock function for the type MockAttachmentConfigProvider
-func (_mock *MockAttachmentConfigProvider) GetAttachments() map[string][]string {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAttachments")
-	}
-
-	var r0 map[string][]string
-	if returnFunc, ok := ret.Get(0).(func() map[string][]string); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string][]string)
-		}
-	}
-	return r0
-}
-
-// MockAttachmentConfigProvider_GetAttachments_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAttachments'
-type MockAttachmentConfigProvider_GetAttachments_Call struct {
-	*mock.Call
-}
-
-// GetAttachments is a helper method to define mock.On call
-func (_e *MockAttachmentConfigProvider_Expecter) GetAttachments() *MockAttachmentConfigProvider_GetAttachments_Call {
-	return &MockAttachmentConfigProvider_GetAttachments_Call{Call: _e.mock.On("GetAttachments")}
-}
-
-func (_c *MockAttachmentConfigProvider_GetAttachments_Call) Run(run func()) *MockAttachmentConfigProvider_GetAttachments_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockAttachmentConfigProvider_GetAttachments_Call) Return(stringToStrings map[string][]string) *MockAttachmentConfigProvider_GetAttachments_Call {
-	_c.Call.Return(stringToStrings)
-	return _c
-}
-
-func (_c *MockAttachmentConfigProvider_GetAttachments_Call) RunAndReturn(run func() map[string][]string) *MockAttachmentConfigProvider_GetAttachments_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNetworkGroups provides a mock function for the type MockAttachmentConfigProvider
 func (_mock *MockAttachmentConfigProvider) GetNetworkGroups() map[string][]string {
 	ret := _mock.Called()

--- a/internal/boundaries/out/pki.go
+++ b/internal/boundaries/out/pki.go
@@ -3,6 +3,7 @@ package out
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"time"
 
 	"github.com/bnema/gordon/internal/domain"
@@ -49,4 +50,10 @@ type CertificateAuthority interface {
 
 	// IntermediateLifetime returns the configured intermediate CA lifetime.
 	IntermediateLifetime() time.Duration
+
+	// InstallRoot installs the root CA certificate into the system trust store.
+	InstallRoot(cert *x509.Certificate) error
+
+	// UninstallRoot removes the root CA certificate from the system trust store.
+	UninstallRoot(cert *x509.Certificate) error
 }

--- a/internal/domain/deploy_failure.go
+++ b/internal/domain/deploy_failure.go
@@ -1,5 +1,7 @@
 package domain
 
+const DefaultDeployFailureSummary = "failed to deploy"
+
 // DeployFailureError describes a surfaced deployment failure.
 type DeployFailureError struct {
 	Summary       string
@@ -14,7 +16,7 @@ type DeployFailureError struct {
 // Error returns the deploy failure summary.
 func (e *DeployFailureError) Error() string {
 	if e == nil || e.Summary == "" {
-		return "failed to deploy"
+		return DefaultDeployFailureSummary
 	}
 
 	return e.Summary

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -933,19 +933,6 @@ func (s *Service) GetAttachmentConfig() out.AttachmentConfigSnapshot {
 	}
 }
 
-// GetAttachments returns attachment configuration.
-// Deprecated: Use GetAllAttachments instead.
-func (s *Service) GetAttachments() map[string][]string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	result := make(map[string][]string)
-	for k, v := range s.config.Attachments {
-		result[k] = append([]string{}, v...)
-	}
-	return result
-}
-
 // GetAllAttachments returns all configured attachments.
 func (s *Service) GetAllAttachments(_ context.Context) map[string][]string {
 	s.mu.RLock()

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -469,24 +469,6 @@ func TestService_GetNetworkGroups(t *testing.T) {
 	assert.ElementsMatch(t, []string{"api.example.com", "db.example.com"}, groups["backend"])
 }
 
-func TestService_GetAttachments(t *testing.T) {
-	v := viper.New()
-	v.Set("attachments", map[string]interface{}{
-		"app.example.com": []interface{}{"redis:latest", "postgres:18"},
-	})
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
-	ctx := testContext()
-
-	_ = svc.Load(ctx)
-
-	attachments := svc.GetAttachments()
-
-	assert.Len(t, attachments, 1)
-	assert.ElementsMatch(t, []string{"redis:latest", "postgres:18"}, attachments["app.example.com"])
-}
-
 func TestService_GetAttachmentConfig(t *testing.T) {
 	v := viper.New()
 	v.Set("attachments", map[string]interface{}{

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -835,10 +835,6 @@ func isPullFailure(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, domain.ErrImagePullFailed) {
-		return true
-	}
-
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "failed to pull image") ||
 		strings.Contains(msg, "pull access denied")

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -835,10 +835,13 @@ func isPullFailure(err error) bool {
 		return false
 	}
 
+	if errors.Is(err, domain.ErrImagePullFailed) {
+		return true
+	}
+
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "failed to pull image") ||
-		strings.Contains(msg, "pull access denied") ||
-		strings.Contains(msg, "unauthorized")
+		strings.Contains(msg, "pull access denied")
 }
 
 func (s *Service) activateDeployedContainer(ctx context.Context, domainName string, container *domain.Container) bool {

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -835,6 +835,10 @@ func isPullFailure(err error) bool {
 		return false
 	}
 
+	if errors.Is(err, domain.ErrImagePullFailed) {
+		return true
+	}
+
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "failed to pull image") ||
 		strings.Contains(msg, "pull access denied")
@@ -1910,24 +1914,24 @@ func (s *Service) pullImage(ctx context.Context, pullRef string, isInternal bool
 		if err := s.pullImageWithRetry(ctx, func(ctx context.Context) error {
 			return s.runtime.PullImageWithAuth(ctx, pullRef, cfg.InternalRegistryUsername, cfg.InternalRegistryPassword)
 		}, isInternal); err != nil {
-			return log.WrapErr(err, "failed to pull image with internal auth")
+			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image with internal auth")
 		}
 	case isInternal:
 		if err := s.pullImageWithRetry(ctx, func(ctx context.Context) error {
 			return s.runtime.PullImage(ctx, pullRef)
 		}, isInternal); err != nil {
-			return log.WrapErr(err, "failed to pull image")
+			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image")
 		}
 	case cfg.RegistryAuthEnabled:
 		if cfg.ServiceTokenUsername == "" || cfg.ServiceToken == "" {
 			return log.WrapErr(fmt.Errorf("registry service token not configured"), "failed to pull image for registry auth")
 		}
 		if err := s.runtime.PullImageWithAuth(ctx, pullRef, cfg.ServiceTokenUsername, cfg.ServiceToken); err != nil {
-			return log.WrapErr(err, "failed to pull image with auth")
+			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image with auth")
 		}
 	default:
 		if err := s.runtime.PullImage(ctx, pullRef); err != nil {
-			return log.WrapErr(err, "failed to pull image")
+			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image")
 		}
 	}
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -502,6 +502,34 @@ func TestService_Deploy_ImagePullFailure(t *testing.T) {
 	assert.ErrorContains(t, deployErr.Err, "failed to pull image")
 }
 
+func TestService_Deploy_DoesNotMisclassifyUnauthorizedEnvLoadFailure(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	ctx := testContext()
+
+	route := domain.Route{
+		Domain: "test.example.com",
+		Image:  "myapp:latest",
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{"myapp:latest"}, nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:latest").Return([]int{8080}, nil)
+	runtime.EXPECT().GetImageLabels(mock.Anything, "myapp:latest").Return(nil, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return(nil, errors.New("unauthorized"))
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "failed to load environment variables: unauthorized")
+	var deployErr *domain.DeployFailureError
+	assert.False(t, errors.As(err, &deployErr))
+}
+
 func TestService_CaptureRecentContainerLogs_SkipsCanceledContext(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	svc := NewService(runtime, nil, nil, nil, Config{}, nil)

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -499,7 +499,14 @@ func TestService_Deploy_ImagePullFailure(t *testing.T) {
 	assert.Equal(t, "verify registry auth and confirm the image exists at the requested tag", deployErr.Hint)
 	assert.Equal(t, "gordon-test.example.com", deployErr.ContainerName)
 	assert.Empty(t, deployErr.ContainerID)
+	assert.ErrorIs(t, deployErr.Err, domain.ErrImagePullFailed)
 	assert.ErrorContains(t, deployErr.Err, "failed to pull image")
+}
+
+func TestIsPullFailure_ErrImagePullFailed(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", domain.ErrImagePullFailed)
+
+	assert.True(t, isPullFailure(err))
 }
 
 func TestService_Deploy_DoesNotMisclassifyUnauthorizedEnvLoadFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- clean up the pre-release CLI and HTTP polish work by deduplicating remote and deploy-failure helpers
- resolve the remaining hexarch follow-ups by routing CA trust operations through the PKI boundary and extracting shared HTTP helper utilities
- address validated review findings around sensitive query logging, deploy error classification, mobileconfig identifiers, and a few low-risk CLI/test hygiene issues

## Test Plan
- [x] go test ./internal/adapters/in/cli/... ./internal/adapters/in/http/... ./internal/adapters/out/pki/... ./internal/boundaries/out/...
- [x] go test ./internal/adapters/in/http/middleware ./internal/adapters/out/pki ./internal/usecase/container ./internal/adapters/out/accesslog ./internal/adapters/in/cli/...
- [x] go build ./...
- [ ] golangci-lint run ./... (repo still reports the pre-existing `stat /home/brice/dev/projects/gordon/run: directory not found` typechecking blocker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image pull-failure classification (fewer misclassified deploy errors).
  * Request logs now redact sensitive query parameters.

* **New Features**
  * CA trust store install/uninstall support.
  * Safer payload identifiers in generated mobile configuration.
  * Improved trusted-proxy and HTTPS authority handling.

* **Refactor**
  * Centralized container ID shortening across CLI.
  * Consolidated remote resolution in auth flows.
  * Reorganized HTTP helper utilities.

* **Chores**
  * Removed deprecated `start` CLI alias.

* **Tests**
  * Added tests covering query redaction, mobileconfig identifiers, and auth/deploy edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->