### PR TITLE
refactor(cli): make push image-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Build locally, push directly to your Gordon server:
 
 ```bash
 # Push an image and deploy it to a domain
-gordon push app.example.com --image myapp:latest
+gordon push myapp:latest --domain app.example.com
 
 # Or add a route manually, then deploy
 gordon routes add app.example.com myapp:latest
@@ -90,7 +90,7 @@ See the [Deploy Action README](.github/actions/deploy/README.md) for multi-platf
 
 | Command | Description |
 |---------|-------------|
-| `gordon push <domain>` | Tag and push an image to deploy |
+| `gordon push [image]` | Tag, push, and optionally deploy an image |
 | `gordon routes list` | List all routes |
 | `gordon routes add <domain> <image>` | Create or update a route |
 | `gordon routes remove <domain>` | Remove a route |

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Config is created at `~/.config/gordon/gordon.toml`. See the [Getting Started gu
 Build locally, push directly to your Gordon server:
 
 ```bash
-# Push an image and deploy it to a domain
-gordon push myapp:latest --domain app.example.com
+# Push using an explicit domain override
+gordon push --domain app.example.com
 
 # Or add a route manually, then deploy
 gordon routes add app.example.com myapp:latest

--- a/docs/cli/attachments.md
+++ b/docs/cli/attachments.md
@@ -255,7 +255,7 @@ gordon bootstrap app.example.com myapp:latest --attachment pitlane-pgsql
 gordon attachments push pitlane-pgsql --build
 
 # Then push and deploy the route image
-gordon push myapp:latest --domain app.example.com --build --no-confirm
+gordon push --domain app.example.com --build --no-confirm
 ```
 
 ### CI/CD Integration

--- a/docs/cli/attachments.md
+++ b/docs/cli/attachments.md
@@ -255,7 +255,7 @@ gordon bootstrap app.example.com myapp:latest --attachment pitlane-pgsql
 gordon attachments push pitlane-pgsql --build
 
 # Then push and deploy the route image
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 ```
 
 ### CI/CD Integration

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -44,7 +44,7 @@ Unlike `gordon push`, `gordon bootstrap` does not require the route to exist fir
 gordon bootstrap app.example.com myapp:latest
 
 # Then push and deploy the image
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 
 # First-time route setup with a database attachment and environment variable
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
@@ -63,7 +63,7 @@ gordon bootstrap app.example.com myapp:latest --remote https://gordon.mydomain.c
 gordon attachments push pitlane-pgsql --build
 
 # Then push and deploy the route image
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 ```
 
 ### Notes

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -44,7 +44,7 @@ Unlike `gordon push`, `gordon bootstrap` does not require the route to exist fir
 gordon bootstrap app.example.com myapp:latest
 
 # Then push and deploy the image
-gordon push myapp:latest --domain app.example.com --build --no-confirm
+gordon push --domain app.example.com --build --no-confirm
 
 # First-time route setup with a database attachment and environment variable
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
@@ -63,7 +63,7 @@ gordon bootstrap app.example.com myapp:latest --remote https://gordon.mydomain.c
 gordon attachments push pitlane-pgsql --build
 
 # Then push and deploy the route image
-gordon push myapp:latest --domain app.example.com --build --no-confirm
+gordon push myapp --build --no-confirm
 ```
 
 ### Notes

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -72,13 +72,13 @@ gordon restart myapp.example.com
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then push and deploy
-gordon push myapp:latest --domain app.example.com --build --no-confirm
+gordon push --domain app.example.com --build --no-confirm
 
 # Push an image and deploy
-gordon push myapp:latest --domain app.example.com --build
+gordon push myapp --build
 
 # Push and deploy without confirmation
-gordon push myapp:latest --domain app.example.com --no-confirm
+gordon push myapp --no-confirm
 
 # Roll back to a previous tag
 gordon rollback myapp.example.com

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -72,13 +72,13 @@ gordon restart myapp.example.com
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then push and deploy
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 
 # Push an image and deploy
-gordon push myapp.example.com --build
+gordon push myapp:latest --domain app.example.com --build
 
 # Push and deploy without confirmation
-gordon push myapp.example.com --no-confirm
+gordon push myapp:latest --domain app.example.com --no-confirm
 
 # Roll back to a previous tag
 gordon rollback myapp.example.com

--- a/docs/cli/push.md
+++ b/docs/cli/push.md
@@ -27,19 +27,20 @@ gordon push [image] [options]
 | `--tag` | Override version tag (default: tag ref from CI, then `git describe --tags --dirty`) |
 | `--no-confirm` | Skip deploy confirmation prompt |
 | `--no-deploy` | Push only; skip deployment prompt |
-| `--domain` | Explicit domain override (legacy mode) |
+| `--domain` | Explicit deploy target override |
 | `--remote, -r` | Remote name or URL (e.g., prod, https://gordon.mydomain.com) |
 | `--token` | Authentication token for remote |
 
 ### Description
 
-`gordon push` resolves the target image from the backend, tags it for the
-Gordon registry, pushes it, and optionally deploys it.
+`gordon push` tags the selected image for the Gordon registry, pushes it, and
+optionally deploys matching routes.
 
 Image resolution order:
-1. If `--domain` is provided, uses domain-based route lookup
-2. If an image name is provided as argument, resolves domain(s) from the backend
-3. If no argument, auto-detects from Dockerfile `gordon.domain` label or current directory name
+1. `--domain` is the explicit deploy target override
+2. Tagged image refs resolve domain(s) from the backend using the image name
+3. Domain-looking positional args use legacy domain-based lookup for compatibility
+4. No-arg mode auto-detects from the Dockerfile label or current directory
 
 To push attachment images (databases, caches, etc.), use `gordon attachments push`.
 
@@ -93,30 +94,33 @@ Gordon reads version tags from CI environment variables (in priority order):
 # Build, push, and deploy (auto-detect image name)
 gordon push --build --remote https://gordon.example.com --no-confirm
 
-# Specify image name explicitly
-gordon push myapp --build --remote https://gordon.example.com --no-confirm
+# Push an image and deploy it
+gordon push myapp:latest --remote https://gordon.example.com --no-confirm
+
+# Push and deploy to an explicit domain
+gordon push myapp:latest --domain app.example.com --remote https://gordon.example.com --no-confirm
 
 # Push existing local image, skip deploy
-gordon push myapp --tag v1.2.0 --no-deploy
-
-# Push and deploy without confirmation
-gordon push myapp --no-confirm
+gordon push myapp:latest --tag v1.2.0 --no-deploy
 
 # Build for ARM and pass build args
-gordon push myapp --build --platform linux/arm64 --build-arg CGO_ENABLED=0
+gordon push myapp:latest --build --platform linux/arm64 --build-arg CGO_ENABLED=0
 
 # Build from a custom Dockerfile path
-gordon push myapp --build -f docker/app/Dockerfile
+gordon push myapp:latest --build -f docker/app/Dockerfile
+
+# Legacy compatibility: domain-looking positional target
+gordon push app.example.com --no-confirm
 
 # CI/CD usage (single env var, no docker login needed)
 export GORDON_TOKEN="your-token"
-gordon push --build --remote https://gordon.example.com --no-confirm
+gordon push myapp:latest --build --remote https://gordon.example.com --no-confirm
 ```
 
 ### Notes
 
 - Remote mode required. See [CLI Overview](./index.md) for targeting options.
-- `gordon push` requires the route to already exist so it can resolve the target image.
+- `gordon push` requires the target route to already exist so it can resolve the deploy target.
   Use `gordon bootstrap` for first deploys.
 - `--build` requires Docker with Buildx. Docker Desktop includes it; on Linux,
   install the `docker-buildx-plugin` package.

--- a/docs/cli/push.md
+++ b/docs/cli/push.md
@@ -24,7 +24,7 @@ gordon push [image] [options]
 | `-f, --file` | Path to Dockerfile (default: `./Dockerfile`, used with `--build`) |
 | `--platform` | Target platform for buildx (default: `linux/amd64`) |
 | `--build-arg` | Additional build args (repeatable, `KEY=VALUE`) |
-| `--tag` | Override version tag (default: tag ref from CI, then `git describe --tags --dirty`) |
+| `--tag` | Override pushed version tag (default: tag ref from CI, then `git describe --tags --dirty`) |
 | `--no-confirm` | Skip deploy confirmation prompt |
 | `--no-deploy` | Push only; skip deployment prompt |
 | `--domain` | Explicit deploy target override |
@@ -37,10 +37,12 @@ gordon push [image] [options]
 optionally deploys matching routes.
 
 Image resolution order:
-1. `--domain` is the explicit deploy target override
-2. Tagged image refs resolve domain(s) from the backend using the image name
-3. Domain-looking positional args use legacy domain-based lookup for compatibility
+1. `--domain` is the explicit deploy target override for legacy workflows
+2. Positional refs resolve routes by image name; tagged refs still use the image name for lookup
+3. Dotted positional refs probe image routes first, then fall back to legacy domain lookup
 4. No-arg mode auto-detects from the Dockerfile label or current directory
+
+The pushed version still comes from `--tag`, CI tag refs, or `git describe --tags --dirty`.
 
 To push attachment images (databases, caches, etc.), use `gordon attachments push`.
 
@@ -95,26 +97,29 @@ Gordon reads version tags from CI environment variables (in priority order):
 gordon push --build --remote https://gordon.example.com --no-confirm
 
 # Push an image and deploy it
-gordon push myapp:latest --remote https://gordon.example.com --no-confirm
+gordon push myapp --remote https://gordon.example.com --no-confirm
 
 # Push and deploy to an explicit domain
-gordon push myapp:latest --domain app.example.com --remote https://gordon.example.com --no-confirm
+gordon push --domain app.example.com --remote https://gordon.example.com --no-confirm
+
+# Tagged refs still resolve routes by image name
+gordon push myapp:v1.2.3 --tag v1.2.3 --no-deploy
 
 # Push existing local image, skip deploy
-gordon push myapp:latest --tag v1.2.0 --no-deploy
+gordon push myapp --tag v1.2.0 --no-deploy
 
 # Build for ARM and pass build args
-gordon push myapp:latest --build --platform linux/arm64 --build-arg CGO_ENABLED=0
+gordon push myapp --build --platform linux/arm64 --build-arg CGO_ENABLED=0
 
 # Build from a custom Dockerfile path
-gordon push myapp:latest --build -f docker/app/Dockerfile
+gordon push myapp --build -f docker/app/Dockerfile
 
 # Legacy compatibility: domain-looking positional target
 gordon push app.example.com --no-confirm
 
 # CI/CD usage (single env var, no docker login needed)
 export GORDON_TOKEN="your-token"
-gordon push myapp:latest --build --remote https://gordon.example.com --no-confirm
+gordon push myapp --build --remote https://gordon.example.com --no-confirm
 ```
 
 ### Notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ gordon remotes use prod
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then build, push, and deploy
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 ```
 
 What this command does:
@@ -161,11 +161,11 @@ What this command does:
 If the route already exists and you only need to push a new image version, use:
 
 ```bash
-gordon push app.example.com --build --no-confirm
+gordon push myapp:latest --build --no-confirm
 ```
 
 `gordon push` still requires the route to already exist so it can resolve the
-target image.
+deploy target.
 
 Your app is now live at `https://app.mydomain.com`!
 
@@ -175,7 +175,7 @@ Push a new image to deploy with zero downtime:
 
 ```bash
 # Make changes, then build + push + deploy
-gordon push myapp --build --no-confirm
+gordon push myapp:latest --build --no-confirm
 ```
 
 Gordon automatically:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ gordon remotes use prod
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then build, push, and deploy
-gordon push myapp:latest --domain app.example.com --build --no-confirm
+gordon push --domain app.example.com --build --no-confirm
 ```
 
 What this command does:
@@ -161,7 +161,7 @@ What this command does:
 If the route already exists and you only need to push a new image version, use:
 
 ```bash
-gordon push myapp:latest --build --no-confirm
+gordon push myapp --build --no-confirm
 ```
 
 `gordon push` still requires the route to already exist so it can resolve the
@@ -175,7 +175,7 @@ Push a new image to deploy with zero downtime:
 
 ```bash
 # Make changes, then build + push + deploy
-gordon push myapp:latest --build --no-confirm
+gordon push myapp --build --no-confirm
 ```
 
 Gordon automatically:

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -150,23 +150,10 @@ func classifyPushArgument(arg string) classifiedPushArg {
 	}
 
 	classified := classifiedPushArg{kind: pushArgKindImage, lookupImage: arg}
-	if isTaggedImageRef(arg) {
-		classified.lookupImage = stripImageTag(arg)
+	if parsedImage, ref := validation.ParseImageReference(arg); parsedImage != arg && !strings.HasPrefix(ref, "sha256:") {
+		classified.lookupImage = parsedImage
 	}
 	return classified
-}
-
-func isTaggedImageRef(arg string) bool {
-	slash := strings.LastIndex(arg, "/")
-	colon := strings.LastIndex(arg, ":")
-	return colon > slash
-}
-
-func stripImageTag(arg string) string {
-	if !isTaggedImageRef(arg) {
-		return arg
-	}
-	return arg[:strings.LastIndex(arg, ":")]
 }
 
 func looksLikeLegacyDomain(arg string) bool {
@@ -196,10 +183,13 @@ func resolveRoute(ctx context.Context, cp ControlPlane, imageArg, domainFlag, do
 
 	if looksLikeLegacyDomain(imageArg) {
 		lookupImage := imageArg
-		if isTaggedImageRef(imageArg) {
-			lookupImage = stripImageTag(imageArg)
+		domainLookupArg := imageArg
+		if parsedImage, ref := validation.ParseImageReference(imageArg); parsedImage != imageArg {
+			domainLookupArg = parsedImage
+			if !strings.HasPrefix(ref, "sha256:") {
+				lookupImage = parsedImage
+			}
 		}
-		domainLookupArg := stripImageTag(imageArg)
 
 		registry, imageName, pushDomain, err = resolveFromImage(ctx, cp, lookupImage, dockerfile)
 		if err == nil {
@@ -220,9 +210,6 @@ func resolveRoute(ctx context.Context, cp ControlPlane, imageArg, domainFlag, do
 	}
 
 	classified := classifyPushArgument(imageArg)
-	if classified.kind == pushArgKindLegacyDomain {
-		return resolveFromDomain(ctx, cp, classified.legacyDomain)
-	}
 
 	return resolveFromImage(ctx, cp, classified.lookupImage, dockerfile)
 }
@@ -393,18 +380,30 @@ func resolveFromImage(ctx context.Context, cp ControlPlane, imageArg, dockerfile
 }
 
 func isImageBootstrapError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), "no route configured for image ")
+	return errors.Is(err, domain.ErrNoRouteForImage)
 }
 
 func noRouteForImageError(imageArg string) error {
 	// bootstrap command is registered in bootstrap.go (see issue #98)
-	return fmt.Errorf(
+	return noRouteForImageBootstrapError{imageArg: imageArg}
+}
+
+type noRouteForImageBootstrapError struct {
+	imageArg string
+}
+
+func (e noRouteForImageBootstrapError) Error() string {
+	return fmt.Sprintf(
 		"no route configured for image %q\n\nFor a first deploy, use 'gordon bootstrap <domain> %s'\nOr configure the route directly with 'gordon routes add <domain> %s'\nIf this is an attachment image, use 'gordon attachments push %s'",
-		imageArg,
-		imageArg,
-		imageArg,
-		imageArg,
+		e.imageArg,
+		e.imageArg,
+		e.imageArg,
+		e.imageArg,
 	)
+}
+
+func (e noRouteForImageBootstrapError) Unwrap() error {
+	return domain.ErrNoRouteForImage
 }
 
 // selectDomain picks the target domain from multiple routes.

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -70,18 +70,19 @@ func newPushCmd() *cobra.Command {
 		Long: `Tags a local image for the Gordon registry and pushes it.
 Uses git tags for versioning. Optionally triggers deployment after push.
 
-The image argument is optional. Resolution order:
-  1. If --domain is provided, uses the legacy domain-based lookup
-  2. If an image name is provided as argument, resolves domain(s) from the backend
-  3. If no argument, auto-detects from Dockerfile labels or current directory name
+Image-first syntax is primary:
+  - Positional args are treated as images unless they look like legacy domains
+  - Tagged image refs resolve domains from the backend using the image name
+  - --domain is a deploy target override for legacy workflows
+  - No-arg mode still auto-detects from Dockerfile labels or current directory name
 
 With --build, builds the image first using docker buildx.
 
 Examples:
-  gordon push --build --remote ...
   gordon push myapp --build --remote ...
+  gordon push myapp:v1.2.3 --no-deploy --remote ...
+  gordon push registry.example.com/myapp:v1.2.3 --build --remote ...
   gordon push --domain myapp.example.com --build --remote ...
-  gordon push myapp --tag v1.2.0 --no-deploy --remote ...
   gordon push --build --build-arg CGO_ENABLED=0 --remote ...`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -128,6 +129,55 @@ func resolveImageRefs(registry, imageName, version string) (versionRef, latestRe
 	return versionRef, latestRef
 }
 
+type pushArgKind string
+
+const (
+	pushArgKindImage        pushArgKind = "image"
+	pushArgKindLegacyDomain pushArgKind = "legacy-domain"
+)
+
+type classifiedPushArg struct {
+	kind         pushArgKind
+	lookupImage  string
+	legacyDomain string
+}
+
+func classifyPushArgument(arg string) classifiedPushArg {
+	if looksLikeLegacyDomain(arg) {
+		return classifiedPushArg{kind: pushArgKindLegacyDomain, legacyDomain: arg}
+	}
+
+	classified := classifiedPushArg{kind: pushArgKindImage, lookupImage: arg}
+	if isTaggedImageRef(arg) {
+		classified.lookupImage = stripImageTag(arg)
+	}
+	return classified
+}
+
+func isTaggedImageRef(arg string) bool {
+	slash := strings.LastIndex(arg, "/")
+	colon := strings.LastIndex(arg, ":")
+	return colon > slash
+}
+
+func stripImageTag(arg string) string {
+	if !isTaggedImageRef(arg) {
+		return arg
+	}
+	return arg[:strings.LastIndex(arg, ":")]
+}
+
+func looksLikeLegacyDomain(arg string) bool {
+	if arg == "" || strings.Contains(arg, "/") {
+		return false
+	}
+	host := arg
+	if idx := strings.Index(host, ":"); idx != -1 {
+		host = host[:idx]
+	}
+	return strings.Contains(host, ".")
+}
+
 // resolveRoute determines the registry, image name, and domain from the input mode.
 func resolveRoute(ctx context.Context, cp ControlPlane, imageArg, domainFlag, dockerfile string) (registry, imageName, pushDomain string, err error) {
 	if domainFlag != "" {
@@ -142,7 +192,12 @@ func resolveRoute(ctx context.Context, cp ControlPlane, imageArg, domainFlag, do
 		fmt.Printf("Detected image: %s\n", styles.Theme.Bold.Render(imageArg))
 	}
 
-	return resolveFromImage(ctx, cp, imageArg, dockerfile)
+	classified := classifyPushArgument(imageArg)
+	if classified.kind == pushArgKindLegacyDomain {
+		return resolveFromDomain(ctx, cp, classified.legacyDomain)
+	}
+
+	return resolveFromImage(ctx, cp, classified.lookupImage, dockerfile)
 }
 
 // resolveVersion determines and validates the version tag.

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -71,8 +71,10 @@ func newPushCmd() *cobra.Command {
 Uses git tags for versioning. Optionally triggers deployment after push.
 
 Image-first syntax is primary:
-  - Positional args are treated as images unless they look like legacy domains
-  - Tagged image refs resolve domains from the backend using the image name
+  - Positional args resolve routes by image name first
+  - Tagged positional refs still resolve routes by image name
+  - The pushed version comes from --tag, CI tag refs, or git describe
+  - Dotted positional refs fall back to legacy domain lookup if no image route exists
   - --domain is a deploy target override for legacy workflows
   - No-arg mode still auto-detects from Dockerfile labels or current directory name
 
@@ -80,7 +82,7 @@ With --build, builds the image first using docker buildx.
 
 Examples:
   gordon push myapp --build --remote ...
-  gordon push myapp:v1.2.3 --no-deploy --remote ...
+  gordon push myapp:v1.2.3 --tag v1.2.3 --no-deploy --remote ...
   gordon push registry.example.com/myapp:v1.2.3 --build --remote ...
   gordon push --domain myapp.example.com --build --remote ...
   gordon push --build --build-arg CGO_ENABLED=0 --remote ...`,
@@ -106,7 +108,7 @@ Examples:
 	cmd.Flags().BoolVar(&build, "build", false, "Build the image first using docker buildx")
 	cmd.Flags().StringVar(&platform, "platform", "linux/amd64", "Target platform (used with --build)")
 	cmd.Flags().StringVarP(&dockerfile, "file", "f", "", "Path to Dockerfile (default: ./Dockerfile, used with --build)")
-	cmd.Flags().StringVar(&tag, "tag", "", "Override version tag (default: CI tag ref or git describe)")
+	cmd.Flags().StringVar(&tag, "tag", "", "Override pushed version tag (default: CI tag ref or git describe)")
 	cmd.Flags().StringArrayVar(&buildArgs, "build-arg", nil, "Additional build args (used with --build)")
 	cmd.Flags().StringVar(&domainFlag, "domain", "", "Explicit domain override (legacy mode)")
 
@@ -190,6 +192,31 @@ func resolveRoute(ctx context.Context, cp ControlPlane, imageArg, domainFlag, do
 			return "", "", "", err
 		}
 		fmt.Printf("Detected image: %s\n", styles.Theme.Bold.Render(imageArg))
+	}
+
+	if looksLikeLegacyDomain(imageArg) {
+		lookupImage := imageArg
+		if isTaggedImageRef(imageArg) {
+			lookupImage = stripImageTag(imageArg)
+		}
+		domainLookupArg := stripImageTag(imageArg)
+
+		registry, imageName, pushDomain, err = resolveFromImage(ctx, cp, lookupImage, dockerfile)
+		if err == nil {
+			return registry, imageName, pushDomain, nil
+		}
+		if !isImageBootstrapError(err) {
+			return "", "", "", err
+		}
+
+		registry, imageName, pushDomain, err = resolveFromDomain(ctx, cp, domainLookupArg)
+		if err == nil {
+			return registry, imageName, pushDomain, nil
+		}
+		if errors.Is(err, domain.ErrRouteNotFound) {
+			return "", "", "", noRouteForImageError(domainLookupArg)
+		}
+		return "", "", "", err
 	}
 
 	classified := classifyPushArgument(imageArg)
@@ -342,14 +369,7 @@ func resolveFromImage(ctx context.Context, cp ControlPlane, imageArg, dockerfile
 	routes = filtered
 
 	if len(routes) == 0 {
-		// bootstrap command is registered in bootstrap.go (see issue #98)
-		return "", "", "", fmt.Errorf(
-			"no route configured for image %q\n\nFor a first deploy, use 'gordon bootstrap <domain> %s'\nOr configure the route directly with 'gordon routes add <domain> %s'\nIf this is an attachment image, use 'gordon attachments push %s'",
-			imageArg,
-			imageArg,
-			imageArg,
-			imageArg,
-		)
+		return "", "", "", noRouteForImageError(imageArg)
 	}
 
 	// Pick the target domain
@@ -370,6 +390,21 @@ func resolveFromImage(ctx context.Context, cp ControlPlane, imageArg, dockerfile
 	}
 
 	return registry, imageName, targetRoute.Domain, nil
+}
+
+func isImageBootstrapError(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "no route configured for image ")
+}
+
+func noRouteForImageError(imageArg string) error {
+	// bootstrap command is registered in bootstrap.go (see issue #98)
+	return fmt.Errorf(
+		"no route configured for image %q\n\nFor a first deploy, use 'gordon bootstrap <domain> %s'\nOr configure the route directly with 'gordon routes add <domain> %s'\nIf this is an attachment image, use 'gordon attachments push %s'",
+		imageArg,
+		imageArg,
+		imageArg,
+		imageArg,
+	)
 }
 
 // selectDomain picks the target domain from multiple routes.

--- a/internal/adapters/in/cli/push_test.go
+++ b/internal/adapters/in/cli/push_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 type resolveFromImageTestControlPlane struct {
+	getRoute          func(context.Context, string) (*domain.Route, error)
 	findRoutesByImage func(context.Context, string) ([]domain.Route, error)
 }
 
@@ -30,7 +31,10 @@ func (c *resolveFromImageTestControlPlane) GetHealth(context.Context) (map[strin
 	panic("unexpected call")
 }
 
-func (c *resolveFromImageTestControlPlane) GetRoute(context.Context, string) (*domain.Route, error) {
+func (c *resolveFromImageTestControlPlane) GetRoute(ctx context.Context, domainName string) (*domain.Route, error) {
+	if c.getRoute != nil {
+		return c.getRoute(ctx, domainName)
+	}
 	panic("unexpected call")
 }
 
@@ -232,6 +236,76 @@ func TestParseImageRef(t *testing.T) {
 			assert.Equal(t, tt.wantRegistry, registry)
 			assert.Equal(t, tt.wantName, name)
 			assert.Equal(t, tt.wantTag, tag)
+		})
+	}
+}
+
+func TestClassifyPushArgument(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        string
+		wantKind   string
+		wantImage  string
+		wantQuery  string
+		wantDomain string
+	}{
+		{name: "tagged image latest", arg: "myapp:latest", wantKind: "image", wantImage: "myapp:latest", wantQuery: "myapp"},
+		{name: "tagged image semver", arg: "myapp:v1.2.3", wantKind: "image", wantImage: "myapp:v1.2.3", wantQuery: "myapp"},
+		{name: "registry qualified image", arg: "registry.example.com/myapp:v1.2.3", wantKind: "image", wantImage: "registry.example.com/myapp:v1.2.3", wantQuery: "registry.example.com/myapp"},
+		{name: "legacy domain", arg: "app.example.com", wantKind: "legacy-domain", wantDomain: "app.example.com"},
+		{name: "bare image name", arg: "myapp", wantKind: "image", wantImage: "myapp", wantQuery: "myapp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			module := []byte("module classifyprobe\n\ngo 1.25\n")
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), module, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			source := fmt.Sprintf(`package cli
+
+import "testing"
+
+func TestProbe(t *testing.T) {
+	cases := []struct {
+		name       string
+		arg        string
+		wantKind   string
+		wantImage  string
+		wantQuery  string
+		wantDomain string
+	}{
+		{name: %q, arg: %q, wantKind: %q, wantImage: %q, wantQuery: %q, wantDomain: %q},
+	}
+
+	for _, tt := range cases {
+		var _ pushArgKind
+		got := classifyPushArgument(tt.arg)
+		_ = got
+		_ = pushArgKindImage
+		_ = pushArgKindLegacyDomain
+	}
+}
+`, tt.name, tt.arg, tt.wantKind, tt.wantImage, tt.wantQuery, tt.wantDomain)
+
+			if err := os.WriteFile(filepath.Join(dir, "probe_test.go"), []byte(source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command("go", "test", "./...")
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(), "GOWORK=off")
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatal("expected classifier compile failure, got success")
+			}
+			output := string(out)
+			if !strings.Contains(output, "undefined: classifyPushArgument") && !strings.Contains(output, "undefined: pushArgKind") {
+				t.Fatalf("expected missing classifier symbols, got:\n%s", output)
+			}
+			t.Fatalf("classifier compile probe failed as expected:\n%s", output)
 		})
 	}
 }
@@ -603,6 +677,55 @@ func TestResolveFromImage_NoRouteSuggestsBootstrap(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `no route configured for image "myapp"`)
 	assert.Contains(t, err.Error(), "gordon bootstrap")
+}
+
+func TestResolveRoute_LegacyDomainArgumentUsesGetRoute(t *testing.T) {
+	cp := &resolveFromImageTestControlPlane{
+		getRoute: func(_ context.Context, domainName string) (*domain.Route, error) {
+			assert.Equal(t, "app.example.com", domainName)
+			return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, nil
+		},
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			t.Fatalf("unexpected FindRoutesByImage call for %q", imageName)
+			return nil, nil
+		},
+	}
+
+	registry, imageName, pushDomain, err := resolveRoute(context.Background(), cp, "app.example.com", "", "Dockerfile")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", registry)
+	assert.Equal(t, "myapp", imageName)
+	assert.Equal(t, "app.example.com", pushDomain)
+}
+
+func TestResolveRoute_TaggedImageStripsTagBeforeLookup(t *testing.T) {
+	cp := &resolveFromImageTestControlPlane{
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			assert.Equal(t, "myapp", imageName)
+			return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, nil
+		},
+	}
+
+	registry, imageName, pushDomain, err := resolveRoute(context.Background(), cp, "myapp:v1.2.3", "", "Dockerfile")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", registry)
+	assert.Equal(t, "myapp", imageName)
+	assert.Equal(t, "app.example.com", pushDomain)
+}
+
+func TestResolveRoute_RegistryQualifiedTaggedImageUsesImageLookup(t *testing.T) {
+	cp := &resolveFromImageTestControlPlane{
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			assert.Equal(t, "registry.example.com/myapp", imageName)
+			return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, nil
+		},
+	}
+
+	_, _, _, err := resolveRoute(context.Background(), cp, "registry.example.com/myapp:v1.2.3", "", "Dockerfile")
+
+	assert.NoError(t, err)
 }
 
 func TestIsInsufficientScope(t *testing.T) {

--- a/internal/adapters/in/cli/push_test.go
+++ b/internal/adapters/in/cli/push_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -249,6 +250,7 @@ func TestClassifyPushArgument(t *testing.T) {
 		{name: "tagged image latest", arg: "myapp:latest", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
 		{name: "tagged image semver", arg: "myapp:v1.2.3", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
 		{name: "registry qualified image", arg: "registry.example.com/myapp:v1.2.3", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "registry.example.com/myapp"}},
+		{name: "registry qualified digest", arg: "registry.example.com/myapp@sha256:deadbeef", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "registry.example.com/myapp@sha256:deadbeef"}},
 		{name: "legacy domain", arg: "app.example.com", want: classifiedPushArg{kind: pushArgKindLegacyDomain, legacyDomain: "app.example.com"}},
 		{name: "bare image name", arg: "myapp", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
 	}
@@ -668,9 +670,17 @@ func TestResolveRoute_DottedBareImageNoRoutesKeepsBootstrapError(t *testing.T) {
 	_, _, _, err := resolveRoute(context.Background(), cp, "my.app", "", "Dockerfile")
 
 	assert.Error(t, err)
+	assert.True(t, errors.Is(err, domain.ErrNoRouteForImage))
 	assert.Contains(t, err.Error(), `no route configured for image "my.app"`)
 	assert.Contains(t, err.Error(), "gordon bootstrap")
 	assert.NotContains(t, err.Error(), "failed to get route for domain")
+}
+
+func TestNoRouteForImageErrorWrapsSentinel(t *testing.T) {
+	err := noRouteForImageError("myapp")
+
+	assert.True(t, errors.Is(err, domain.ErrNoRouteForImage))
+	assert.Contains(t, err.Error(), `no route configured for image "myapp"`)
 }
 
 func TestResolveRoute_DottedBareDomainFallsBackToLegacyLookup(t *testing.T) {

--- a/internal/adapters/in/cli/push_test.go
+++ b/internal/adapters/in/cli/push_test.go
@@ -630,15 +630,61 @@ func TestResolveFromImage_NoRouteSuggestsBootstrap(t *testing.T) {
 	assert.Contains(t, err.Error(), "gordon bootstrap")
 }
 
-func TestResolveRoute_LegacyDomainArgumentUsesGetRoute(t *testing.T) {
+func TestResolveRoute_DottedBareImageUsesImageLookup(t *testing.T) {
 	cp := &resolveFromImageTestControlPlane{
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			assert.Equal(t, "my.app", imageName)
+			return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/my.app:latest"}}, nil
+		},
+		getRoute: func(context.Context, string) (*domain.Route, error) {
+			t.Fatalf("unexpected GetRoute call")
+			return nil, nil
+		},
+	}
+
+	registry, imageName, pushDomain, err := resolveRoute(context.Background(), cp, "my.app", "", "Dockerfile")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "registry.example.com", registry)
+	assert.Equal(t, "my.app", imageName)
+	assert.Equal(t, "app.example.com", pushDomain)
+}
+
+func TestResolveRoute_DottedBareImageNoRoutesKeepsBootstrapError(t *testing.T) {
+	sawImageLookup := false
+	cp := &resolveFromImageTestControlPlane{
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			sawImageLookup = true
+			assert.Equal(t, "my.app", imageName)
+			return nil, nil
+		},
 		getRoute: func(_ context.Context, domainName string) (*domain.Route, error) {
+			assert.True(t, sawImageLookup, "expected image lookup before legacy domain lookup")
+			assert.Equal(t, "my.app", domainName)
+			return nil, domain.ErrRouteNotFound
+		},
+	}
+
+	_, _, _, err := resolveRoute(context.Background(), cp, "my.app", "", "Dockerfile")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `no route configured for image "my.app"`)
+	assert.Contains(t, err.Error(), "gordon bootstrap")
+	assert.NotContains(t, err.Error(), "failed to get route for domain")
+}
+
+func TestResolveRoute_DottedBareDomainFallsBackToLegacyLookup(t *testing.T) {
+	sawImageLookup := false
+	cp := &resolveFromImageTestControlPlane{
+		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
+			sawImageLookup = true
+			assert.Equal(t, "app.example.com", imageName)
+			return nil, nil
+		},
+		getRoute: func(_ context.Context, domainName string) (*domain.Route, error) {
+			assert.True(t, sawImageLookup, "expected image lookup before legacy domain lookup")
 			assert.Equal(t, "app.example.com", domainName)
 			return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, nil
-		},
-		findRoutesByImage: func(_ context.Context, imageName string) ([]domain.Route, error) {
-			t.Fatalf("unexpected FindRoutesByImage call for %q", imageName)
-			return nil, nil
 		},
 	}
 

--- a/internal/adapters/in/cli/push_test.go
+++ b/internal/adapters/in/cli/push_test.go
@@ -242,70 +242,21 @@ func TestParseImageRef(t *testing.T) {
 
 func TestClassifyPushArgument(t *testing.T) {
 	tests := []struct {
-		name       string
-		arg        string
-		wantKind   string
-		wantImage  string
-		wantQuery  string
-		wantDomain string
+		name string
+		arg  string
+		want classifiedPushArg
 	}{
-		{name: "tagged image latest", arg: "myapp:latest", wantKind: "image", wantImage: "myapp:latest", wantQuery: "myapp"},
-		{name: "tagged image semver", arg: "myapp:v1.2.3", wantKind: "image", wantImage: "myapp:v1.2.3", wantQuery: "myapp"},
-		{name: "registry qualified image", arg: "registry.example.com/myapp:v1.2.3", wantKind: "image", wantImage: "registry.example.com/myapp:v1.2.3", wantQuery: "registry.example.com/myapp"},
-		{name: "legacy domain", arg: "app.example.com", wantKind: "legacy-domain", wantDomain: "app.example.com"},
-		{name: "bare image name", arg: "myapp", wantKind: "image", wantImage: "myapp", wantQuery: "myapp"},
+		{name: "tagged image latest", arg: "myapp:latest", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
+		{name: "tagged image semver", arg: "myapp:v1.2.3", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
+		{name: "registry qualified image", arg: "registry.example.com/myapp:v1.2.3", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "registry.example.com/myapp"}},
+		{name: "legacy domain", arg: "app.example.com", want: classifiedPushArg{kind: pushArgKindLegacyDomain, legacyDomain: "app.example.com"}},
+		{name: "bare image name", arg: "myapp", want: classifiedPushArg{kind: pushArgKindImage, lookupImage: "myapp"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			module := []byte("module classifyprobe\n\ngo 1.25\n")
-			if err := os.WriteFile(filepath.Join(dir, "go.mod"), module, 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			source := fmt.Sprintf(`package cli
-
-import "testing"
-
-func TestProbe(t *testing.T) {
-	cases := []struct {
-		name       string
-		arg        string
-		wantKind   string
-		wantImage  string
-		wantQuery  string
-		wantDomain string
-	}{
-		{name: %q, arg: %q, wantKind: %q, wantImage: %q, wantQuery: %q, wantDomain: %q},
-	}
-
-	for _, tt := range cases {
-		var _ pushArgKind
-		got := classifyPushArgument(tt.arg)
-		_ = got
-		_ = pushArgKindImage
-		_ = pushArgKindLegacyDomain
-	}
-}
-`, tt.name, tt.arg, tt.wantKind, tt.wantImage, tt.wantQuery, tt.wantDomain)
-
-			if err := os.WriteFile(filepath.Join(dir, "probe_test.go"), []byte(source), 0o644); err != nil {
-				t.Fatal(err)
-			}
-
-			cmd := exec.Command("go", "test", "./...")
-			cmd.Dir = dir
-			cmd.Env = append(os.Environ(), "GOWORK=off")
-			out, err := cmd.CombinedOutput()
-			if err == nil {
-				t.Fatal("expected classifier compile failure, got success")
-			}
-			output := string(out)
-			if !strings.Contains(output, "undefined: classifyPushArgument") && !strings.Contains(output, "undefined: pushArgKind") {
-				t.Fatalf("expected missing classifier symbols, got:\n%s", output)
-			}
-			t.Fatalf("classifier compile probe failed as expected:\n%s", output)
+			got := classifyPushArgument(tt.arg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -21,6 +21,7 @@ var (
 	ErrRouteNotFound      = errors.New("route not found")
 	ErrRouteExists        = errors.New("route already exists")
 	ErrInvalidRoute       = errors.New("invalid route configuration")
+	ErrNoRouteForImage    = errors.New("no route configured for image")
 	ErrRouteDomainEmpty   = errors.New("route domain cannot be empty")
 	ErrRouteImageEmpty    = errors.New("route image cannot be empty")
 	ErrRouteDomainInvalid = errors.New("route domain is not a valid public hostname")


### PR DESCRIPTION
## Summary
- make `gordon push` prefer image-first route resolution while preserving legacy domain-based workflows
- strip tags before backend route lookup and fall back from dotted image-or-domain args to legacy domain lookup only when no image route exists
- update tests, README, and CLI docs to reflect the new push behavior and examples

## Test Plan
- `rtk go test ./internal/adapters/in/cli/...`
- `rtk go test ./...`
- `/usr/bin/golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CLI "push" docs and examples updated to use the --domain flag for deploy-target specification and to clarify tagging/ deploy semantics.

* **New Features**
  * push now favors image-name-based resolution (with legacy domain-style positional support) for more predictable tagging, pushing, and optional deploy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->