### PR TITLE
feat(cli): split routes inventory from route status

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -116,6 +116,7 @@ gordon auth internal
 
 # Routes
 gordon routes list
+gordon routes status
 gordon routes add myapp.example.com myapp:latest
 gordon routes remove myapp.example.com
 gordon routes deploy myapp.example.com
@@ -166,6 +167,20 @@ gordon autoroute allow remove example.com
 The CLI can target remote Gordon instances using client config, an active remote, `--remote`,
 or `GORDON_REMOTE` environment variable. Use `--remote` and `--token` as global overrides
 when you want to bypass your saved configuration.
+
+`gordon routes list` and `gordon routes status` are the exceptions: when neither `--remote`
+nor `GORDON_REMOTE` is set, they show local routes first, then every saved remote. Set either
+one to force a single target.
+
+```bash
+# Aggregate routes views
+gordon routes list
+gordon routes status
+
+# Single-target override
+gordon routes list --remote prod
+GORDON_REMOTE=prod gordon routes status
+```
 
 **Important:** The remote URL must be the `gordon_domain` configured on the remote Gordon instance. This is the domain that serves both the container registry and the Admin API.
 If remote CLI gets a `404` during `/auth/token` exchange, the server likely still sets only `server.registry_domain` and needs `server.gordon_domain` configured.

--- a/docs/cli/remotes.md
+++ b/docs/cli/remotes.md
@@ -162,12 +162,14 @@ gordon remotes use <name>
 
 ### Description
 
-When a remote is active, it's used automatically for all remote-capable commands without needing to specify `--remote` and `--token`:
+When a remote is active, it's used automatically for most remote-capable commands without needing to specify `--remote` and `--token`.
+`gordon routes list` and `gordon routes status` are the exception: they aggregate local + saved remotes unless you set `--remote` or `GORDON_REMOTE`.
 
 ```bash
 gordon remotes use prod
-gordon routes list              # Uses prod remote automatically
 gordon secrets list app.com     # Uses prod remote automatically
+gordon routes list              # Aggregates local + saved remotes
+gordon routes status            # Aggregates local + saved remotes
 ```
 
 ### Example
@@ -242,6 +244,8 @@ token = "eyJ..."
 
 When multiple sources specify remote or token, the CLI uses this priority:
 
+For `routes list` and `routes status`, `--remote` and `GORDON_REMOTE` are the explicit single-target selectors. Without either one, those commands aggregate local + saved remotes even when an active remote exists.
+
 **Remote URL:**
 1. `--remote` flag
 2. `GORDON_REMOTE` environment variable
@@ -263,8 +267,13 @@ When multiple sources specify remote or token, the CLI uses this priority:
 This allows overriding specific values while keeping defaults:
 
 ```bash
-# Active remote is prod, but use different token
-gordon routes list --token $TEMPORARY_TOKEN
+# Aggregate routes views
+gordon routes list
+gordon routes status
+
+# Force one target
+GORDON_REMOTE=prod gordon routes list
+GORDON_REMOTE=prod gordon routes status
 ```
 
 ---
@@ -281,12 +290,12 @@ gordon remotes add dev https://gordon.dev.example.com --token-env DEV_TOKEN
 
 # Work with prod
 gordon remotes use prod
-gordon routes list
 gordon secrets list myapp.example.com
+gordon routes list --remote prod
 
 # Switch to staging
 gordon remotes use staging
-gordon routes list
+GORDON_REMOTE=staging gordon routes status
 ```
 
 ### CI/CD Pipeline
@@ -306,13 +315,17 @@ steps:
 ### Compare Environments
 
 ```bash
-# Compare routes across environments
-gordon routes list --remote https://gordon.example.com --token $PROD_TOKEN
-gordon routes list --remote https://gordon.staging.example.com --token $STAGING_TOKEN
+# Aggregate route inventory/status across local + saved remotes
+gordon routes list
+gordon routes status
 
-# Or switch between active remotes
-gordon remotes use prod && gordon routes list
-gordon remotes use staging && gordon routes list
+# Compare one target at a time
+gordon routes list --remote https://gordon.example.com --token $PROD_TOKEN
+GORDON_REMOTE=staging gordon routes status
+
+# Or switch between active remotes for other commands
+gordon remotes use prod && gordon secrets list myapp.example.com
+gordon remotes use staging && gordon secrets list myapp.example.com
 ```
 
 ### Private Admin + Wildcard App Domains

--- a/docs/cli/routes.md
+++ b/docs/cli/routes.md
@@ -2,8 +2,10 @@
 
 Manage routes on local or remote Gordon instances.
 
-Remote targeting uses client config or an active remote by default.
-Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
+Most remote-capable commands use client config or an active remote by default.
+`gordon routes list` and `gordon routes status` are different: when neither
+`--remote` nor `GORDON_REMOTE` is set, they show local routes first, then each
+saved remote under its own heading. See [CLI Overview](./index.md).
 
 ## gordon routes
 
@@ -11,7 +13,8 @@ Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 | Subcommand | Description |
 |------------|-------------|
-| `list` | List all routes |
+| `list` | List routes by domain and image |
+| `status` | Show detailed route status |
 | `show` | Show details for a single route |
 | `add` | Create or update a route |
 | `remove` | Remove a route |
@@ -21,22 +24,34 @@ Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 ## gordon routes list
 
-List all configured routes.
+List routes by domain and image only.
+
+When no target is selected, Gordon shows local routes first, then each saved
+remote under its own heading. Use `--remote` or `GORDON_REMOTE` to show one
+target only.
 
 ```bash
 gordon routes list
 gordon routes list --json
 gordon routes list --remote https://gordon.mydomain.com --token $TOKEN
+GORDON_REMOTE=prod gordon routes list
 ```
 
 ### Output
 
-```
-Domain                    Image                     Status
---------------------------------------------------------------------------------
-app.example.com           myapp:latest              running
-api.example.com           myapi:v2.1.0              running
-admin.example.com         admin-panel:latest        stopped
+```text
+Routes
+
+Local
+  app.example.com           myapp:latest
+  api.example.com           myapi:v2.1.0
+
+Remote: hetzner-vps
+  gordon.example.com        gordon-webapp:latest
+
+Remote: igor
+  grafana.supri.xyz         grafana
+  test.supri.xyz            hello-test
 ```
 
 ### JSON Output
@@ -48,17 +63,105 @@ gordon routes list --json
 ```json
 [
   {
-    "domain": "app.example.com",
-    "image": "myapp:latest",
-    "status": "running"
+    "kind": "local",
+    "name": "local",
+    "routes": [
+      {
+        "domain": "app.example.com",
+        "image": "myapp:latest"
+      }
+    ]
   },
   {
-    "domain": "api.example.com",
-    "image": "myapi:v2.1.0",
-    "status": "running"
+    "kind": "remote",
+    "name": "igor",
+    "url": "https://gordon.supri.xyz",
+    "routes": [
+      {
+        "domain": "grafana.supri.xyz",
+        "image": "grafana"
+      }
+    ]
   }
 ]
 ```
+
+Single-target mode still returns a one-element array. Sections can also include
+an `error` field when a target is unavailable.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output routes as JSON |
+| `--remote, -r` | Remote name or URL (e.g., prod, https://gordon.mydomain.com) |
+| `--token` | Authentication token for remote |
+
+---
+
+## gordon routes status
+
+Show detailed route status for each target.
+
+`routes status` uses the same target selection rules as `routes list`. When no
+target is selected, Gordon shows local status first, then each saved remote
+under its own heading.
+
+```bash
+gordon routes status
+gordon routes status --json
+gordon routes status --remote https://gordon.mydomain.com --token $TOKEN
+GORDON_REMOTE=prod gordon routes status
+```
+
+### Output
+
+```text
+Route Status
+
+Local
+  <rich tree for local routes>
+
+Remote: hetzner-vps
+  <rich tree for that remote>
+
+Remote: igor
+  <rich tree for that remote>
+```
+
+The rich view keeps network grouping, container status, HTTP probe status, and
+attachments within each target.
+
+### JSON Output
+
+```json
+[
+  {
+    "kind": "local",
+    "name": "local",
+    "routes": [
+      {
+        "domain": "app.example.com",
+        "image": "myapp:latest",
+        "container_id": "abcd1234",
+        "container_status": "running",
+        "http_status": 200,
+        "network": "gordon-shared",
+        "attachments": [
+          {
+            "name": "postgres",
+            "image": "postgres:18",
+            "status": "running"
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+Single-target mode still returns a one-element array. Sections can also include
+an `error` field when a target is unavailable.
 
 ### Options
 

--- a/internal/adapters/in/cli/controlplane_resolver.go
+++ b/internal/adapters/in/cli/controlplane_resolver.go
@@ -28,6 +28,11 @@ func resolveControlPlane(configPath string) (*controlPlaneHandle, error) {
 		return &controlPlaneHandle{plane: NewRemoteControlPlane(client), isRemote: true}, nil
 	}
 
+	return resolveLocalControlPlane(configPath)
+}
+
+func resolveLocalControlPlane(configPath string) (*controlPlaneHandle, error) {
+
 	kernel, err := app.NewKernel(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize local control plane: %w", err)

--- a/internal/adapters/in/cli/controlplane_resolver.go
+++ b/internal/adapters/in/cli/controlplane_resolver.go
@@ -32,7 +32,7 @@ func resolveControlPlane(configPath string) (*controlPlaneHandle, error) {
 }
 
 func resolveLocalControlPlane(configPath string) (*controlPlaneHandle, error) {
-	kernel, err := app.NewKernel(configPath)
+	kernel, err := app.NewKernelQuiet(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize local control plane: %w", err)
 	}

--- a/internal/adapters/in/cli/controlplane_resolver.go
+++ b/internal/adapters/in/cli/controlplane_resolver.go
@@ -32,7 +32,6 @@ func resolveControlPlane(configPath string) (*controlPlaneHandle, error) {
 }
 
 func resolveLocalControlPlane(configPath string) (*controlPlaneHandle, error) {
-
 	kernel, err := app.NewKernel(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize local control plane: %w", err)

--- a/internal/adapters/in/cli/json_parity_test.go
+++ b/internal/adapters/in/cli/json_parity_test.go
@@ -13,6 +13,7 @@ func TestAllListCommands_AcceptJSONFlag(t *testing.T) {
 		builder func() *cobra.Command
 	}{
 		{"routes list", newRoutesListCmd},
+		{"routes status", newRoutesStatusCmd},
 		{"attachments list", newAttachmentsListCmd},
 		{"secrets list", newSecretsListCmd},
 		{"images list", newImagesListCmd},

--- a/internal/adapters/in/cli/json_test.go
+++ b/internal/adapters/in/cli/json_test.go
@@ -266,6 +266,65 @@ func TestRoutesList_JSONShape_RoundTripsLocalPayload(t *testing.T) {
 	assert.Equal(t, payload[0], got[0])
 }
 
+func TestRoutesStatus_JSONFlag_Accepted(t *testing.T) {
+	cmd := newRoutesStatusCmd()
+	f := cmd.Flags().Lookup("json")
+	assert.NotNil(t, f)
+	if f != nil {
+		assert.Equal(t, "false", f.DefValue)
+	}
+}
+
+func TestRoutesList_JSONShape_RoundTripsSections(t *testing.T) {
+	payload := []routeListSection{{
+		Kind: "local",
+		Name: "local",
+		Routes: []routeListItem{{
+			Domain: "app.local",
+			Image:  "myapp:latest",
+		}},
+	}}
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var got []routeListSection
+	require.NoError(t, json.Unmarshal(encoded, &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "local", got[0].Kind)
+	assert.Equal(t, "app.local", got[0].Routes[0].Domain)
+}
+
+func TestRoutesStatus_JSONShape_RoundTripsSections(t *testing.T) {
+	payload := []routeStatusSection{{
+		Kind: "remote",
+		Name: "igor",
+		URL:  "https://gordon.supri.xyz",
+		Routes: []routeStatusItem{{
+			Domain:          "grafana.supri.xyz",
+			Image:           "grafana",
+			ContainerStatus: "running",
+			HTTPStatus:      200,
+			Network:         "gordon-shared",
+			Attachments: []routeStatusAttachment{{
+				Name:   "prometheus",
+				Image:  "prometheus:v5",
+				Status: "running",
+			}},
+		}},
+	}}
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var got []routeStatusSection
+	require.NoError(t, json.Unmarshal(encoded, &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "igor", got[0].Name)
+	assert.Equal(t, 200, got[0].Routes[0].HTTPStatus)
+	assert.Equal(t, "prometheus", got[0].Routes[0].Attachments[0].Name)
+}
+
 func TestWriteJSON_ProducesValidIndentedJSON(t *testing.T) {
 	var out bytes.Buffer
 	err := writeJSON(&out, map[string]any{"ok": true})

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -269,6 +269,13 @@ func collectRoutesListSections(ctx context.Context, cfgPath string, deps routesL
 		section := loadRoutesListExplicitRemoteSection(ctx, deps, resolved)
 		return []routeListSection{section}, nil
 	}
+	if target, ok := resolveRoutesExplicitTarget(); ok {
+		return []routeListSection{{
+			Kind:  "remote",
+			Name:  target,
+			Error: unresolvedRoutesTargetError(target),
+		}}, nil
+	}
 
 	return collectRoutesListAggregateSections(ctx, cfgPath, deps)
 }
@@ -370,6 +377,13 @@ func collectRoutesStatusSections(ctx context.Context, cfgPath string, deps route
 	if resolved, ok := deps.explicitRemote(); ok {
 		section := loadRoutesStatusExplicitRemoteSection(ctx, deps, resolved)
 		return []routeStatusSection{section}, nil
+	}
+	if target, ok := resolveRoutesExplicitTarget(); ok {
+		return []routeStatusSection{{
+			Kind:  "remote",
+			Name:  target,
+			Error: unresolvedRoutesTargetError(target),
+		}}, nil
 	}
 
 	return collectRoutesStatusAggregateSections(ctx, cfgPath, deps)
@@ -583,6 +597,10 @@ func capitalizeKind(kind string) string {
 		return strings.ToUpper(kind)
 	}
 	return strings.ToUpper(kind[:1]) + kind[1:]
+}
+
+func unresolvedRoutesTargetError(target string) string {
+	return fmt.Sprintf("could not resolve remote target %q", target)
 }
 
 func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool) {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -128,14 +128,14 @@ type routeStatusSection struct {
 }
 
 type routesListDeps struct {
-	explicitRemote func() (*remote.ResolvedRemote, bool)
+	explicitRemote func() (*remote.ResolvedRemote, bool, error)
 	loadLocal      func(context.Context, string) (routeListSection, error)
 	listRemotes    func() (map[string]remote.RemoteEntry, string, error)
 	loadRemote     func(context.Context, string, remote.RemoteEntry) (routeListSection, error)
 }
 
 type routesStatusDeps struct {
-	explicitRemote func() (*remote.ResolvedRemote, bool)
+	explicitRemote func() (*remote.ResolvedRemote, bool, error)
 	loadLocal      func(context.Context, string) (routeStatusSection, error)
 	listRemotes    func() (map[string]remote.RemoteEntry, string, error)
 	loadRemote     func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error)
@@ -265,7 +265,9 @@ func collectRoutesListSections(ctx context.Context, cfgPath string, deps routesL
 		deps.loadRemote = loadRoutesListRemoteSection
 	}
 
-	if resolved, ok := deps.explicitRemote(); ok {
+	if resolved, ok, err := deps.explicitRemote(); err != nil {
+		return nil, err
+	} else if ok {
 		section := loadRoutesListExplicitRemoteSection(ctx, deps, resolved)
 		return []routeListSection{section}, nil
 	}
@@ -281,7 +283,10 @@ func collectRoutesListSections(ctx context.Context, cfgPath string, deps routesL
 }
 
 func loadRoutesListExplicitRemoteSection(ctx context.Context, deps routesListDeps, resolved *remote.ResolvedRemote) routeListSection {
-	section, _ := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	section, err := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	if err != nil && section.Error == "" {
+		section.Error = err.Error()
+	}
 	return normalizeRouteListRemoteSection(section, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
 }
 
@@ -289,6 +294,7 @@ func collectRoutesListAggregateSections(ctx context.Context, cfgPath string, dep
 
 	type localResult struct {
 		section routeListSection
+		err     error
 	}
 	type remotesResult struct {
 		entries map[string]remote.RemoteEntry
@@ -299,16 +305,22 @@ func collectRoutesListAggregateSections(ctx context.Context, cfgPath string, dep
 	remotesCh := make(chan remotesResult, 1)
 
 	go func() {
-		section, _ := deps.loadLocal(ctx, cfgPath)
-		localCh <- localResult{section: section}
+		section, err := deps.loadLocal(ctx, cfgPath)
+		localCh <- localResult{section: section, err: err}
 	}()
 	go func() {
 		entries, _, err := deps.listRemotes()
 		remotesCh <- remotesResult{entries: entries, err: err}
 	}()
 
-	local := (<-localCh).section
+	localRes := <-localCh
 	remotes := <-remotesCh
+	local := localRes.section
+	if err := localRes.err; err != nil {
+		if local.Error == "" {
+			local.Error = err.Error()
+		}
+	}
 
 	sections := make([]routeListSection, 0, 1)
 	sections = append(sections, normalizeRouteListLocalSection(local))
@@ -327,7 +339,10 @@ func collectRoutesListAggregateSections(ctx context.Context, cfgPath string, dep
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			section, _ := deps.loadRemote(ctx, name, entry)
+			section, err := deps.loadRemote(ctx, name, entry)
+			if err != nil && section.Error == "" {
+				section.Error = err.Error()
+			}
 			remoteSections[i] = normalizeRouteListRemoteSection(section, name, entry)
 		}()
 	}
@@ -374,7 +389,9 @@ func collectRoutesStatusSections(ctx context.Context, cfgPath string, deps route
 		deps.loadRemote = loadRoutesStatusRemoteSection
 	}
 
-	if resolved, ok := deps.explicitRemote(); ok {
+	if resolved, ok, err := deps.explicitRemote(); err != nil {
+		return nil, err
+	} else if ok {
 		section := loadRoutesStatusExplicitRemoteSection(ctx, deps, resolved)
 		return []routeStatusSection{section}, nil
 	}
@@ -390,7 +407,10 @@ func collectRoutesStatusSections(ctx context.Context, cfgPath string, deps route
 }
 
 func loadRoutesStatusExplicitRemoteSection(ctx context.Context, deps routesStatusDeps, resolved *remote.ResolvedRemote) routeStatusSection {
-	section, _ := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	section, err := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	if err != nil && section.Error == "" {
+		section.Error = err.Error()
+	}
 	return normalizeRouteStatusRemoteSection(section, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
 }
 
@@ -398,6 +418,7 @@ func collectRoutesStatusAggregateSections(ctx context.Context, cfgPath string, d
 
 	type localResult struct {
 		section routeStatusSection
+		err     error
 	}
 	type remotesResult struct {
 		entries map[string]remote.RemoteEntry
@@ -408,16 +429,22 @@ func collectRoutesStatusAggregateSections(ctx context.Context, cfgPath string, d
 	remotesCh := make(chan remotesResult, 1)
 
 	go func() {
-		section, _ := deps.loadLocal(ctx, cfgPath)
-		localCh <- localResult{section: section}
+		section, err := deps.loadLocal(ctx, cfgPath)
+		localCh <- localResult{section: section, err: err}
 	}()
 	go func() {
 		entries, _, err := deps.listRemotes()
 		remotesCh <- remotesResult{entries: entries, err: err}
 	}()
 
-	local := (<-localCh).section
+	localRes := <-localCh
 	remotes := <-remotesCh
+	local := localRes.section
+	if err := localRes.err; err != nil {
+		if local.Error == "" {
+			local.Error = err.Error()
+		}
+	}
 
 	sections := make([]routeStatusSection, 0, 1)
 	sections = append(sections, normalizeRouteStatusLocalSection(local))
@@ -436,7 +463,10 @@ func collectRoutesStatusAggregateSections(ctx context.Context, cfgPath string, d
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			section, _ := deps.loadRemote(ctx, name, entry)
+			section, err := deps.loadRemote(ctx, name, entry)
+			if err != nil && section.Error == "" {
+				section.Error = err.Error()
+			}
 			remoteSections[i] = normalizeRouteStatusRemoteSection(section, name, entry)
 		}()
 	}
@@ -603,10 +633,10 @@ func unresolvedRoutesTargetError(target string) string {
 	return fmt.Sprintf("could not resolve remote target %q", target)
 }
 
-func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool) {
+func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool, error) {
 	target, ok := resolveRoutesExplicitTarget()
 	if !ok {
-		return nil, false
+		return nil, false, nil
 	}
 
 	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
@@ -614,12 +644,12 @@ func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool) {
 			URL:         target,
 			Token:       resolveRoutesTokenForTarget("", remote.RemoteEntry{}),
 			InsecureTLS: resolveRoutesInsecureForTarget("", remote.RemoteEntry{}),
-		}, true
+		}, true, nil
 	}
 
 	remotes, err := remote.LoadRemotes("")
 	if err != nil {
-		return nil, false
+		return nil, false, err
 	}
 
 	if remotes != nil {
@@ -629,11 +659,11 @@ func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool) {
 				URL:         entry.URL,
 				Token:       resolveRoutesTokenForTarget(target, entry),
 				InsecureTLS: resolveRoutesInsecureForTarget(target, entry),
-			}, true
+			}, true, nil
 		}
 	}
 
-	return nil, false
+	return nil, false, nil
 }
 
 func resolveRoutesExplicitTarget() (string, bool) {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -975,8 +975,13 @@ func runRoutesShow(ctx context.Context, cp ControlPlane, out io.Writer, routeDom
 	containerStatus := "unknown"
 	httpStatus := 0
 	if routeHealth != nil {
-		containerStatus = routeHealth.ContainerStatus
+		if routeHealth.ContainerStatus != "" {
+			containerStatus = routeHealth.ContainerStatus
+		}
 		httpStatus = routeHealth.HTTPStatus
+		if healthErr == "" && routeHealth.Error != "" {
+			healthErr = routeHealth.Error
+		}
 	}
 
 	if jsonOut {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -636,7 +636,7 @@ func renderRoutesStatusSection(out io.Writer, section routeStatusSection) error 
 
 	if len(section.Routes) > 0 {
 		tree := buildRouteStatusTree(section.Routes)
-		if err := cliWriteLine(out, tree.Render()); err != nil {
+		if err := cliWriteLine(out, strings.TrimSuffix(tree.Render(), "\n")); err != nil {
 			return err
 		}
 	}

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -86,6 +89,58 @@ type networkGroup struct {
 	routes []remote.RouteInfo
 }
 
+type routeListItem struct {
+	Domain string `json:"domain"`
+	Image  string `json:"image"`
+}
+
+type routeListSection struct {
+	Kind   string          `json:"kind"`
+	Name   string          `json:"name"`
+	URL    string          `json:"url,omitempty"`
+	Error  string          `json:"error,omitempty"`
+	Routes []routeListItem `json:"routes,omitempty"`
+}
+
+type routeStatusAttachment struct {
+	Name   string `json:"name"`
+	Image  string `json:"image"`
+	Status string `json:"status"`
+}
+
+type routeStatusItem struct {
+	Domain          string                  `json:"domain"`
+	Image           string                  `json:"image"`
+	ContainerID     string                  `json:"container_id,omitempty"`
+	ContainerStatus string                  `json:"container_status"`
+	HTTPStatus      int                     `json:"http_status"`
+	HealthError     string                  `json:"health_error,omitempty"`
+	Network         string                  `json:"network"`
+	Attachments     []routeStatusAttachment `json:"attachments,omitempty"`
+}
+
+type routeStatusSection struct {
+	Kind   string            `json:"kind"`
+	Name   string            `json:"name"`
+	URL    string            `json:"url,omitempty"`
+	Error  string            `json:"error,omitempty"`
+	Routes []routeStatusItem `json:"routes,omitempty"`
+}
+
+type routesListDeps struct {
+	explicitRemote func() (*remote.ResolvedRemote, bool)
+	loadLocal      func(context.Context, string) (routeListSection, error)
+	listRemotes    func() (map[string]remote.RemoteEntry, string, error)
+	loadRemote     func(context.Context, string, remote.RemoteEntry) (routeListSection, error)
+}
+
+type routesStatusDeps struct {
+	explicitRemote func() (*remote.ResolvedRemote, bool)
+	loadLocal      func(context.Context, string) (routeStatusSection, error)
+	listRemotes    func() (map[string]remote.RemoteEntry, string, error)
+	loadRemote     func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error)
+}
+
 // groupRoutesByNetwork separates routes into network groups (2+ routes sharing a network)
 // and solo routes. Both are sorted alphabetically by domain.
 func groupRoutesByNetwork(routes []remote.RouteInfo) ([]networkGroup, []remote.RouteInfo) {
@@ -136,12 +191,7 @@ the local Gordon configuration.`,
 	}
 
 	cmd.AddCommand(newRoutesListCmd())
-
-	// "status" is an alias for "list"
-	statusCmd := newRoutesListCmd()
-	statusCmd.Use = "status"
-	statusCmd.Short = "Show status of all routes (alias for list)"
-	cmd.AddCommand(statusCmd)
+	cmd.AddCommand(newRoutesStatusCmd())
 
 	cmd.AddCommand(newRoutesShowCmd())
 	cmd.AddCommand(newRoutesAddCmd())
@@ -158,19 +208,670 @@ func newRoutesListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all routes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				return runRoutesListRemote(ctx, client, jsonOut, cmd.OutOrStdout())
+			sections, err := collectRoutesListSections(cmd.Context(), configPath, routesListDeps{})
+			if err != nil {
+				return err
 			}
-			return runRoutesListLocal(ctx, configPath, jsonOut, cmd.OutOrStdout())
+
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), sections)
+			}
+
+			return renderRoutesListSections(cmd.OutOrStdout(), sections)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+func newRoutesStatusCmd() *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show detailed route status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sections, err := collectRoutesStatusSections(cmd.Context(), configPath, routesStatusDeps{})
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), sections)
+			}
+
+			return renderRoutesStatusSections(cmd.OutOrStdout(), sections)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+
+	return cmd
+}
+
+func collectRoutesListSections(ctx context.Context, cfgPath string, deps routesListDeps) ([]routeListSection, error) {
+	if deps.explicitRemote == nil {
+		deps.explicitRemote = resolveRoutesExplicitRemote
+	}
+	if deps.loadLocal == nil {
+		deps.loadLocal = loadRoutesListLocalSection
+	}
+	if deps.listRemotes == nil {
+		deps.listRemotes = remote.ListRemotes
+	}
+	if deps.loadRemote == nil {
+		deps.loadRemote = loadRoutesListRemoteSection
+	}
+
+	if resolved, ok := deps.explicitRemote(); ok {
+		section := loadRoutesListExplicitRemoteSection(ctx, deps, resolved)
+		return []routeListSection{section}, nil
+	}
+
+	return collectRoutesListAggregateSections(ctx, cfgPath, deps)
+}
+
+func loadRoutesListExplicitRemoteSection(ctx context.Context, deps routesListDeps, resolved *remote.ResolvedRemote) routeListSection {
+	section, _ := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	return normalizeRouteListRemoteSection(section, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+}
+
+func collectRoutesListAggregateSections(ctx context.Context, cfgPath string, deps routesListDeps) ([]routeListSection, error) {
+
+	type localResult struct {
+		section routeListSection
+	}
+	type remotesResult struct {
+		entries map[string]remote.RemoteEntry
+		err     error
+	}
+
+	localCh := make(chan localResult, 1)
+	remotesCh := make(chan remotesResult, 1)
+
+	go func() {
+		section, _ := deps.loadLocal(ctx, cfgPath)
+		localCh <- localResult{section: section}
+	}()
+	go func() {
+		entries, _, err := deps.listRemotes()
+		remotesCh <- remotesResult{entries: entries, err: err}
+	}()
+
+	local := (<-localCh).section
+	remotes := <-remotesCh
+
+	sections := make([]routeListSection, 0, 1)
+	sections = append(sections, normalizeRouteListLocalSection(local))
+
+	if remotes.err != nil {
+		sections = append(sections, routeListSection{Kind: "remote", Name: "remotes", Error: remotes.err.Error()})
+		return sections, nil
+	}
+
+	names := sortedRemoteNames(remotes.entries)
+	remoteSections := make([]routeListSection, len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		i, name := i, name
+		entry := remotes.entries[name]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			section, _ := deps.loadRemote(ctx, name, entry)
+			remoteSections[i] = normalizeRouteListRemoteSection(section, name, entry)
+		}()
+	}
+	wg.Wait()
+
+	sections = append(sections, remoteSections...)
+	return sections, nil
+}
+
+func normalizeRouteListLocalSection(section routeListSection) routeListSection {
+	if section.Kind == "" {
+		section.Kind = "local"
+	}
+	if section.Name == "" {
+		section.Name = "local"
+	}
+	return section
+}
+
+func normalizeRouteListRemoteSection(section routeListSection, name string, entry remote.RemoteEntry) routeListSection {
+	if section.Kind == "" {
+		section.Kind = "remote"
+	}
+	if section.Name == "" {
+		section.Name = name
+	}
+	if section.URL == "" {
+		section.URL = entry.URL
+	}
+	return section
+}
+
+func collectRoutesStatusSections(ctx context.Context, cfgPath string, deps routesStatusDeps) ([]routeStatusSection, error) {
+	if deps.explicitRemote == nil {
+		deps.explicitRemote = resolveRoutesExplicitRemote
+	}
+	if deps.loadLocal == nil {
+		deps.loadLocal = loadRoutesStatusLocalSection
+	}
+	if deps.listRemotes == nil {
+		deps.listRemotes = remote.ListRemotes
+	}
+	if deps.loadRemote == nil {
+		deps.loadRemote = loadRoutesStatusRemoteSection
+	}
+
+	if resolved, ok := deps.explicitRemote(); ok {
+		section := loadRoutesStatusExplicitRemoteSection(ctx, deps, resolved)
+		return []routeStatusSection{section}, nil
+	}
+
+	return collectRoutesStatusAggregateSections(ctx, cfgPath, deps)
+}
+
+func loadRoutesStatusExplicitRemoteSection(ctx context.Context, deps routesStatusDeps, resolved *remote.ResolvedRemote) routeStatusSection {
+	section, _ := deps.loadRemote(ctx, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+	return normalizeRouteStatusRemoteSection(section, resolved.DisplayName(), remote.RemoteEntry{URL: resolved.URL, Token: resolved.Token, InsecureTLS: resolved.InsecureTLS})
+}
+
+func collectRoutesStatusAggregateSections(ctx context.Context, cfgPath string, deps routesStatusDeps) ([]routeStatusSection, error) {
+
+	type localResult struct {
+		section routeStatusSection
+	}
+	type remotesResult struct {
+		entries map[string]remote.RemoteEntry
+		err     error
+	}
+
+	localCh := make(chan localResult, 1)
+	remotesCh := make(chan remotesResult, 1)
+
+	go func() {
+		section, _ := deps.loadLocal(ctx, cfgPath)
+		localCh <- localResult{section: section}
+	}()
+	go func() {
+		entries, _, err := deps.listRemotes()
+		remotesCh <- remotesResult{entries: entries, err: err}
+	}()
+
+	local := (<-localCh).section
+	remotes := <-remotesCh
+
+	sections := make([]routeStatusSection, 0, 1)
+	sections = append(sections, normalizeRouteStatusLocalSection(local))
+
+	if remotes.err != nil {
+		sections = append(sections, routeStatusSection{Kind: "remote", Name: "remotes", Error: remotes.err.Error()})
+		return sections, nil
+	}
+
+	names := sortedRemoteNames(remotes.entries)
+	remoteSections := make([]routeStatusSection, len(names))
+	var wg sync.WaitGroup
+	for i, name := range names {
+		i, name := i, name
+		entry := remotes.entries[name]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			section, _ := deps.loadRemote(ctx, name, entry)
+			remoteSections[i] = normalizeRouteStatusRemoteSection(section, name, entry)
+		}()
+	}
+	wg.Wait()
+
+	sections = append(sections, remoteSections...)
+	return sections, nil
+}
+
+func normalizeRouteStatusLocalSection(section routeStatusSection) routeStatusSection {
+	if section.Kind == "" {
+		section.Kind = "local"
+	}
+	if section.Name == "" {
+		section.Name = "local"
+	}
+	return section
+}
+
+func normalizeRouteStatusRemoteSection(section routeStatusSection, name string, entry remote.RemoteEntry) routeStatusSection {
+	if section.Kind == "" {
+		section.Kind = "remote"
+	}
+	if section.Name == "" {
+		section.Name = name
+	}
+	if section.URL == "" {
+		section.URL = entry.URL
+	}
+	return section
+}
+
+func renderRoutesListSections(out io.Writer, sections []routeListSection) error {
+	if err := cliWriteLine(out, cliRenderTitle("Routes")); err != nil {
+		return err
+	}
+	if err := cliWriteLine(out, ""); err != nil {
+		return err
+	}
+
+	for i, section := range sections {
+		if i > 0 {
+			if err := cliWriteLine(out, ""); err != nil {
+				return err
+			}
+		}
+		if err := renderRoutesListSection(out, section); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func renderRoutesListSection(out io.Writer, section routeListSection) error {
+	if err := cliWriteLine(out, routeSectionHeading(section.Kind, section.Name)); err != nil {
+		return err
+	}
+
+	if len(section.Routes) > 0 {
+		const imageColWidth = 45
+		rows := make([][]string, 0, len(section.Routes))
+		for _, route := range section.Routes {
+			rows = append(rows, []string{route.Domain, truncateImage(route.Image, imageColWidth)})
+		}
+
+		table := components.NewTable(
+			components.WithColumns([]components.TableColumn{
+				{Title: "Domain", Width: 30},
+				{Title: "Image", Width: imageColWidth},
+			}),
+			components.WithRows(rows),
+		)
+
+		if err := cliWriteLine(out, table.View()); err != nil {
+			return err
+		}
+	}
+
+	if section.Error != "" {
+		return cliWriteLine(out, cliRenderWarning(section.Error))
+	}
+
+	if len(section.Routes) == 0 {
+		return cliWriteLine(out, cliRenderMuted("No routes configured"))
+	}
+
+	return nil
+}
+
+func renderRoutesStatusSections(out io.Writer, sections []routeStatusSection) error {
+	if err := cliWriteLine(out, cliRenderTitle("Route Status")); err != nil {
+		return err
+	}
+	if err := cliWriteLine(out, ""); err != nil {
+		return err
+	}
+
+	for i, section := range sections {
+		if i > 0 {
+			if err := cliWriteLine(out, ""); err != nil {
+				return err
+			}
+		}
+		if err := renderRoutesStatusSection(out, section); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func renderRoutesStatusSection(out io.Writer, section routeStatusSection) error {
+	if err := cliWriteLine(out, routeSectionHeading(section.Kind, section.Name)); err != nil {
+		return err
+	}
+
+	if len(section.Routes) > 0 {
+		tree := buildRouteStatusTree(section.Routes)
+		if err := cliWriteLine(out, tree.Render()); err != nil {
+			return err
+		}
+	}
+
+	if section.Error != "" {
+		return cliWriteLine(out, cliRenderWarning(section.Error))
+	}
+
+	if len(section.Routes) == 0 {
+		return cliWriteLine(out, cliRenderMuted("No routes configured"))
+	}
+
+	return nil
+}
+
+func routeSectionHeading(kind, name string) string {
+	switch kind {
+	case "local":
+		return "Local"
+	case "remote":
+		if name != "" {
+			return "Remote: " + name
+		}
+		return "Remote"
+	default:
+		if name != "" {
+			return capitalizeKind(kind) + ": " + name
+		}
+		return capitalizeKind(kind)
+	}
+}
+
+func capitalizeKind(kind string) string {
+	if kind == "" {
+		return ""
+	}
+	if len(kind) == 1 {
+		return strings.ToUpper(kind)
+	}
+	return strings.ToUpper(kind[:1]) + kind[1:]
+}
+
+func resolveRoutesExplicitRemote() (*remote.ResolvedRemote, bool) {
+	target, ok := resolveRoutesExplicitTarget()
+	if !ok {
+		return nil, false
+	}
+
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		return &remote.ResolvedRemote{
+			URL:         target,
+			Token:       resolveRoutesTokenForTarget("", remote.RemoteEntry{}),
+			InsecureTLS: resolveRoutesInsecureForTarget("", remote.RemoteEntry{}),
+		}, true
+	}
+
+	remotes, err := remote.LoadRemotes("")
+	if err != nil {
+		return nil, false
+	}
+
+	if remotes != nil {
+		if entry, found := remotes.Remotes[target]; found {
+			return &remote.ResolvedRemote{
+				Name:        target,
+				URL:         entry.URL,
+				Token:       resolveRoutesTokenForTarget(target, entry),
+				InsecureTLS: resolveRoutesInsecureForTarget(target, entry),
+			}, true
+		}
+	}
+
+	return nil, false
+}
+
+func resolveRoutesExplicitTarget() (string, bool) {
+	if target := strings.TrimSpace(remoteFlag); target != "" {
+		return target, true
+	}
+	if target := strings.TrimSpace(os.Getenv("GORDON_REMOTE")); target != "" {
+		return target, true
+	}
+	return "", false
+}
+
+func resolveRoutesTokenForTarget(name string, entry remote.RemoteEntry) string {
+	if token := strings.TrimSpace(tokenFlag); token != "" {
+		return token
+	}
+	if token := strings.TrimSpace(os.Getenv("GORDON_TOKEN")); token != "" {
+		return token
+	}
+	if name != "" {
+		return remote.ResolveTokenForRemote(name, entry)
+	}
+	return ""
+}
+
+func resolveRoutesInsecureForTarget(name string, entry remote.RemoteEntry) bool {
+	if insecureTLSFlag {
+		return true
+	}
+	if env := strings.TrimSpace(os.Getenv("GORDON_INSECURE")); env != "" {
+		if value, err := strconv.ParseBool(env); err == nil {
+			return value
+		}
+	}
+	if name != "" {
+		return entry.InsecureTLS
+	}
+	return false
+}
+
+func newRoutesTargetClient(name string, entry remote.RemoteEntry) *remote.Client {
+	return remote.NewClient(entry.URL, remoteClientOptions(resolveRoutesTokenForTarget(name, entry), resolveRoutesInsecureForTarget(name, entry))...)
+}
+
+func loadRoutesListLocalSection(ctx context.Context, cfgPath string) (routeListSection, error) {
+	local, err := GetLocalServices(cfgPath)
+	if err != nil {
+		return routeListSection{Kind: "local", Name: "local", Error: err.Error()}, nil
+	}
+
+	routes := local.GetConfigService().GetRoutes(ctx)
+	section := routeListSection{Kind: "local", Name: "local", Routes: make([]routeListItem, 0, len(routes))}
+	for _, route := range routes {
+		section.Routes = append(section.Routes, routeListItem{Domain: route.Domain, Image: route.Image})
+	}
+
+	return section, nil
+}
+
+func loadRoutesListRemoteSection(ctx context.Context, name string, entry remote.RemoteEntry) (routeListSection, error) {
+	section := routeListSection{Kind: "remote", Name: name, URL: entry.URL}
+	client := newRoutesTargetClient(name, entry)
+	routes, err := client.ListRoutesWithDetails(ctx)
+	if err != nil {
+		section.Error = err.Error()
+		return section, nil
+	}
+
+	section.Routes = routeListItemsFromInfos(routes)
+	return section, nil
+}
+
+func loadRoutesStatusLocalSection(ctx context.Context, cfgPath string) (routeStatusSection, error) {
+	section := routeStatusSection{Kind: "local", Name: "local"}
+	handle, err := resolveLocalControlPlane(cfgPath)
+	if err != nil {
+		section.Error = err.Error()
+		return section, nil
+	}
+	defer handle.close()
+
+	routes, err := handle.plane.ListRoutesWithDetails(ctx)
+	if err != nil {
+		section.Error = err.Error()
+		return section, nil
+	}
+
+	health, err := handle.plane.GetHealth(ctx)
+	if err != nil {
+		section.Error = err.Error()
+		health = nil
+	}
+
+	section.Routes = routeStatusItemsFromInfos(routes, health)
+	return section, nil
+}
+
+func loadRoutesStatusRemoteSection(ctx context.Context, name string, entry remote.RemoteEntry) (routeStatusSection, error) {
+	section := routeStatusSection{Kind: "remote", Name: name, URL: entry.URL}
+	client := newRoutesTargetClient(name, entry)
+	cp := NewRemoteControlPlane(client)
+
+	routes, err := cp.ListRoutesWithDetails(ctx)
+	if err != nil {
+		section.Error = err.Error()
+		return section, nil
+	}
+
+	health, err := cp.GetHealth(ctx)
+	if err != nil {
+		section.Error = err.Error()
+		health = nil
+	}
+
+	section.Routes = routeStatusItemsFromInfos(routes, health)
+	return section, nil
+}
+
+func routeStatusItemsFromInfos(routes []remote.RouteInfo, health map[string]*remote.RouteHealth) []routeStatusItem {
+	items := make([]routeStatusItem, 0, len(routes))
+	for _, route := range routes {
+		item := routeStatusItem{
+			Domain:          route.Domain,
+			Image:           route.Image,
+			ContainerID:     route.ContainerID,
+			ContainerStatus: route.ContainerStatus,
+			Network:         route.Network,
+		}
+		if item.ContainerStatus == "" {
+			if routeHealth := health[route.Domain]; routeHealth != nil {
+				item.ContainerStatus = routeHealth.ContainerStatus
+				item.HTTPStatus = routeHealth.HTTPStatus
+				item.HealthError = routeHealth.Error
+			}
+		}
+		if item.ContainerStatus == "" {
+			item.ContainerStatus = "unknown"
+		}
+		if item.HTTPStatus == 0 {
+			if routeHealth := health[route.Domain]; routeHealth != nil {
+				item.HTTPStatus = routeHealth.HTTPStatus
+				item.HealthError = routeHealth.Error
+			}
+		}
+		if item.HealthError == "" {
+			if routeHealth := health[route.Domain]; routeHealth != nil {
+				item.HealthError = routeHealth.Error
+			}
+		}
+		item.Attachments = make([]routeStatusAttachment, 0, len(route.Attachments))
+		for _, attachment := range route.Attachments {
+			status := attachment.Status
+			if status == "" {
+				status = "unknown"
+			}
+			item.Attachments = append(item.Attachments, routeStatusAttachment{Name: attachment.Name, Image: attachment.Image, Status: status})
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func routeListItemsFromInfos(routes []remote.RouteInfo) []routeListItem {
+	items := make([]routeListItem, 0, len(routes))
+	for _, route := range routes {
+		items = append(items, routeListItem{Domain: route.Domain, Image: route.Image})
+	}
+	return items
+}
+
+func buildRouteStatusTree(routes []routeStatusItem) *components.Tree {
+	sortedRoutes := make([]routeStatusItem, len(routes))
+	copy(sortedRoutes, routes)
+	sort.SliceStable(sortedRoutes, func(i, j int) bool {
+		if sortedRoutes[i].Network != sortedRoutes[j].Network {
+			return sortedRoutes[i].Network < sortedRoutes[j].Network
+		}
+		if sortedRoutes[i].Domain != sortedRoutes[j].Domain {
+			return sortedRoutes[i].Domain < sortedRoutes[j].Domain
+		}
+		if sortedRoutes[i].Image != sortedRoutes[j].Image {
+			return sortedRoutes[i].Image < sortedRoutes[j].Image
+		}
+		if sortedRoutes[i].ContainerID != sortedRoutes[j].ContainerID {
+			return sortedRoutes[i].ContainerID < sortedRoutes[j].ContainerID
+		}
+		if sortedRoutes[i].ContainerStatus != sortedRoutes[j].ContainerStatus {
+			return sortedRoutes[i].ContainerStatus < sortedRoutes[j].ContainerStatus
+		}
+		return sortedRoutes[i].HTTPStatus < sortedRoutes[j].HTTPStatus
+	})
+
+	infos := make([]remote.RouteInfo, 0, len(routes))
+	itemsByDomain := make(map[string]routeStatusItem, len(routes))
+	for _, route := range sortedRoutes {
+		infos = append(infos, remote.RouteInfo{
+			Domain:          route.Domain,
+			Image:           route.Image,
+			ContainerID:     route.ContainerID,
+			ContainerStatus: route.ContainerStatus,
+			Network:         route.Network,
+			Attachments:     routeStatusAttachmentsToRemote(route.Attachments),
+		})
+		itemsByDomain[route.Domain] = route
+	}
+
+	groups, solo := groupRoutesByNetwork(infos)
+	tree := components.NewTree()
+
+	for _, group := range groups {
+		g := tree.AddGroup(group.name)
+		for _, route := range group.routes {
+			item := itemsByDomain[route.Domain]
+			node := g.AddNode(routeStatusTitle(item), item.Image)
+			addRouteStatusAttachmentChildren(node, item)
+		}
+	}
+
+	for _, route := range solo {
+		item := itemsByDomain[route.Domain]
+		node := tree.AddNode(routeStatusTitle(item), item.Image)
+		addRouteStatusAttachmentChildren(node, item)
+	}
+
+	return tree
+}
+
+func routeStatusTitle(route routeStatusItem) string {
+	containerStatus := route.ContainerStatus
+	if containerStatus == "" {
+		containerStatus = "unknown"
+	}
+
+	httpIcon := components.StatusIcon(styles.IconHTTPStatus, httpHealthToStatus(&remote.RouteHealth{HTTPStatus: route.HTTPStatus, Error: route.HealthError}))
+	containerIcon := components.StatusIcon(styles.IconContainerStatus, components.ParseStatus(containerStatus))
+
+	return httpIcon + " " + containerIcon + " " + route.Domain
+}
+
+func addRouteStatusAttachmentChildren(node *components.Node, route routeStatusItem) {
+	for _, att := range route.Attachments {
+		status := att.Status
+		if status == "" {
+			status = "unknown"
+		}
+		attIcon := components.StatusIcon(styles.IconContainerStatus, components.ParseStatus(status))
+		node.AddChild(attIcon+" "+att.Name, att.Image)
+	}
+}
+
+func routeStatusAttachmentsToRemote(attachments []routeStatusAttachment) []remote.Attachment {
+	result := make([]remote.Attachment, 0, len(attachments))
+	for _, att := range attachments {
+		result = append(result, remote.Attachment{Name: att.Name, Image: att.Image, Status: att.Status})
+	}
+	return result
 }
 
 func newRoutesShowCmd() *cobra.Command {
@@ -255,196 +956,6 @@ func runRoutesShow(ctx context.Context, cp ControlPlane, out io.Writer, routeDom
 			return err
 		}
 	}
-
-	return nil
-}
-
-// runRoutesListRemote lists routes from a remote Gordon instance.
-func runRoutesListRemote(ctx context.Context, client *remote.Client, jsonOut bool, out io.Writer) error {
-	routes, err := client.ListRoutesWithDetails(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list routes: %w", err)
-	}
-
-	health, _ := client.GetHealth(ctx)
-	if health == nil {
-		health = make(map[string]*remote.RouteHealth)
-	}
-
-	if jsonOut {
-		return routesListJSON(out, routes, health)
-	}
-
-	if len(routes) == 0 {
-		_, _ = fmt.Fprintln(out, styles.Theme.Muted.Render("No routes configured"))
-		return nil
-	}
-
-	groups, solo := groupRoutesByNetwork(routes)
-
-	type sortableItem struct {
-		sortKey string
-		group   *networkGroup
-		route   *remote.RouteInfo
-	}
-
-	var items []sortableItem
-	for i := range groups {
-		items = append(items, sortableItem{
-			sortKey: groups[i].routes[0].Domain,
-			group:   &groups[i],
-		})
-	}
-	for i := range solo {
-		items = append(items, sortableItem{
-			sortKey: solo[i].Domain,
-			route:   &solo[i],
-		})
-	}
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].sortKey < items[j].sortKey
-	})
-
-	tree := components.NewTree()
-
-	for _, item := range items {
-		if item.group != nil {
-			g := tree.AddGroup(item.group.name)
-			for _, route := range item.group.routes {
-				title := routeTitle(route, health)
-				node := g.AddNode(title, route.Image)
-				addAttachmentChildren(node, route)
-			}
-		} else {
-			title := routeTitle(*item.route, health)
-			node := tree.AddNode(title, item.route.Image)
-			addAttachmentChildren(node, *item.route)
-		}
-	}
-
-	if err := cliWriteLine(out, cliRenderTitle("Routes")); err != nil {
-		return err
-	}
-	if err := cliWriteLine(out, ""); err != nil {
-		return err
-	}
-	return cliWriteLine(out, tree.Render())
-}
-
-// routeTitle builds the pre-styled title line for a route node.
-func routeTitle(route remote.RouteInfo, health map[string]*remote.RouteHealth) string {
-	containerStatus := route.ContainerStatus
-	if containerStatus == "" {
-		if h := health[route.Domain]; h != nil {
-			containerStatus = h.ContainerStatus
-		} else {
-			containerStatus = "unknown"
-		}
-	}
-
-	httpIcon := components.StatusIcon(styles.IconHTTPStatus, httpHealthToStatus(health[route.Domain]))
-	containerIcon := components.StatusIcon(styles.IconContainerStatus, components.ParseStatus(containerStatus))
-
-	return httpIcon + " " + containerIcon + " " + route.Domain
-}
-
-// addAttachmentChildren adds attachment nodes as children of a route node.
-func addAttachmentChildren(node *components.Node, route remote.RouteInfo) {
-	for _, att := range route.Attachments {
-		attStatus := att.Status
-		if attStatus == "" {
-			attStatus = "unknown"
-		}
-		attIcon := components.StatusIcon(styles.IconContainerStatus, components.ParseStatus(attStatus))
-		node.AddChild(attIcon+" "+att.Name, att.Image)
-	}
-}
-
-func routesListJSON(out io.Writer, routes []remote.RouteInfo, health map[string]*remote.RouteHealth) error {
-	payload := make([]map[string]any, 0, len(routes))
-	for _, route := range routes {
-		routeHealth := health[route.Domain]
-		containerStatus := route.ContainerStatus
-		if containerStatus == "" {
-			if routeHealth != nil {
-				containerStatus = routeHealth.ContainerStatus
-			} else {
-				containerStatus = "unknown"
-			}
-		}
-
-		httpStatus := 0
-		if routeHealth != nil {
-			httpStatus = routeHealth.HTTPStatus
-		}
-
-		attachments := make([]map[string]string, 0, len(route.Attachments))
-		for _, attachment := range route.Attachments {
-			attachments = append(attachments, map[string]string{
-				"name":   attachment.Name,
-				"image":  attachment.Image,
-				"status": attachment.Status,
-			})
-		}
-
-		payload = append(payload, map[string]any{
-			"domain":           route.Domain,
-			"image":            route.Image,
-			"container_status": containerStatus,
-			"network":          route.Network,
-			"http_status":      httpStatus,
-			"attachments":      attachments,
-		})
-	}
-
-	return writeJSON(out, payload)
-}
-
-// runRoutesListLocal lists routes from local configuration.
-func runRoutesListLocal(ctx context.Context, cfgPath string, jsonOut bool, out io.Writer) error {
-	local, err := GetLocalServices(cfgPath)
-	if err != nil {
-		return fmt.Errorf("failed to initialize local services: %w", err)
-	}
-
-	routes := local.GetConfigService().GetRoutes(ctx)
-
-	if jsonOut {
-		payload := make([]map[string]string, 0, len(routes))
-		for _, route := range routes {
-			payload = append(payload, map[string]string{
-				"domain": route.Domain,
-				"image":  route.Image,
-			})
-		}
-		return writeJSON(out, payload)
-	}
-
-	if len(routes) == 0 {
-		_, _ = fmt.Fprintln(out, styles.Theme.Muted.Render("No routes configured"))
-		return nil
-	}
-
-	// Build table rows (no health info in local mode)
-	const imageColWidth = 45
-	rows := make([][]string, len(routes))
-	for i, route := range routes {
-		displayImage := truncateImage(route.Image, imageColWidth)
-		rows[i] = []string{route.Domain, displayImage}
-	}
-
-	// Render table
-	table := components.NewTable(
-		components.WithColumns([]components.TableColumn{
-			{Title: "Domain", Width: 30},
-			{Title: "Image", Width: imageColWidth},
-		}),
-		components.WithRows(rows),
-	)
-
-	_, _ = fmt.Fprintln(out, styles.Theme.Title.Render("Routes (local)"))
-	_, _ = fmt.Fprintln(out)
-	_, _ = fmt.Fprintln(out, table.View())
 
 	return nil
 }

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -500,6 +500,8 @@ func normalizeRouteStatusRemoteSection(section routeStatusSection, name string, 
 }
 
 func renderRoutesListSections(out io.Writer, sections []routeListSection) error {
+	sections = renderedRouteListSections(sections)
+
 	if err := cliWriteLine(out, cliRenderTitle("Routes")); err != nil {
 		return err
 	}
@@ -558,6 +560,8 @@ func renderRoutesListSection(out io.Writer, section routeListSection) error {
 }
 
 func renderRoutesStatusSections(out io.Writer, sections []routeStatusSection) error {
+	sections = renderedRouteStatusSections(sections)
+
 	if err := cliWriteLine(out, cliRenderTitle("Route Status")); err != nil {
 		return err
 	}
@@ -577,6 +581,52 @@ func renderRoutesStatusSections(out io.Writer, sections []routeStatusSection) er
 	}
 
 	return nil
+}
+
+func renderedRouteListSections(sections []routeListSection) []routeListSection {
+	if !shouldHideLocalRouteListSection(sections) {
+		return sections
+	}
+	return sections[1:]
+}
+
+func shouldHideLocalRouteListSection(sections []routeListSection) bool {
+	if len(sections) < 2 {
+		return false
+	}
+	local := sections[0]
+	if local.Kind != "local" || local.Error == "" {
+		return false
+	}
+	for _, section := range sections[1:] {
+		if section.Kind == "remote" && section.Error == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderedRouteStatusSections(sections []routeStatusSection) []routeStatusSection {
+	if !shouldHideLocalRouteStatusSection(sections) {
+		return sections
+	}
+	return sections[1:]
+}
+
+func shouldHideLocalRouteStatusSection(sections []routeStatusSection) bool {
+	if len(sections) < 2 {
+		return false
+	}
+	local := sections[0]
+	if local.Kind != "local" || local.Error == "" {
+		return false
+	}
+	for _, section := range sections[1:] {
+		if section.Kind == "remote" && section.Error == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func renderRoutesStatusSection(out io.Writer, section routeStatusSection) error {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -931,7 +931,12 @@ func runRoutesShow(ctx context.Context, cp ControlPlane, out io.Writer, routeDom
 		return fmt.Errorf("failed to get route: %w", err)
 	}
 
-	health, _ := cp.GetHealth(ctx)
+	health, err := cp.GetHealth(ctx)
+	healthErr := ""
+	if err != nil {
+		healthErr = err.Error()
+		health = nil
+	}
 	var routeHealth *remote.RouteHealth
 	if health != nil {
 		routeHealth = health[routeDomain]
@@ -951,19 +956,26 @@ func runRoutesShow(ctx context.Context, cp ControlPlane, out io.Writer, routeDom
 			"container_status": containerStatus,
 			"http_status":      httpStatus,
 		}
+		if healthErr != "" {
+			payload["health_error"] = healthErr
+		}
 		return writeJSON(out, payload)
 	}
 
-	if err := cliWriteLine(out, cliRenderTitle("Route: "+route.Domain)); err != nil {
+	return writeRouteShowText(out, route.Domain, route.Image, containerStatus, httpStatus, healthErr)
+}
+
+func writeRouteShowText(out io.Writer, domainName, image, containerStatus string, httpStatus int, healthErr string) error {
+	if err := cliWriteLine(out, cliRenderTitle("Route: "+domainName)); err != nil {
 		return err
 	}
 	if err := cliWriteLine(out, ""); err != nil {
 		return err
 	}
-	if err := cliWriteLine(out, cliRenderMeta("Domain:", route.Domain)); err != nil {
+	if err := cliWriteLine(out, cliRenderMeta("Domain:", domainName)); err != nil {
 		return err
 	}
-	if err := cliWriteLine(out, cliRenderMeta("Image:", route.Image)); err != nil {
+	if err := cliWriteLine(out, cliRenderMeta("Image:", image)); err != nil {
 		return err
 	}
 	if err := cliWriteLine(out, cliRenderMeta("Container:", containerStatus)); err != nil {
@@ -971,6 +983,11 @@ func runRoutesShow(ctx context.Context, cp ControlPlane, out io.Writer, routeDom
 	}
 	if httpStatus > 0 {
 		if err := cliWriteLine(out, cliRenderMeta("HTTP Status:", fmt.Sprintf("%d", httpStatus))); err != nil {
+			return err
+		}
+	}
+	if healthErr != "" {
+		if err := cliWriteLine(out, cliRenderWarning(healthErr)); err != nil {
 			return err
 		}
 	}

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -682,6 +684,69 @@ func TestCollectRoutesStatusAggregateSections_EncodesLoaderErrors(t *testing.T) 
 	})
 }
 
+func TestLoadRoutesStatusLocalSection_DoesNotLeakKernelInitLogs(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "gordon.toml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`[server]
+gordon_domain = "gordon.local"
+data_dir = `+strconv.Quote(filepath.Join(tmpDir, "data"))+`
+
+[auth]
+enabled = true
+`), 0o600))
+
+	stdout, stderr := captureOutput(t, func() {
+		section, err := loadRoutesStatusLocalSection(context.Background(), cfgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "local", section.Kind)
+		assert.Equal(t, "local", section.Name)
+		assert.Contains(t, section.Error, "failed to initialize local control plane")
+		assert.Contains(t, section.Error, "auth.secrets_backend is required")
+	})
+
+	combined := stdout + stderr
+	assert.NotContains(t, combined, "failed to resolve secrets backend")
+	assert.NotContains(t, combined, "local kernel running in minimal mode")
+}
+
+func captureOutput(t *testing.T, fn func()) (string, string) {
+	t.Helper()
+
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = outW
+	os.Stderr = errW
+
+	stdoutCh := make(chan string, 1)
+	stderrCh := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, outR)
+		stdoutCh <- buf.String()
+	}()
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, errR)
+		stderrCh <- buf.String()
+	}()
+
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+
+	return <-stdoutCh, <-stderrCh
+}
+
 func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.T) {
 	sections := []routeStatusSection{
 		{
@@ -736,6 +801,57 @@ func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.
 	assert.Less(t, localIdx, routeIdx)
 	assert.Less(t, routeIdx, remoteIdx)
 	assert.Less(t, remoteIdx, errorIdx)
+}
+
+func TestRenderRoutesListSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T) {
+	sections := []routeListSection{
+		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
+		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"},
+	}
+
+	var out bytes.Buffer
+	err := renderRoutesListSections(&out, sections)
+
+	require.NoError(t, err)
+	rendered := stripANSI(out.String())
+	assert.NotContains(t, rendered, "Local")
+	assert.NotContains(t, rendered, "failed to initialize local control plane")
+	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "No routes configured")
+}
+
+func TestRenderRoutesStatusSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T) {
+	sections := []routeStatusSection{
+		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
+		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"},
+	}
+
+	var out bytes.Buffer
+	err := renderRoutesStatusSections(&out, sections)
+
+	require.NoError(t, err)
+	rendered := stripANSI(out.String())
+	assert.NotContains(t, rendered, "Local")
+	assert.NotContains(t, rendered, "failed to initialize local control plane")
+	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "No routes configured")
+}
+
+func TestRenderRoutesStatusSections_KeepsLocalErrorWhenAllRemotesFail(t *testing.T) {
+	sections := []routeStatusSection{
+		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
+		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz", Error: "dial tcp timeout"},
+	}
+
+	var out bytes.Buffer
+	err := renderRoutesStatusSections(&out, sections)
+
+	require.NoError(t, err)
+	rendered := stripANSI(out.String())
+	assert.Contains(t, rendered, "Local")
+	assert.Contains(t, rendered, "failed to initialize local control plane")
+	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "dial tcp timeout")
 }
 
 func TestBuildRouteStatusTree_DeterministicAcrossInputOrder(t *testing.T) {

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,9 +14,28 @@ import (
 	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
+	"github.com/bnema/gordon/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type routesShowTestControlPlane struct {
+	resolveFromImageTestControlPlane
+	getHealth func(context.Context) (map[string]*remote.RouteHealth, error)
+}
+
+var _ ControlPlane = (*routesShowTestControlPlane)(nil)
+
+func (c *routesShowTestControlPlane) ListRoutesWithDetails(context.Context) ([]remote.RouteInfo, error) {
+	panic("unexpected call")
+}
+
+func (c *routesShowTestControlPlane) GetHealth(ctx context.Context) (map[string]*remote.RouteHealth, error) {
+	if c.getHealth != nil {
+		return c.getHealth(ctx)
+	}
+	panic("unexpected call")
+}
 
 func TestTruncateImage(t *testing.T) {
 	tests := []struct {
@@ -249,6 +270,57 @@ func TestRouteStatusTitle_PreservesProbeFailureError(t *testing.T) {
 		" app.example.com"
 
 	assert.Equal(t, expected, routeStatusTitle(item))
+}
+
+func TestRunRoutesShow_JSONIncludesHealthError(t *testing.T) {
+	fake := &routesShowTestControlPlane{
+		resolveFromImageTestControlPlane: resolveFromImageTestControlPlane{
+			getRoute: func(context.Context, string) (*domain.Route, error) {
+				return &domain.Route{Domain: "app.example.com", Image: "app:latest"}, nil
+			},
+		},
+		getHealth: func(context.Context) (map[string]*remote.RouteHealth, error) {
+			return nil, errors.New("probe failed")
+		},
+	}
+
+	var out bytes.Buffer
+	err := runRoutesShow(context.Background(), fake, &out, "app.example.com", true)
+
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "app.example.com", got["domain"])
+	assert.Equal(t, "app:latest", got["image"])
+	assert.Equal(t, "unknown", got["container_status"])
+	assert.Equal(t, float64(0), got["http_status"])
+	assert.Equal(t, "probe failed", got["health_error"])
+}
+
+func TestRunRoutesShow_TextIncludesHealthWarning(t *testing.T) {
+	fake := &routesShowTestControlPlane{
+		resolveFromImageTestControlPlane: resolveFromImageTestControlPlane{
+			getRoute: func(context.Context, string) (*domain.Route, error) {
+				return &domain.Route{Domain: "app.example.com", Image: "app:latest"}, nil
+			},
+		},
+		getHealth: func(context.Context) (map[string]*remote.RouteHealth, error) {
+			return nil, errors.New("probe failed")
+		},
+	}
+
+	var out bytes.Buffer
+	err := runRoutesShow(context.Background(), fake, &out, "app.example.com", false)
+
+	require.NoError(t, err)
+
+	text := stripANSI(out.String())
+	assert.Contains(t, text, "Route: app.example.com")
+	assert.Contains(t, text, "Domain:")
+	assert.Contains(t, text, "Image:")
+	assert.Contains(t, text, "Container:")
+	assert.Contains(t, text, "probe failed")
 }
 
 func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *testing.T) {

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -249,11 +249,41 @@ func TestResolveRoutesExplicitRemote_AllowsAdHocURLWhenSavedRemotesConfigUnreada
 	configPath := filepath.Join(configHome, "gordon", "remotes.toml")
 	require.NoError(t, os.MkdirAll(configPath, 0o755))
 
-	resolved, ok := resolveRoutesExplicitRemote()
+	resolved, ok, err := resolveRoutesExplicitRemote()
 	require.True(t, ok)
+	require.NoError(t, err)
 	require.NotNil(t, resolved)
 	assert.Equal(t, "https://ad-hoc.example.com", resolved.URL)
 	assert.Empty(t, resolved.Name)
+}
+
+func TestResolveRoutesExplicitRemote_ReturnsErrorForUnreadableNamedRemoteConfig(t *testing.T) {
+	originalRemoteFlag := remoteFlag
+	originalTokenFlag := tokenFlag
+	originalInsecureTLSFlag := insecureTLSFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+		tokenFlag = originalTokenFlag
+		insecureTLSFlag = originalInsecureTLSFlag
+	})
+
+	remoteFlag = "missing-remote"
+	tokenFlag = ""
+	insecureTLSFlag = false
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GORDON_REMOTE", "")
+
+	configPath := filepath.Join(configHome, "gordon", "remotes.toml")
+	require.NoError(t, os.MkdirAll(configPath, 0o755))
+
+	resolved, ok, err := resolveRoutesExplicitRemote()
+	require.Error(t, err)
+	require.False(t, ok)
+	require.Nil(t, resolved)
+	assert.Contains(t, err.Error(), "failed to read remotes")
 }
 
 func TestRouteStatusTitle_PreservesProbeFailureError(t *testing.T) {
@@ -325,8 +355,8 @@ func TestRunRoutesShow_TextIncludesHealthWarning(t *testing.T) {
 
 func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *testing.T) {
 	testsDeps := routesListDeps{
-		explicitRemote: func() (*remote.ResolvedRemote, bool) {
-			return nil, false
+		explicitRemote: func() (*remote.ResolvedRemote, bool, error) {
+			return nil, false, nil
 		},
 		loadLocal: func(context.Context, string) (routeListSection, error) {
 			return routeListSection{
@@ -378,11 +408,11 @@ func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *
 
 func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 	testsDeps := routesListDeps{
-		explicitRemote: func() (*remote.ResolvedRemote, bool) {
+		explicitRemote: func() (*remote.ResolvedRemote, bool, error) {
 			return &remote.ResolvedRemote{
 				Name: "igor",
 				URL:  "https://gordon.supri.xyz",
-			}, true
+			}, true, nil
 		},
 		loadLocal: func(context.Context, string) (routeListSection, error) {
 			t.Fatal("loadLocal should not be called when an explicit remote is selected")
@@ -413,23 +443,7 @@ func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 	assert.Equal(t, "test.supri.xyz", sections[0].Routes[0].Domain)
 }
 
-func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *testing.T) {
-	originalRemoteFlag := remoteFlag
-	originalTokenFlag := tokenFlag
-	originalInsecureTLSFlag := insecureTLSFlag
-	t.Cleanup(func() {
-		remoteFlag = originalRemoteFlag
-		tokenFlag = originalTokenFlag
-		insecureTLSFlag = originalInsecureTLSFlag
-	})
-
-	remoteFlag = "missing-remote"
-	tokenFlag = ""
-	insecureTLSFlag = false
-	configHome := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("GORDON_REMOTE", "")
+func TestCollectRoutesSections_ExplicitRemoteResolutionErrorReturnsError(t *testing.T) {
 
 	t.Run("list", func(t *testing.T) {
 		var loadLocalCalls atomic.Int32
@@ -437,7 +451,9 @@ func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *
 		var loadRemoteCalls atomic.Int32
 
 		deps := routesListDeps{
-			explicitRemote: resolveRoutesExplicitRemote,
+			explicitRemote: func() (*remote.ResolvedRemote, bool, error) {
+				return nil, false, errors.New("failed to read remotes: boom")
+			},
 			loadLocal: func(context.Context, string) (routeListSection, error) {
 				loadLocalCalls.Add(1)
 				return routeListSection{}, nil
@@ -454,12 +470,9 @@ func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *
 
 		sections, err := collectRoutesListSections(context.Background(), "", deps)
 
-		require.NoError(t, err)
-		require.Len(t, sections, 1)
-		assert.Equal(t, "remote", sections[0].Kind)
-		assert.Equal(t, "missing-remote", sections[0].Name)
-		require.NotEmpty(t, sections[0].Error)
-		assert.Contains(t, sections[0].Error, "missing-remote")
+		require.Error(t, err)
+		require.Nil(t, sections)
+		assert.Contains(t, err.Error(), "failed to read remotes")
 		assert.Zero(t, loadLocalCalls.Load())
 		assert.Zero(t, listRemotesCalls.Load())
 		assert.Zero(t, loadRemoteCalls.Load())
@@ -471,7 +484,9 @@ func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *
 		var loadRemoteCalls atomic.Int32
 
 		deps := routesStatusDeps{
-			explicitRemote: resolveRoutesExplicitRemote,
+			explicitRemote: func() (*remote.ResolvedRemote, bool, error) {
+				return nil, false, errors.New("failed to read remotes: boom")
+			},
 			loadLocal: func(context.Context, string) (routeStatusSection, error) {
 				loadLocalCalls.Add(1)
 				return routeStatusSection{}, nil
@@ -488,15 +503,120 @@ func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *
 
 		sections, err := collectRoutesStatusSections(context.Background(), "", deps)
 
-		require.NoError(t, err)
-		require.Len(t, sections, 1)
-		assert.Equal(t, "remote", sections[0].Kind)
-		assert.Equal(t, "missing-remote", sections[0].Name)
-		require.NotEmpty(t, sections[0].Error)
-		assert.Contains(t, sections[0].Error, "missing-remote")
+		require.Error(t, err)
+		require.Nil(t, sections)
+		assert.Contains(t, err.Error(), "failed to read remotes")
 		assert.Zero(t, loadLocalCalls.Load())
 		assert.Zero(t, listRemotesCalls.Load())
 		assert.Zero(t, loadRemoteCalls.Load())
+	})
+}
+
+func TestLoadRoutesListExplicitRemoteSection_PropagatesLoaderError(t *testing.T) {
+	section := loadRoutesListExplicitRemoteSection(context.Background(), routesListDeps{
+		loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
+			return routeListSection{}, errors.New("boom")
+		},
+	}, &remote.ResolvedRemote{Name: "igor", URL: "https://gordon.supri.xyz"})
+
+	assert.Equal(t, "remote", section.Kind)
+	assert.Equal(t, "igor", section.Name)
+	assert.Equal(t, "https://gordon.supri.xyz", section.URL)
+	assert.Equal(t, "boom", section.Error)
+}
+
+func TestLoadRoutesStatusExplicitRemoteSection_PropagatesLoaderError(t *testing.T) {
+	section := loadRoutesStatusExplicitRemoteSection(context.Background(), routesStatusDeps{
+		loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
+			return routeStatusSection{}, errors.New("boom")
+		},
+	}, &remote.ResolvedRemote{Name: "igor", URL: "https://gordon.supri.xyz"})
+
+	assert.Equal(t, "remote", section.Kind)
+	assert.Equal(t, "igor", section.Name)
+	assert.Equal(t, "https://gordon.supri.xyz", section.URL)
+	assert.Equal(t, "boom", section.Error)
+}
+
+func TestCollectRoutesListAggregateSections_EncodesLoaderErrors(t *testing.T) {
+	t.Run("local loader error", func(t *testing.T) {
+		sections, err := collectRoutesListAggregateSections(context.Background(), "config.toml", routesListDeps{
+			loadLocal: func(context.Context, string) (routeListSection, error) {
+				return routeListSection{Kind: "local", Name: "local"}, errors.New("local failed")
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				return map[string]remote.RemoteEntry{}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
+				return routeListSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, nil
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, sections, 1)
+		assert.Equal(t, "local", sections[0].Kind)
+		assert.Equal(t, "local failed", sections[0].Error)
+	})
+
+	t.Run("remote loader error", func(t *testing.T) {
+		sections, err := collectRoutesListAggregateSections(context.Background(), "config.toml", routesListDeps{
+			loadLocal: func(context.Context, string) (routeListSection, error) {
+				return routeListSection{Kind: "local", Name: "local"}, nil
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				return map[string]remote.RemoteEntry{"igor": {URL: "https://gordon.supri.xyz"}}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
+				return routeListSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, errors.New("remote failed")
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, sections, 2)
+		assert.Equal(t, "local", sections[0].Kind)
+		assert.Equal(t, "remote", sections[1].Kind)
+		assert.Equal(t, "remote failed", sections[1].Error)
+	})
+}
+
+func TestCollectRoutesStatusAggregateSections_EncodesLoaderErrors(t *testing.T) {
+	t.Run("local loader error", func(t *testing.T) {
+		sections, err := collectRoutesStatusAggregateSections(context.Background(), "config.toml", routesStatusDeps{
+			loadLocal: func(context.Context, string) (routeStatusSection, error) {
+				return routeStatusSection{Kind: "local", Name: "local"}, errors.New("local failed")
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				return map[string]remote.RemoteEntry{}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
+				return routeStatusSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, nil
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, sections, 1)
+		assert.Equal(t, "local", sections[0].Kind)
+		assert.Equal(t, "local failed", sections[0].Error)
+	})
+
+	t.Run("remote loader error", func(t *testing.T) {
+		sections, err := collectRoutesStatusAggregateSections(context.Background(), "config.toml", routesStatusDeps{
+			loadLocal: func(context.Context, string) (routeStatusSection, error) {
+				return routeStatusSection{Kind: "local", Name: "local"}, nil
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				return map[string]remote.RemoteEntry{"igor": {URL: "https://gordon.supri.xyz"}}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
+				return routeStatusSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, errors.New("remote failed")
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, sections, 2)
+		assert.Equal(t, "local", sections[0].Kind)
+		assert.Equal(t, "remote", sections[1].Kind)
+		assert.Equal(t, "remote failed", sections[1].Error)
 	})
 }
 

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -353,6 +353,68 @@ func TestRunRoutesShow_TextIncludesHealthWarning(t *testing.T) {
 	assert.Contains(t, text, "probe failed")
 }
 
+func TestRunRoutesShow_JSONIncludesRouteProbeFailureAndUnknownContainerStatus(t *testing.T) {
+	fake := &routesShowTestControlPlane{
+		resolveFromImageTestControlPlane: resolveFromImageTestControlPlane{
+			getRoute: func(context.Context, string) (*domain.Route, error) {
+				return &domain.Route{Domain: "app.example.com", Image: "app:latest"}, nil
+			},
+		},
+		getHealth: func(context.Context) (map[string]*remote.RouteHealth, error) {
+			return map[string]*remote.RouteHealth{
+				"app.example.com": {
+					HTTPStatus:      503,
+					ContainerStatus: "",
+					Error:           "probe failed",
+				},
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runRoutesShow(context.Background(), fake, &out, "app.example.com", true)
+
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "app.example.com", got["domain"])
+	assert.Equal(t, "app:latest", got["image"])
+	assert.Equal(t, "unknown", got["container_status"])
+	assert.Equal(t, float64(503), got["http_status"])
+	assert.Equal(t, "probe failed", got["health_error"])
+}
+
+func TestRunRoutesShow_TextIncludesRouteProbeFailureAndUnknownContainerStatus(t *testing.T) {
+	fake := &routesShowTestControlPlane{
+		resolveFromImageTestControlPlane: resolveFromImageTestControlPlane{
+			getRoute: func(context.Context, string) (*domain.Route, error) {
+				return &domain.Route{Domain: "app.example.com", Image: "app:latest"}, nil
+			},
+		},
+		getHealth: func(context.Context) (map[string]*remote.RouteHealth, error) {
+			return map[string]*remote.RouteHealth{
+				"app.example.com": {
+					HTTPStatus:      503,
+					ContainerStatus: "",
+					Error:           "probe failed",
+				},
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	err := runRoutesShow(context.Background(), fake, &out, "app.example.com", false)
+
+	require.NoError(t, err)
+
+	text := stripANSI(out.String())
+	assert.Contains(t, text, "Route: app.example.com")
+	assert.Contains(t, text, "Container:")
+	assert.Contains(t, text, "unknown")
+	assert.Contains(t, text, "probe failed")
+}
+
 func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *testing.T) {
 	testsDeps := routesListDeps{
 		explicitRemote: func() (*remote.ResolvedRemote, bool, error) {

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
@@ -338,6 +339,93 @@ func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 	require.Len(t, sections, 1)
 	assert.Equal(t, "igor", sections[0].Name)
 	assert.Equal(t, "test.supri.xyz", sections[0].Routes[0].Domain)
+}
+
+func TestCollectRoutesSections_ExplicitUnknownNamedTargetReturnsErrorSection(t *testing.T) {
+	originalRemoteFlag := remoteFlag
+	originalTokenFlag := tokenFlag
+	originalInsecureTLSFlag := insecureTLSFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+		tokenFlag = originalTokenFlag
+		insecureTLSFlag = originalInsecureTLSFlag
+	})
+
+	remoteFlag = "missing-remote"
+	tokenFlag = ""
+	insecureTLSFlag = false
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GORDON_REMOTE", "")
+
+	t.Run("list", func(t *testing.T) {
+		var loadLocalCalls atomic.Int32
+		var listRemotesCalls atomic.Int32
+		var loadRemoteCalls atomic.Int32
+
+		deps := routesListDeps{
+			explicitRemote: resolveRoutesExplicitRemote,
+			loadLocal: func(context.Context, string) (routeListSection, error) {
+				loadLocalCalls.Add(1)
+				return routeListSection{}, nil
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				listRemotesCalls.Add(1)
+				return map[string]remote.RemoteEntry{}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
+				loadRemoteCalls.Add(1)
+				return routeListSection{}, nil
+			},
+		}
+
+		sections, err := collectRoutesListSections(context.Background(), "", deps)
+
+		require.NoError(t, err)
+		require.Len(t, sections, 1)
+		assert.Equal(t, "remote", sections[0].Kind)
+		assert.Equal(t, "missing-remote", sections[0].Name)
+		require.NotEmpty(t, sections[0].Error)
+		assert.Contains(t, sections[0].Error, "missing-remote")
+		assert.Zero(t, loadLocalCalls.Load())
+		assert.Zero(t, listRemotesCalls.Load())
+		assert.Zero(t, loadRemoteCalls.Load())
+	})
+
+	t.Run("status", func(t *testing.T) {
+		var loadLocalCalls atomic.Int32
+		var listRemotesCalls atomic.Int32
+		var loadRemoteCalls atomic.Int32
+
+		deps := routesStatusDeps{
+			explicitRemote: resolveRoutesExplicitRemote,
+			loadLocal: func(context.Context, string) (routeStatusSection, error) {
+				loadLocalCalls.Add(1)
+				return routeStatusSection{}, nil
+			},
+			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+				listRemotesCalls.Add(1)
+				return map[string]remote.RemoteEntry{}, "", nil
+			},
+			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
+				loadRemoteCalls.Add(1)
+				return routeStatusSection{}, nil
+			},
+		}
+
+		sections, err := collectRoutesStatusSections(context.Background(), "", deps)
+
+		require.NoError(t, err)
+		require.Len(t, sections, 1)
+		assert.Equal(t, "remote", sections[0].Kind)
+		assert.Equal(t, "missing-remote", sections[0].Name)
+		require.NotEmpty(t, sections[0].Error)
+		assert.Contains(t, sections[0].Error, "missing-remote")
+		assert.Zero(t, loadLocalCalls.Load())
+		assert.Zero(t, listRemotesCalls.Load())
+		assert.Zero(t, loadRemoteCalls.Load())
+	})
 }
 
 func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.T) {

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -1,11 +1,18 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
 	"github.com/bnema/gordon/internal/adapters/in/cli/ui/components"
+	"github.com/bnema/gordon/internal/adapters/in/cli/ui/styles"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncateImage(t *testing.T) {
@@ -196,4 +203,212 @@ func TestStripNetworkPrefix(t *testing.T) {
 			assert.Equal(t, tt.expected, stripNetworkPrefix(tt.network))
 		})
 	}
+}
+
+func TestResolveRoutesExplicitRemote_AllowsAdHocURLWhenSavedRemotesConfigUnreadable(t *testing.T) {
+	originalRemoteFlag := remoteFlag
+	originalTokenFlag := tokenFlag
+	originalInsecureTLSFlag := insecureTLSFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+		tokenFlag = originalTokenFlag
+		insecureTLSFlag = originalInsecureTLSFlag
+	})
+
+	remoteFlag = ""
+	tokenFlag = ""
+	insecureTLSFlag = false
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GORDON_REMOTE", "https://ad-hoc.example.com")
+
+	configPath := filepath.Join(configHome, "gordon", "remotes.toml")
+	require.NoError(t, os.MkdirAll(configPath, 0o755))
+
+	resolved, ok := resolveRoutesExplicitRemote()
+	require.True(t, ok)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "https://ad-hoc.example.com", resolved.URL)
+	assert.Empty(t, resolved.Name)
+}
+
+func TestRouteStatusTitle_PreservesProbeFailureError(t *testing.T) {
+	item := routeStatusItem{
+		Domain:          "app.example.com",
+		Image:           "app:latest",
+		ContainerStatus: "running",
+		HTTPStatus:      0,
+		HealthError:     "connection refused",
+	}
+
+	expected := components.StatusIcon(styles.IconHTTPStatus, components.StatusError) + " " +
+		components.StatusIcon(styles.IconContainerStatus, components.ParseStatus("running")) +
+		" app.example.com"
+
+	assert.Equal(t, expected, routeStatusTitle(item))
+}
+
+func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *testing.T) {
+	testsDeps := routesListDeps{
+		explicitRemote: func() (*remote.ResolvedRemote, bool) {
+			return nil, false
+		},
+		loadLocal: func(context.Context, string) (routeListSection, error) {
+			return routeListSection{
+				Kind: "local",
+				Name: "local",
+				Routes: []routeListItem{{
+					Domain: "app.local",
+					Image:  "myapp:latest",
+				}},
+			}, nil
+		},
+		listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+			return map[string]remote.RemoteEntry{
+				"igor":        {URL: "https://gordon.supri.xyz"},
+				"hetzner-vps": {URL: "https://reg.bnema.dev"},
+			}, "igor", nil
+		},
+		loadRemote: func(_ context.Context, name string, entry remote.RemoteEntry) (routeListSection, error) {
+			if name == "hetzner-vps" {
+				return routeListSection{
+					Kind:  "remote",
+					Name:  name,
+					URL:   entry.URL,
+					Error: "remote unavailable",
+				}, nil
+			}
+			return routeListSection{
+				Kind: "remote",
+				Name: name,
+				URL:  entry.URL,
+				Routes: []routeListItem{{
+					Domain: "grafana.supri.xyz",
+					Image:  "grafana",
+				}},
+			}, nil
+		},
+	}
+
+	sections, err := collectRoutesListSections(context.Background(), "", testsDeps)
+
+	require.NoError(t, err)
+	require.Len(t, sections, 3)
+	assert.Equal(t, "local", sections[0].Name)
+	assert.Equal(t, "hetzner-vps", sections[1].Name)
+	assert.Equal(t, "igor", sections[2].Name)
+	assert.Equal(t, "remote unavailable", sections[1].Error)
+	assert.Equal(t, "grafana.supri.xyz", sections[2].Routes[0].Domain)
+}
+
+func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
+	testsDeps := routesListDeps{
+		explicitRemote: func() (*remote.ResolvedRemote, bool) {
+			return &remote.ResolvedRemote{
+				Name: "igor",
+				URL:  "https://gordon.supri.xyz",
+			}, true
+		},
+		loadLocal: func(context.Context, string) (routeListSection, error) {
+			t.Fatal("loadLocal should not be called when an explicit remote is selected")
+			return routeListSection{}, nil
+		},
+		listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
+			t.Fatal("listRemotes should not be called when an explicit remote is selected")
+			return nil, "", nil
+		},
+		loadRemote: func(_ context.Context, name string, entry remote.RemoteEntry) (routeListSection, error) {
+			return routeListSection{
+				Kind: "remote",
+				Name: name,
+				URL:  entry.URL,
+				Routes: []routeListItem{{
+					Domain: "test.supri.xyz",
+					Image:  "hello-test",
+				}},
+			}, nil
+		},
+	}
+
+	sections, err := collectRoutesListSections(context.Background(), "", testsDeps)
+
+	require.NoError(t, err)
+	require.Len(t, sections, 1)
+	assert.Equal(t, "igor", sections[0].Name)
+	assert.Equal(t, "test.supri.xyz", sections[0].Routes[0].Domain)
+}
+
+func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.T) {
+	sections := []routeStatusSection{
+		{
+			Kind: "local",
+			Name: "local",
+			Routes: []routeStatusItem{{
+				Domain:          "app.local",
+				Image:           "myapp:latest",
+				ContainerStatus: "running",
+			}},
+		},
+		{
+			Kind:  "remote",
+			Name:  "igor",
+			URL:   "https://gordon.supri.xyz",
+			Error: "dial tcp timeout",
+		},
+	}
+
+	var out bytes.Buffer
+	err := renderRoutesStatusSections(&out, sections)
+
+	require.NoError(t, err)
+	rendered := stripANSI(out.String())
+	lines := strings.Split(rendered, "\n")
+
+	lineIndex := func(substr string) int {
+		for i, line := range lines {
+			if strings.Contains(line, substr) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	titleIdx := lineIndex("Route Status")
+	require.NotEqual(t, -1, titleIdx)
+
+	localIdx := lineIndex("Local")
+	require.NotEqual(t, -1, localIdx)
+
+	routeIdx := lineIndex("app.local")
+	require.NotEqual(t, -1, routeIdx)
+
+	remoteIdx := lineIndex("Remote: igor")
+	require.NotEqual(t, -1, remoteIdx)
+
+	errorIdx := lineIndex("dial tcp timeout")
+	require.NotEqual(t, -1, errorIdx)
+
+	assert.Less(t, titleIdx, localIdx)
+	assert.Less(t, localIdx, routeIdx)
+	assert.Less(t, routeIdx, remoteIdx)
+	assert.Less(t, remoteIdx, errorIdx)
+}
+
+func TestBuildRouteStatusTree_DeterministicAcrossInputOrder(t *testing.T) {
+	routes := []routeStatusItem{
+		{Domain: "zulu.example", Image: "zulu:v1", Network: "gordon-zulu", ContainerStatus: "running"},
+		{Domain: "alpha.example", Image: "alpha:v1", Network: "gordon-alpha", ContainerStatus: "running"},
+		{Domain: "mike.example", Image: "solo:v1", ContainerStatus: "running"},
+	}
+
+	var outA bytes.Buffer
+	_, _ = outA.WriteString(stripANSI(buildRouteStatusTree(routes).Render()))
+
+	var outB bytes.Buffer
+	reordered := []routeStatusItem{routes[2], routes[0], routes[1]}
+	_, _ = outB.WriteString(stripANSI(buildRouteStatusTree(reordered).Render()))
+
+	assert.Equal(t, outA.String(), outB.String())
 }

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -434,12 +434,12 @@ func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *
 		},
 		listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
 			return map[string]remote.RemoteEntry{
-				"igor":        {URL: "https://gordon.supri.xyz"},
-				"hetzner-vps": {URL: "https://reg.bnema.dev"},
-			}, "igor", nil
+				"remote-a": {URL: "https://remote-a.example.com"},
+				"remote-b": {URL: "https://remote-b.example.com"},
+			}, "remote-a", nil
 		},
 		loadRemote: func(_ context.Context, name string, entry remote.RemoteEntry) (routeListSection, error) {
-			if name == "hetzner-vps" {
+			if name == "remote-b" {
 				return routeListSection{
 					Kind:  "remote",
 					Name:  name,
@@ -452,8 +452,8 @@ func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *
 				Name: name,
 				URL:  entry.URL,
 				Routes: []routeListItem{{
-					Domain: "grafana.supri.xyz",
-					Image:  "grafana",
+					Domain: "dashboard.example.com",
+					Image:  "dashboard",
 				}},
 			}, nil
 		},
@@ -464,18 +464,18 @@ func TestCollectRoutesListSections_DefaultModeIncludesLocalThenSortedRemotes(t *
 	require.NoError(t, err)
 	require.Len(t, sections, 3)
 	assert.Equal(t, "local", sections[0].Name)
-	assert.Equal(t, "hetzner-vps", sections[1].Name)
-	assert.Equal(t, "igor", sections[2].Name)
-	assert.Equal(t, "remote unavailable", sections[1].Error)
-	assert.Equal(t, "grafana.supri.xyz", sections[2].Routes[0].Domain)
+	assert.Equal(t, "remote-a", sections[1].Name)
+	assert.Equal(t, "remote-b", sections[2].Name)
+	assert.Equal(t, "dashboard.example.com", sections[1].Routes[0].Domain)
+	assert.Equal(t, "remote unavailable", sections[2].Error)
 }
 
 func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 	testsDeps := routesListDeps{
 		explicitRemote: func() (*remote.ResolvedRemote, bool, error) {
 			return &remote.ResolvedRemote{
-				Name: "igor",
-				URL:  "https://gordon.supri.xyz",
+				Name: "remote-a",
+				URL:  "https://remote-a.example.com",
 			}, true, nil
 		},
 		loadLocal: func(context.Context, string) (routeListSection, error) {
@@ -492,8 +492,8 @@ func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 				Name: name,
 				URL:  entry.URL,
 				Routes: []routeListItem{{
-					Domain: "test.supri.xyz",
-					Image:  "hello-test",
+					Domain: "test.example.com",
+					Image:  "hello-app",
 				}},
 			}, nil
 		},
@@ -503,8 +503,8 @@ func TestCollectRoutesListSections_ExplicitRemoteSkipsAggregate(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, sections, 1)
-	assert.Equal(t, "igor", sections[0].Name)
-	assert.Equal(t, "test.supri.xyz", sections[0].Routes[0].Domain)
+	assert.Equal(t, "remote-a", sections[0].Name)
+	assert.Equal(t, "test.example.com", sections[0].Routes[0].Domain)
 }
 
 func TestCollectRoutesSections_ExplicitRemoteResolutionErrorReturnsError(t *testing.T) {
@@ -581,11 +581,11 @@ func TestLoadRoutesListExplicitRemoteSection_PropagatesLoaderError(t *testing.T)
 		loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
 			return routeListSection{}, errors.New("boom")
 		},
-	}, &remote.ResolvedRemote{Name: "igor", URL: "https://gordon.supri.xyz"})
+	}, &remote.ResolvedRemote{Name: "remote-a", URL: "https://remote-a.example.com"})
 
 	assert.Equal(t, "remote", section.Kind)
-	assert.Equal(t, "igor", section.Name)
-	assert.Equal(t, "https://gordon.supri.xyz", section.URL)
+	assert.Equal(t, "remote-a", section.Name)
+	assert.Equal(t, "https://remote-a.example.com", section.URL)
 	assert.Equal(t, "boom", section.Error)
 }
 
@@ -594,11 +594,11 @@ func TestLoadRoutesStatusExplicitRemoteSection_PropagatesLoaderError(t *testing.
 		loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
 			return routeStatusSection{}, errors.New("boom")
 		},
-	}, &remote.ResolvedRemote{Name: "igor", URL: "https://gordon.supri.xyz"})
+	}, &remote.ResolvedRemote{Name: "remote-a", URL: "https://remote-a.example.com"})
 
 	assert.Equal(t, "remote", section.Kind)
-	assert.Equal(t, "igor", section.Name)
-	assert.Equal(t, "https://gordon.supri.xyz", section.URL)
+	assert.Equal(t, "remote-a", section.Name)
+	assert.Equal(t, "https://remote-a.example.com", section.URL)
 	assert.Equal(t, "boom", section.Error)
 }
 
@@ -612,7 +612,7 @@ func TestCollectRoutesListAggregateSections_EncodesLoaderErrors(t *testing.T) {
 				return map[string]remote.RemoteEntry{}, "", nil
 			},
 			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
-				return routeListSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, nil
+				return routeListSection{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"}, nil
 			},
 		})
 
@@ -628,10 +628,10 @@ func TestCollectRoutesListAggregateSections_EncodesLoaderErrors(t *testing.T) {
 				return routeListSection{Kind: "local", Name: "local"}, nil
 			},
 			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
-				return map[string]remote.RemoteEntry{"igor": {URL: "https://gordon.supri.xyz"}}, "", nil
+				return map[string]remote.RemoteEntry{"remote-a": {URL: "https://remote-a.example.com"}}, "", nil
 			},
 			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeListSection, error) {
-				return routeListSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, errors.New("remote failed")
+				return routeListSection{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"}, errors.New("remote failed")
 			},
 		})
 
@@ -653,7 +653,7 @@ func TestCollectRoutesStatusAggregateSections_EncodesLoaderErrors(t *testing.T) 
 				return map[string]remote.RemoteEntry{}, "", nil
 			},
 			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
-				return routeStatusSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, nil
+				return routeStatusSection{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"}, nil
 			},
 		})
 
@@ -669,10 +669,10 @@ func TestCollectRoutesStatusAggregateSections_EncodesLoaderErrors(t *testing.T) 
 				return routeStatusSection{Kind: "local", Name: "local"}, nil
 			},
 			listRemotes: func() (map[string]remote.RemoteEntry, string, error) {
-				return map[string]remote.RemoteEntry{"igor": {URL: "https://gordon.supri.xyz"}}, "", nil
+				return map[string]remote.RemoteEntry{"remote-a": {URL: "https://remote-a.example.com"}}, "", nil
 			},
 			loadRemote: func(context.Context, string, remote.RemoteEntry) (routeStatusSection, error) {
-				return routeStatusSection{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"}, errors.New("remote failed")
+				return routeStatusSection{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"}, errors.New("remote failed")
 			},
 		})
 
@@ -760,8 +760,8 @@ func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.
 		},
 		{
 			Kind:  "remote",
-			Name:  "igor",
-			URL:   "https://gordon.supri.xyz",
+			Name:  "remote-a",
+			URL:   "https://remote-a.example.com",
 			Error: "dial tcp timeout",
 		},
 	}
@@ -791,7 +791,7 @@ func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.
 	routeIdx := lineIndex("app.local")
 	require.NotEqual(t, -1, routeIdx)
 
-	remoteIdx := lineIndex("Remote: igor")
+	remoteIdx := lineIndex("Remote: remote-a")
 	require.NotEqual(t, -1, remoteIdx)
 
 	errorIdx := lineIndex("dial tcp timeout")
@@ -803,10 +803,41 @@ func TestRenderRoutesStatusSections_IncludesSectionHeadingsAndErrors(t *testing.
 	assert.Less(t, remoteIdx, errorIdx)
 }
 
+func TestRenderRoutesStatusSections_DoesNotAddExtraBlankLineBetweenSections(t *testing.T) {
+	sections := []routeStatusSection{
+		{
+			Kind: "remote",
+			Name: "remote-b",
+			Routes: []routeStatusItem{{
+				Domain:          "app.example.com",
+				Image:           "app:latest",
+				ContainerStatus: "running",
+			}},
+		},
+		{
+			Kind: "remote",
+			Name: "remote-a",
+			Routes: []routeStatusItem{{
+				Domain:          "dashboard.example.com",
+				Image:           "dashboard",
+				ContainerStatus: "running",
+			}},
+		},
+	}
+
+	var out bytes.Buffer
+	err := renderRoutesStatusSections(&out, sections)
+
+	require.NoError(t, err)
+	rendered := stripANSI(out.String())
+	assert.NotContains(t, rendered, "app:latest\n\n\nRemote: remote-a")
+	assert.Contains(t, rendered, "app:latest\n\nRemote: remote-a")
+}
+
 func TestRenderRoutesListSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T) {
 	sections := []routeListSection{
 		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
-		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"},
+		{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"},
 	}
 
 	var out bytes.Buffer
@@ -816,14 +847,14 @@ func TestRenderRoutesListSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T
 	rendered := stripANSI(out.String())
 	assert.NotContains(t, rendered, "Local")
 	assert.NotContains(t, rendered, "failed to initialize local control plane")
-	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "Remote: remote-a")
 	assert.Contains(t, rendered, "No routes configured")
 }
 
 func TestRenderRoutesStatusSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T) {
 	sections := []routeStatusSection{
 		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
-		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz"},
+		{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com"},
 	}
 
 	var out bytes.Buffer
@@ -833,14 +864,14 @@ func TestRenderRoutesStatusSections_HidesLocalErrorWhenRemoteIsUsable(t *testing
 	rendered := stripANSI(out.String())
 	assert.NotContains(t, rendered, "Local")
 	assert.NotContains(t, rendered, "failed to initialize local control plane")
-	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "Remote: remote-a")
 	assert.Contains(t, rendered, "No routes configured")
 }
 
 func TestRenderRoutesStatusSections_KeepsLocalErrorWhenAllRemotesFail(t *testing.T) {
 	sections := []routeStatusSection{
 		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
-		{Kind: "remote", Name: "igor", URL: "https://gordon.supri.xyz", Error: "dial tcp timeout"},
+		{Kind: "remote", Name: "remote-a", URL: "https://remote-a.example.com", Error: "dial tcp timeout"},
 	}
 
 	var out bytes.Buffer
@@ -850,7 +881,7 @@ func TestRenderRoutesStatusSections_KeepsLocalErrorWhenAllRemotesFail(t *testing
 	rendered := stripANSI(out.String())
 	assert.Contains(t, rendered, "Local")
 	assert.Contains(t, rendered, "failed to initialize local control plane")
-	assert.Contains(t, rendered, "Remote: igor")
+	assert.Contains(t, rendered, "Remote: remote-a")
 	assert.Contains(t, rendered, "dial tcp timeout")
 }
 

--- a/internal/app/kernel.go
+++ b/internal/app/kernel.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/bnema/zerowrap"
 
@@ -29,13 +30,24 @@ type Kernel struct {
 
 // NewKernel initializes local services without starting server listeners.
 func NewKernel(configPath string) (*Kernel, error) {
+	return newKernel(configPath, initLogger)
+}
+
+// NewKernelQuiet initializes local services without emitting console logs.
+func NewKernelQuiet(configPath string) (*Kernel, error) {
+	return newKernel(configPath, quietInitLogger)
+}
+
+type kernelLoggerInit func(cfg Config) (zerowrap.Logger, func(), error)
+
+func newKernel(configPath string, initLog kernelLoggerInit) (*Kernel, error) {
 	ctx := context.Background()
 	v, cfg, err := initConfig(configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	log, cleanup, err := initLogger(cfg)
+	log, cleanup, err := initLog(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +96,10 @@ func NewKernel(configPath string) (*Kernel, error) {
 		secretSvc:   secretSvc,
 		cleanup:     cleanup,
 	}, nil
+}
+
+func quietInitLogger(Config) (zerowrap.Logger, func(), error) {
+	return zerowrap.New(zerowrap.Config{Level: "disabled", Output: io.Discard}), func() {}, nil
 }
 
 func (k *Kernel) Close() error {


### PR DESCRIPTION
## Summary
- make `gordon routes list` show a simple route inventory and add `gordon routes status` for the rich status tree
- aggregate local routes plus saved remotes by default, while keeping `--remote` and `GORDON_REMOTE` as explicit single-target selectors
- update JSON tests and CLI docs to match the new list/status behavior

## Test Plan
- `go test ./internal/adapters/in/cli/...`
- `go test ./...`
- `go build ./...`
- `/usr/bin/golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `gordon routes status` command to show route health and attachments.

* **Improvements**
  * `gordon routes list` and `gordon routes status` aggregate local results first, then each saved remote by default; `--remote`/env forces single-target behavior.
  * Richer per-route status output, clearer per-target headings, structured JSON sections, and deterministic ordering; remote errors reported per-section.

* **Documentation**
  * CLI quick reference, examples, and remote-targeting guidance updated.

* **Tests**
  * Expanded tests for JSON flags, shapes, ordering, and status rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->