### PR TITLE
docs: clarify push domain override examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Build locally, push directly to your Gordon server:
 
 ```bash
 # Push using an explicit domain override
-gordon push --domain app.example.com
+gordon push myapp:latest --domain app.example.com
 
 # Or add a route manually, then deploy
 gordon routes add app.example.com myapp:latest

--- a/docs/cli/attachments.md
+++ b/docs/cli/attachments.md
@@ -255,7 +255,7 @@ gordon bootstrap app.example.com myapp:latest --attachment pitlane-pgsql
 gordon attachments push pitlane-pgsql --build
 
 # Then push and deploy the route image
-gordon push --domain app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 ```
 
 ### CI/CD Integration

--- a/docs/cli/bootstrap.md
+++ b/docs/cli/bootstrap.md
@@ -44,7 +44,7 @@ Unlike `gordon push`, `gordon bootstrap` does not require the route to exist fir
 gordon bootstrap app.example.com myapp:latest
 
 # Then push and deploy the image
-gordon push --domain app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 
 # First-time route setup with a database attachment and environment variable
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -72,7 +72,7 @@ gordon restart myapp.example.com
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then push and deploy
-gordon push --domain app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 
 # Push an image and deploy
 gordon push myapp --build

--- a/docs/cli/push.md
+++ b/docs/cli/push.md
@@ -100,7 +100,7 @@ gordon push --build --remote https://gordon.example.com --no-confirm
 gordon push myapp --remote https://gordon.example.com --no-confirm
 
 # Push and deploy to an explicit domain
-gordon push --domain app.example.com --remote https://gordon.example.com --no-confirm
+gordon push myapp:latest --domain app.example.com --remote https://gordon.example.com --no-confirm
 
 # Tagged refs still resolve routes by image name
 gordon push myapp:v1.2.3 --tag v1.2.3 --no-deploy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ gordon remotes use prod
 gordon bootstrap app.example.com myapp:latest --attachment postgres:18 --env APP_ENV=production
 
 # Then build, push, and deploy
-gordon push --domain app.example.com --build --no-confirm
+gordon push myapp:latest --domain app.example.com --build --no-confirm
 ```
 
 What this command does:


### PR DESCRIPTION
## Summary
- make the image argument explicit in `gordon push ... --domain ...` examples
- update README and related CLI docs to use `gordon push myapp:latest --domain app.example.com`
- remove the confusing bare `--domain` examples that implied the image argument was optional in that form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples across documentation to include explicit image references in `gordon push` invocations, clarifying the recommended command syntax for deploying applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->