### PR TITLE
Security hardening audit fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.worktrees
+.gitignore
+.gitleaks.toml
+Dockerfile
+*.log
+/tmp
+coverage.out
+dist
+build
+node_modules

--- a/.github/actions/setup-gordon/action.yml
+++ b/.github/actions/setup-gordon/action.yml
@@ -83,7 +83,8 @@ runs:
         curl -fsSL -o "${dest}" "${url}"
 
         # Verify checksum before extraction
-        checksum_lines="$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\\*?${archive}$" "${checksums}" || true)"
+        archive_escaped="$(printf '%s\n' "${archive}" | sed 's/[.[\\*^$()+?{|]/\\\\&/g')"
+        checksum_lines="$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\\*?${archive_escaped}$" "${checksums}" || true)"
         if [ "$(printf '%s\n' "${checksum_lines}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]; then
           echo "Expected exactly one checksum for ${archive} in checksums.txt" >&2
           exit 1

--- a/.github/actions/setup-gordon/action.yml
+++ b/.github/actions/setup-gordon/action.yml
@@ -26,6 +26,8 @@ runs:
     - name: Install Gordon
       id: install
       shell: bash
+      env:
+        GORDON_VERSION_INPUT: ${{ inputs.version }}
       run: |
         set -euo pipefail
 
@@ -43,7 +45,11 @@ runs:
           *)      echo "Unsupported architecture: ${RUNNER_ARCH}" >&2; exit 1 ;;
         esac
 
-        version="${{ inputs.version }}"
+        version="${GORDON_VERSION_INPUT}"
+        if ! [[ "${version}" =~ ^(latest|v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?)$ ]]; then
+          echo "Invalid Gordon version: ${version}" >&2
+          exit 1
+        fi
 
         # Resolve 'latest' to an actual tag via redirect URL
         if [ "${version}" = "latest" ]; then
@@ -53,24 +59,66 @@ runs:
             echo "Failed to resolve latest Gordon version" >&2
             exit 1
           fi
+          if ! [[ "${version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Resolved invalid Gordon version: ${version}" >&2
+            exit 1
+          fi
         fi
 
         archive="gordon_${os}_${arch}.tar.gz"
-        url="https://github.com/bnema/gordon/releases/download/${version}/${archive}"
-        dest="/tmp/${archive}"
+        base_url="https://github.com/bnema/gordon/releases/download/${version}"
+        url="${base_url}/${archive}"
+        checksums_url="${base_url}/checksums.txt"
+        work_dir="$(mktemp -d)"
+        dest="${work_dir}/${archive}"
+        checksums="${work_dir}/checksums.txt"
+        extract_dir="${work_dir}/extract"
         install_path="/usr/local/bin/gordon"
+        trap 'rm -rf "${work_dir}"' EXIT
 
         echo "Installing Gordon ${version} (${os}/${arch}) from ${url}"
 
-        # Download the release archive
+        # Download the release archive and checksums
+        curl -fsSL -o "${checksums}" "${checksums_url}"
         curl -fsSL -o "${dest}" "${url}"
 
-        # Extract just the gordon binary and clean up
-        tar -xzf "${dest}" -C /usr/local/bin/ gordon
-        rm -f "${dest}"
+        # Verify checksum before extraction
+        checksum_lines="$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\\*?${archive}$" "${checksums}" || true)"
+        if [ "$(printf '%s\n' "${checksum_lines}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]; then
+          echo "Expected exactly one checksum for ${archive} in checksums.txt" >&2
+          exit 1
+        fi
+        expected="$(printf '%s\n' "${checksum_lines}" | awk '{print $1}')"
+        if command -v sha256sum >/dev/null 2>&1; then
+          actual="$(sha256sum "${dest}" | awk '{print $1}')"
+        elif command -v shasum >/dev/null 2>&1; then
+          actual="$(shasum -a 256 "${dest}" | awk '{print $1}')"
+        else
+          echo "Neither sha256sum nor shasum is available for checksum verification" >&2
+          exit 1
+        fi
+        if [ "${expected}" != "${actual}" ]; then
+          echo "Checksum verification failed for ${archive}" >&2
+          echo "Expected: ${expected}" >&2
+          echo "Actual:   ${actual}" >&2
+          exit 1
+        fi
 
-        # Make executable and verify
-        chmod +x "${install_path}"
+        # Extract just the gordon binary and reject symlinks/directories
+        mkdir -p "${extract_dir}"
+        tar -xzf "${dest}" -C "${extract_dir}" gordon
+        binary="${extract_dir}/gordon"
+        if [ ! -f "${binary}" ] || [ -L "${binary}" ]; then
+          echo "Archive did not contain a regular Gordon binary" >&2
+          exit 1
+        fi
+
+        # Install with explicit executable permissions and verify
+        if [ -w "$(dirname "${install_path}")" ]; then
+          install -m 0755 "${binary}" "${install_path}"
+        else
+          sudo install -m 0755 "${binary}" "${install_path}"
+        fi
         gordon version
 
         # Set outputs

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+title = "Gordon gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Allow documented placeholder credentials in Markdown examples"
+condition = "AND"
+paths = [
+  '''docs/config/env\.md$''',
+  '''docs/cli/auth\.md$''',
+  '''docs/config/telemetry\.md$''',
+  '''wiki/guides/remote-cli\.md$''',
+]
+regexes = [
+  '''sk-1234567890''',
+  '''8f3a2b1c4d5e6f7a8b9c0d1e2f3a4b5c\.\.\.''',
+  '''YWRtaW5AZXhhbXBsZS5jb206c2VjcmV0''',
+  '''eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.\.\.''',
+]
+
+[[allowlists]]
+description = "Allow deterministic non-secret test fixtures"
+condition = "AND"
+paths = [
+  '''internal/adapters/in/cli/remote/client_test\.go$''',
+  '''internal/adapters/out/envloader/file_test\.go$''',
+]
+regexes = [
+  '''short-lived-123''',
+  '''YXBpLnN1Yi5leGFtcGxlLmNvbQ\.env''',
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-stage build for optimized container image
 
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26.1-alpine3.22 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -o gordon .
 
 # Runtime stage
-FROM alpine:latest
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache \
@@ -56,11 +56,10 @@ COPY --chown=gordon:gordon gordon.toml.example /app/gordon.toml.example
 USER gordon
 
 # Expose ports
-EXPOSE 8080 5000
+EXPOSE 8088 5000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost:8080/health || exit 1
+# Admin health is served on the registry/admin listener and is gated by auth in
+# normal deployments, so this image does not declare a Docker healthcheck.
 
 # Default command
 CMD ["./gordon", "serve"]

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -139,7 +139,7 @@ Standard Go durations also work: `24h`, `30m`, `1h30m`
 
 Registry scopes: `push`, `pull`, `push,pull`
 
-Admin scopes: `admin:*:*`, `admin:routes:read`, `admin:routes:write`, `admin:config:read`, `admin:config:write`, `admin:status:read`, `admin:secrets:read`, `admin:secrets:write`
+Admin scopes: `admin:*:*`, `admin:routes:read`, `admin:routes:write`, `admin:config:read`, `admin:config:write`, `admin:status:read`, `admin:logs:read`, `admin:secrets:read`, `admin:secrets:write`
 
 Combine scopes with commas:
 
@@ -280,6 +280,7 @@ Usage:
 | `admin:config:read` | Read-only config access |
 | `admin:config:write` | Config write access |
 | `admin:status:read` | Read-only status/health |
+| `admin:logs:read` | Read-only logs access |
 | `admin:secrets:read` | List secret keys |
 | `admin:secrets:write` | Set/delete secrets |
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -139,7 +139,7 @@ Standard Go durations also work: `24h`, `30m`, `1h30m`
 
 Registry scopes: `push`, `pull`, `push,pull`
 
-Admin scopes: `admin:*:*`, `admin:routes:read`, `admin:routes:write`, `admin:config:read`, `admin:config:write`, `admin:status:read`, `admin:logs:read`, `admin:secrets:read`, `admin:secrets:write`
+Admin scopes: `admin:*:*`, `admin:routes:read`, `admin:routes:write`, `admin:config:read`, `admin:config:write`, `admin:status:read`, `admin:logs:read`, `admin:volumes:read`, `admin:volumes:write`, `admin:secrets:read`, `admin:secrets:write`
 
 Combine scopes with commas:
 

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -17,8 +17,8 @@ Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 ## gordon config show
 
-Display the full Gordon server configuration including server settings,
-auto-route, network isolation, routes, and external routes.
+Display the Gordon server configuration including server settings,
+auto-route, network isolation, routes, and external route domains. Sensitive filesystem paths and upstream external route targets are redacted by default.
 
 ```bash
 gordon config show
@@ -39,8 +39,7 @@ gordon config show --remote https://gordon.mydomain.com --token $TOKEN
   "server": {
     "port": 1111,
     "registry_port": 5000,
-    "registry_domain": "reg.example.com",
-    "data_dir": "/var/lib/gordon"
+    "registry_domain": "reg.example.com"
   },
   "auto_route": {
     "enabled": true,
@@ -53,11 +52,13 @@ gordon config show --remote https://gordon.mydomain.com --token $TOKEN
   "routes": [
     {"domain": "app.example.com", "image": "myapp:latest"}
   ],
-  "external_routes": {
-    "reg.example.com": "localhost:5000"
-  }
+  "external_routes": [
+    {"domain": "reg.example.com"}
+  ]
 }
 ```
+
+External route targets and `server.data_dir` are intentionally omitted from the default admin config response because they reveal internal network and filesystem layout.
 
 ### Auto-Route Allowed Domains
 

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -235,6 +235,8 @@ gordon logs [domain] [options]
 Remote targeting uses client config or an active remote by default.
 Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
+Remote log access requires an admin token with `admin:logs:read` (or `admin:*:*`). `admin:status:read` is not sufficient for logs.
+
 ### Examples
 
 ```bash

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -93,6 +93,8 @@ Admin scopes (for remote CLI):
 | `admin:config:write` | Config write access |
 | `admin:status:read` | Read-only status/health |
 | `admin:logs:read` | Read-only logs access |
+| `admin:volumes:read` | List Docker volumes |
+| `admin:volumes:write` | Prune eligible Gordon-managed volumes |
 | `admin:secrets:read` | List secret keys |
 | `admin:secrets:write` | Set/delete secrets |
 

--- a/docs/config/auth.md
+++ b/docs/config/auth.md
@@ -92,6 +92,7 @@ Admin scopes (for remote CLI):
 | `admin:config:read` | Read-only config access |
 | `admin:config:write` | Config write access |
 | `admin:status:read` | Read-only status/health |
+| `admin:logs:read` | Read-only logs access |
 | `admin:secrets:read` | List secret keys |
 | `admin:secrets:write` | Set/delete secrets |
 

--- a/docs/config/deploy.md
+++ b/docs/config/deploy.md
@@ -98,6 +98,18 @@ container shutdown.
 
 Default: `"30s"`
 
+## Container security profile
+
+Runtime hardening is configured under `[containers]`:
+
+```toml
+[containers]
+security_profile = "compat" # "compat" or "strict"
+```
+
+- `compat` is the default and preserves existing image compatibility while keeping `no-new-privileges` and capability drop/add defaults.
+- `strict` enables a read-only root filesystem, drops all capabilities, and only adds `NET_BIND_SERVICE`. Images that write outside mounted volumes or need extra Linux capabilities may require changes before using this profile.
+
 ## Notes
 
 - Changes to `deploy.pull_policy` require a restart to take effect.

--- a/docs/config/images.md
+++ b/docs/config/images.md
@@ -16,6 +16,10 @@ The CLI `gordon images prune` uses the same defaults as the scheduled job (keep 
 ## Configuration
 
 ```toml
+[images]
+allowed_registries = []
+require_digest = false
+
 [images.prune]
 enabled = false
 schedule = "daily"
@@ -26,6 +30,8 @@ keep_last = 3
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| `images.allowed_registries` | array | `[]` | Allowlist for explicit external image registries. Empty means no explicit external registries are accepted. Gordon always allows its configured registry and rejects localhost/private/link-local registries. Include ports when needed, e.g. `"registry.example.com:5000"`. |
+| `images.require_digest` | bool | `false` | Require allowlisted external image references to use a valid `@sha256:<64 hex chars>` digest. Gordon registry images are exempt. |
 | `images.prune.enabled` | bool | `false` | Enables scheduled image cleanup |
 | `images.prune.schedule` | string | `"daily"` | Schedule preset: `hourly`, `daily`, `weekly`, `monthly` |
 | `images.prune.keep_last` | int | `3` | Number of newest non-`latest` tags kept per repository during registry cleanup (`latest` is always kept when present) |

--- a/docs/config/images.md
+++ b/docs/config/images.md
@@ -30,7 +30,7 @@ keep_last = 3
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `images.allowed_registries` | array | `[]` | Allowlist for explicit external image registries. Empty means no explicit external registries are accepted. Gordon always allows its configured registry and rejects localhost/private/link-local registries. Include ports when needed, e.g. `"registry.example.com:5000"`. |
+| `images.allowed_registries` | array | `[]` | Allowlist for external image registries. Empty means no external registries are accepted. Unqualified image names such as `nginx:latest` are treated as Docker Hub (`docker.io`) for policy checks. Gordon always allows its configured registry and rejects localhost/private/link-local registries. Include ports when needed, e.g. `"registry.example.com:5000"`. |
 | `images.require_digest` | bool | `false` | Require allowlisted external image references to use a valid `@sha256:<64 hex chars>` digest. Gordon registry images are exempt. |
 | `images.prune.enabled` | bool | `false` | Enables scheduled image cleanup |
 | `images.prune.schedule` | string | `"daily"` | Schedule preset: `hourly`, `daily`, `weekly`, `monthly` |

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -63,6 +63,10 @@ drain_mode = "auto"                      # auto, inflight, delay
 drain_timeout = "30s"                    # Max wait for in-flight drain
 drain_delay = "2s"                       # Wait after proxy invalidation before stopping the old container
 
+# Container runtime profile
+[containers]
+security_profile = "compat"              # compat or strict
+
 # Logging
 [logging]
 level = "info"                           # trace, debug, info, warn, error
@@ -106,6 +110,7 @@ preserve = true                          # Keep volumes on container removal
 [network_isolation]
 enabled = true                           # Per-app isolated networks
 network_prefix = "gordon"                # Network name prefix
+internal = false                          # Set true to block direct egress from isolated networks
 
 # Auto-route
 [auto_route]
@@ -138,6 +143,10 @@ weekly = 4
 monthly = 12
 
 # Images
+[images]
+allowed_registries = []                   # Explicit external registries allowed for deploy/attachments
+require_digest = false                    # Require digests for allowlisted external registries
+
 [images.prune]
 enabled = false
 schedule = "daily"
@@ -164,6 +173,7 @@ keep_last = 3
 | `[attachments]` | Service dependencies | [Attachments](./attachments.md) |
 | `[backups]` | Database backups | [Backups](./backups.md) |
 | `[images.prune]` | Scheduled image cleanup | [Images](./images.md) |
+| Security hardening | Security controls and recommended knobs | [Security Hardening](./security-hardening.md) |
 
 ## Default Values
 
@@ -172,6 +182,8 @@ keep_last = 3
 | `server.port` | `8088` |
 | `server.registry_port` | `5000` |
 | `server.data_dir` | `~/.gordon` |
+| `server.max_blob_chunk_size` | `"95MB"` |
+| `server.max_blob_size` | `"1GB"` |
 | `auth.enabled` | `true` |
 | `auth.secrets_backend` | `"unsafe"` |
 | `auth.token_expiry` | `"30d"` |
@@ -187,6 +199,7 @@ keep_last = 3
 | `deploy.drain_mode` | `"auto"` |
 | `deploy.drain_timeout` | `"30s"` |
 | `deploy.drain_delay` | `"2s"` |
+| `containers.security_profile` | `"compat"` |
 | `logging.level` | `"info"` |
 | `logging.format` | `"console"` |
 | `logging.file.enabled` | `false` |
@@ -198,9 +211,12 @@ keep_last = 3
 | `volumes.prefix` | `"gordon"` |
 | `volumes.preserve` | `true` |
 | `network_isolation.enabled` | `true` |
+| `network_isolation.internal` | `false` |
 | `auto_route.enabled` | `false` |
 | `backups.enabled` | `false` |
 | `backups.schedule` | `"daily"` (`"hourly"`, `"daily"`, `"weekly"`, `"monthly"`) |
+| `images.allowed_registries` | `[]` |
+| `images.require_digest` | `false` |
 | `images.prune.enabled` | `false` |
 | `images.prune.schedule` | `"daily"` |
 | `images.prune.keep_last` | `3` |
@@ -229,7 +245,6 @@ gordon reload
 | `server.gordon_domain` (registry domain) |
 | `server.registry_port` |
 | `server.max_proxy_body_size` |
-| `server.max_blob_chunk_size` |
 | `server.max_proxy_response_size` |
 | `server.max_concurrent_conns` |
 
@@ -241,6 +256,8 @@ gordon reload
 |---------|
 | `server.port` |
 | `server.data_dir` |
+| `server.max_blob_chunk_size` |
+| `server.max_blob_size` |
 | `auth.*` |
 | `deploy.readiness_mode` |
 | `deploy.readiness_delay` |

--- a/docs/config/network-isolation.md
+++ b/docs/config/network-isolation.md
@@ -8,6 +8,7 @@ Isolate applications in separate Docker networks for enhanced security.
 [network_isolation]
 enabled = true
 network_prefix = "gordon"
+internal = false
 ```
 
 ## Migration Note
@@ -26,6 +27,7 @@ enabled = false
 |--------|------|---------|-------------|
 | `enabled` | bool | `true` | Enable per-app network isolation (changed from `false`) |
 | `network_prefix` | string | `"gordon"` | Prefix for created networks |
+| `internal` | bool | `false` | Create isolated Docker networks with Docker's `Internal` flag, blocking direct external egress from containers on those networks. Default remains `false` for compatibility. |
 
 ## How It Works
 

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -17,7 +17,8 @@ tls_key_file = ""                            # PEM key path (optional, must be s
 force_https_redirect = false                 # Redirect all HTTP traffic to HTTPS (for direct-access setups)
 gordon_domain = ""                           # Required: Gordon domain (registry + API)
 data_dir = "~/.gordon"                       # Data directory (varies by install type)
-max_blob_chunk_size = "512MB"                # Max size per registry blob upload chunk
+max_blob_chunk_size = "95MB"                 # Max size per registry blob upload chunk
+max_blob_size = "1GB"                        # Max cumulative size per registry blob/layer upload
 registry_allowed_ips = []                    # IPs or CIDR ranges allowed to access the registry (empty = allow all)
 proxy_allowed_ips = []                       # IPs or CIDR ranges allowed to reach the proxy (empty = allow all, e.g. Cloudflare IPs)
 registry_listen_address = ""                 # Bind address for registry (empty = all interfaces, "127.0.0.1" = loopback only)
@@ -189,7 +190,8 @@ keep_last = 3                                # Keep N newest tags per repository
 | `server.force_https_redirect` | `false` | Redirect all HTTP to HTTPS (for direct-access setups) |
 | `server.gordon_domain` | `""` | **Required** - Gordon domain |
 | `server.data_dir` | `~/.gordon` | Data directory |
-| `server.max_blob_chunk_size` | `"512MB"` | Max size per registry blob upload chunk |
+| `server.max_blob_chunk_size` | `"95MB"` | Max size per registry blob upload chunk |
+| `server.max_blob_size` | `"1GB"` | Max cumulative size per registry blob/layer upload |
 | `server.registry_allowed_ips` | `[]` | IPs or CIDR ranges allowed to access the registry (empty = allow all) |
 | `server.proxy_allowed_ips` | `[]` | IPs or CIDR ranges allowed to reach the proxy (empty = allow all) |
 | `server.registry_listen_address` | `""` | Bind address for registry (empty = all interfaces) |

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -94,6 +94,12 @@ drain_timeout = "30s"                        # Max wait for in-flight request dr
 drain_delay = "2s"                           # Wait after cache invalidation before old stop
 
 # =============================================================================
+# CONTAINERS
+# =============================================================================
+[containers]
+security_profile = "compat"                  # "compat" or "strict"
+
+# =============================================================================
 # AUTO-ROUTE
 # =============================================================================
 [auto_route]
@@ -105,6 +111,7 @@ enabled = false                              # Create routes from image labels a
 [network_isolation]
 enabled = true                               # Enable per-app Docker networks
 network_prefix = "gordon"                    # Prefix for created networks
+internal = false                             # Create Docker internal networks (blocks direct egress)
 
 # =============================================================================
 # VOLUMES
@@ -157,6 +164,10 @@ monthly = 0                                  # Keep N monthly backups per DB
 # =============================================================================
 # IMAGES
 # =============================================================================
+[images]
+allowed_registries = []
+require_digest = false
+
 [images.prune]
 enabled = false                              # Enable scheduled image cleanup
 schedule = "daily"                          # "hourly", "daily", "weekly", "monthly"
@@ -215,9 +226,11 @@ keep_last = 3                                # Keep N newest tags per repository
 | `deploy.drain_mode` | `"auto"` | Drain strategy (`auto`, `inflight`, `delay`) |
 | `deploy.drain_timeout` | `"30s"` | Max wait for in-flight request drain before old stop |
 | `deploy.drain_delay` | `"2s"` | Delay before stopping previous container after cache invalidation |
+| `containers.security_profile` | `"compat"` | Runtime hardening profile: `compat` preserves existing behavior, `strict` enables read-only rootfs and narrower capabilities |
 | `auto_route.enabled` | `false` | Auto-route disabled |
 | `network_isolation.enabled` | `true` | Network isolation enabled |
 | `network_isolation.network_prefix` | `"gordon"` | Network prefix |
+| `network_isolation.internal` | `false` | Create Docker internal networks without direct external egress |
 | `volumes.auto_create` | `true` | Auto-create volumes |
 | `volumes.prefix` | `"gordon"` | Volume prefix |
 | `volumes.preserve` | `true` | Keep volumes |
@@ -228,6 +241,8 @@ keep_last = 3                                # Keep N newest tags per repository
 | `backups.retention.daily` | `0` | Keep no daily backups by default (recommend `7`) |
 | `backups.retention.weekly` | `0` | Keep no weekly backups by default |
 | `backups.retention.monthly` | `0` | Keep no monthly backups by default |
+| `images.allowed_registries` | `[]` | Explicit external registry allowlist; empty rejects explicit external registries; dangerous local/private registries are always rejected |
+| `images.require_digest` | `false` | Require digest-pinned references for allowlisted external registries |
 | `images.prune.enabled` | `false` | Scheduled image cleanup disabled |
 | `images.prune.schedule` | `"daily"` | Cleanup schedule preset |
 | `images.prune.keep_last` | `3` | Number of recent tags kept per repository |

--- a/docs/config/security-hardening.md
+++ b/docs/config/security-hardening.md
@@ -1,0 +1,90 @@
+# Security Hardening Controls
+
+This page summarizes Gordon's security-related configuration knobs and the defaults operators should know before exposing an instance.
+
+## Registry upload quotas
+
+Registry blob uploads are bounded by two limits under `[server]`:
+
+```toml
+[server]
+max_blob_chunk_size = "95MB"
+max_blob_size = "1GB"
+```
+
+- `max_blob_chunk_size` limits a single upload chunk.
+- `max_blob_size` limits the cumulative blob/layer upload size.
+- Exceeding either limit returns an OCI-compatible size error and the failed upload is cleaned up.
+
+## Admin logs permission
+
+Container and deploy logs can include environment-derived output. Gordon gates log access behind a dedicated scope:
+
+```bash
+gordon auth token generate --subject ops --scopes "admin:logs:read" --expiry 30d
+```
+
+- `/admin/logs` and deploy failure logs require `admin:logs:read`.
+- `admin:status:read` does not grant log access.
+- Common secret patterns are redacted before logs are returned.
+
+## Volume pruning scope
+
+Volume pruning only removes unused Docker volumes explicitly managed by Gordon (`gordon.managed=true`). It ignores unrelated Docker volumes even if they are unused.
+
+Use dedicated admin scopes:
+
+- `admin:volumes:read` for listing volumes.
+- `admin:volumes:write` for prune operations.
+
+## Pass migration plaintext handling
+
+When Gordon migrates legacy plaintext `.env` files into `pass`, it removes the plaintext source after a successful migration and does not leave `.env.migrated` copies by default. If pass entries already exist, migration fails closed and leaves the plaintext file in place for manual operator review rather than deleting potentially unique values.
+
+## External image registries
+
+Gordon's configured registry is always allowed. Explicit external registries must be allowlisted:
+
+```toml
+[images]
+allowed_registries = ["docker.io", "ghcr.io", "registry.example.com:5000"]
+require_digest = true
+```
+
+- Empty `allowed_registries` rejects explicit external registries.
+- `localhost`, loopback, private, link-local, unspecified, and metadata-style registries are rejected.
+- `require_digest = true` requires allowlisted external images to use `@sha256:<64 hex chars>`.
+- Include ports in allowlist entries when the registry uses a non-default port.
+
+## Docker network isolation
+
+Per-app Docker networks are enabled by default. To block direct external egress from isolated networks, opt into Docker internal networks:
+
+```toml
+[network_isolation]
+enabled = true
+internal = true
+```
+
+`internal = false` remains the compatibility default because some applications and attachments need direct egress during startup.
+
+## Container runtime profile
+
+```toml
+[containers]
+security_profile = "compat" # or "strict"
+```
+
+- `compat` preserves broad image compatibility while retaining `no-new-privileges` and default capability restrictions.
+- `strict` enables a read-only root filesystem, drops all capabilities, and only adds `NET_BIND_SERVICE`.
+
+Use `strict` for images designed to write only to mounted volumes and run without extra Linux capabilities.
+
+## Related
+
+- [Auth](./auth.md)
+- [Images](./images.md)
+- [Network Isolation](./network-isolation.md)
+- [Deploy](./deploy.md)
+- [Volumes](./volumes.md)
+- [Reference](./reference.md)

--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -14,6 +14,8 @@ tls_port = 8443                          # HTTPS listener port (0 = disabled)
 # force_https_redirect = false             # Redirect all HTTP traffic to HTTPS
 gordon_domain = "gordon.mydomain.com"    # Gordon domain (required)
 # data_dir = "~/.gordon"                 # Data storage directory (default)
+max_blob_chunk_size = "95MB"             # Max registry blob upload chunk
+max_blob_size = "1GB"                    # Max cumulative registry blob/layer upload
 ```
 
 ## Options
@@ -31,6 +33,7 @@ gordon_domain = "gordon.mydomain.com"    # Gordon domain (required)
 | `data_dir` | string | `~/.gordon` | Directory for registry data, logs, and env files |
 | `max_proxy_body_size` | string | `"512MB"` | Maximum request body size for proxied requests |
 | `max_blob_chunk_size` | string | `"95MB"` | Maximum request body size for a single registry blob upload chunk |
+| `max_blob_size` | string | `"1GB"` | Maximum cumulative size for one registry blob/layer upload |
 | `registry_allowed_ips` | []string | `[]` | IPs or CIDR ranges allowed to access the registry (empty = allow all) |
 | `proxy_allowed_ips` | []string | `[]` | IPs or CIDR ranges allowed to reach the proxy (empty = allow all) |
 | `registry_listen_address` | string | `""` | Bind address for registry (empty = all interfaces) |
@@ -273,6 +276,22 @@ max_blob_chunk_size = "1GB"    # Allow larger layers
 - Gordon CLI uploads image layers in 50MB chunks by default, and this setting caps the maximum chunk accepted per request
 - Keep this below Cloudflare's 100MB per-request limit when operating behind Cloudflare; the default (`95MB`) is fine
 - Increase it only if you expect larger direct registry uploads from other clients
+
+## Maximum Registry Blob Size
+
+The `max_blob_size` setting limits the cumulative size of one blob/layer upload across all chunks:
+
+```toml
+[server]
+max_blob_size = "1GB"  # Default
+```
+
+**Purpose:** Prevents disk exhaustion from multi-chunk uploads where each individual chunk is below `max_blob_chunk_size` but the total blob grows without bound.
+
+**Behavior:**
+- Gordon tracks the current upload size and rejects appends that would exceed the limit.
+- Rejected uploads return an OCI-compatible `413` size error.
+- Failed uploads are cleaned up so temporary blob data does not accumulate indefinitely.
 
 ## Registry IP Allowlist
 

--- a/docs/security-hardening-regression-matrix.md
+++ b/docs/security-hardening-regression-matrix.md
@@ -1,0 +1,222 @@
+# Security Hardening Regression Matrix
+
+This matrix lists the behaviors that should be tested while implementing the security-hardening fixes from the audit. It is intentionally focused on regressions: normal Gordon workflows must continue to work while exploit paths are blocked.
+
+## Registry uploads
+
+### Normal behavior to preserve
+- Docker push of a small image succeeds.
+- Docker push with multiple layers succeeds when every layer is below the configured cumulative blob limit.
+- Chunked blob upload succeeds when the cumulative size remains below the new cumulative limit setting, tentatively named `max_blob_size` unless implementation chooses a clearer config name.
+- A final `PUT` with a valid digest finalizes the blob and returns OCI-compatible headers.
+- Existing `max_blob_chunk_size` behavior still rejects a single oversized chunk; this remains distinct from the cumulative per-blob/layer limit.
+
+### Security behavior to verify
+- Repeated `PATCH` chunks cannot exceed the cumulative upload limit.
+- `Content-Length` larger than the remaining allowed size is rejected before writing when possible.
+- A rejected upload does not leave unbounded stale data on disk.
+- Cancel/cleanup paths remove upload temp files and upload locks.
+- Error response remains Docker Registry compatible (`413` / `SIZE_INVALID`).
+
+### Suggested tests
+- Unit tests for filesystem blob append under and over cumulative size.
+- Handler tests for `PATCH` and final `PUT` over limit.
+- Integration/manual: push image with a large layer and confirm failure is clean.
+
+## Deploy errors and logs
+
+### Normal behavior to preserve
+- Successful deploy response still includes status, domain, and container ID.
+- Failed deploy still returns useful high-level error/cause/hint.
+- Operators with the new logs permission can still retrieve logs through `/admin/logs`.
+- CLI deploy displays helpful failure information without leaking raw secrets.
+
+### Security behavior to verify
+- A token with only `admin:config:write` cannot receive raw container logs in `/admin/deploy` error responses.
+- Logs returned through log endpoints are redacted for common secret patterns.
+- `admin:status:read` no longer grants log read access.
+- `admin:*:*` remains compatible and can access logs.
+
+### Suggested tests
+- Handler tests for deploy error response with and without `logs:read`.
+- Scope tests for `logs:read`, wildcard, and old `status:read` behavior.
+- Redactor table tests for `PASSWORD=`, `TOKEN=`, `SECRET=`, `API_KEY=`, `DATABASE_URL=`, and simple JSON fields.
+
+## Admin scopes and compatibility
+
+### Normal behavior to preserve
+- Existing `admin:*:*` tokens continue to work everywhere.
+- Existing `routes`, `config`, `secrets`, and `status` scopes keep their intended behavior.
+- Token exchange through `/auth/token` still works for admin scopes.
+
+### Security behavior to verify
+- New sensitive resources such as `logs` and possibly `volumes` are parsed and enforced.
+- Unknown or malformed scopes remain ignored/denied, not accidentally allowed.
+
+### Suggested tests
+- Domain auth scope parsing tests.
+- Admin middleware/handler tests for each sensitive endpoint.
+
+## Auto-route env-file extraction
+
+### Normal behavior to preserve
+- Valid `gordon.env-file` imports default env values for a newly created auto-route.
+- Existing env values still override image-provided defaults.
+- Secret reference rejection remains intact.
+- Auto-route without env-file remains unchanged.
+
+### Security behavior to verify
+- Oversized env files are rejected before full memory read.
+- Disallowed paths (`/proc`, `/sys`, `/dev`, `/run`, `/var/run`, `/`, traversal) are rejected.
+- Failed env-file import does not prevent route/deploy behavior beyond the intended warning path unless explicitly designed.
+
+### Suggested tests
+- Runtime extraction tests using a controlled reader larger than the limit.
+- Auto-route usecase tests for allowed/disallowed paths.
+- Tests confirming `${pass:...}` / `${sops:...}` refs remain rejected.
+
+## Domain canonicalization and proxy routing
+
+### Normal behavior to preserve
+- Existing lowercase route domains continue to resolve.
+- Registry domain still routes to registry.
+- External routes still resolve and retain SSRF protections.
+- Hostnames with expected public domains work through proxy.
+
+### Security behavior to verify
+- `App.Example.com` and `app.example.com` map to the same canonical route.
+- Duplicate case-variant routes cannot be created.
+- Host with invalid port/trailing dot/case is handled consistently.
+- HTTP-to-HTTPS redirect does not reflect arbitrary unconfigured Host values.
+
+### Suggested tests
+- Config service tests for add/update/list canonical route domains.
+- Auto-route tests for case variants.
+- Proxy handler tests for Host normalization.
+- Middleware tests for redirect target host validation.
+
+## Volumes
+
+### Normal behavior to preserve
+- Listing volumes still shows Gordon-managed volumes.
+- Dry-run prune still reports what would be removed.
+- Actual prune still removes unused Gordon-managed volumes.
+- In-use Gordon volumes are not removed.
+
+### Security behavior to verify
+- Unused non-Gordon Docker volumes are not removed.
+- Volumes without explicit Gordon ownership metadata, preferably `gordon.managed=true`, are ignored; prefix-only matching is unsafe except as a constrained legacy fallback with dedicated tests.
+- Any new `volumes:read/write` scope is enforced correctly.
+
+### Suggested tests
+- Volume service tests with mixed Gordon/non-Gordon, used/unused volumes.
+- Admin handler tests for permissions.
+- Manual: create an unrelated Docker volume, run Gordon prune dry-run/real, confirm it remains.
+
+## Backups
+
+### Normal behavior to preserve
+- Manual backup completes and appears in list.
+- Scheduled backup path format remains readable/listable.
+- Backup detect still finds supported DB attachments.
+- Existing backups can still be listed after filename format changes.
+
+### Security behavior to verify
+- Two backups for same domain/db/schedule in the same second do not share tmp/final filenames.
+- Concurrent backups do not truncate each other.
+- Store uses unique tmp files and atomic rename.
+- Path traversal protections remain intact.
+
+### Suggested tests
+- Filesystem storage tests with identical timestamps.
+- Concurrent store test with two readers and same domain/db/schedule.
+- List tests for old and new filename formats if compatibility is needed.
+
+## Secrets and pass migration
+
+### Normal behavior to preserve
+- `pass` backend still migrates existing env keys correctly.
+- Attachment env migration still works.
+- Unsafe backend still loads valid files under `dataDir/secrets` for development.
+- Existing env file parsing remains compatible.
+
+### Security behavior to verify
+- Unsafe backend rejects `../` and absolute `auth.token_secret` paths.
+- Migration does not leave plaintext `.env.migrated` by default.
+- If an explicit keep/quarantine option exists, files are stored with restrictive permissions and loud warnings.
+
+### Suggested tests
+- `loadSecret` path traversal tests.
+- Migration tests verifying plaintext source file removal/quarantine.
+- Permission tests where practical (`0600` files, `0700` dirs).
+
+## Config snapshot
+
+### Normal behavior to preserve
+- `/admin/config` still returns enough information for CLI/admin use.
+- Routes and network isolation status remain visible to authorized callers.
+
+### Security behavior to verify
+- `data_dir` is hidden by default or only available under a deliberately stronger detailed mode.
+- External route targets are hidden/redacted by default or gated.
+- `config:read` behavior remains documented.
+
+### Suggested tests
+- Admin config response tests for default and detailed modes.
+- CLI remote config tests if output shape changes.
+
+## External image registries
+
+### Normal behavior to preserve
+- Images in the Gordon registry deploy normally.
+- Explicitly allowlisted external registries deploy if configured.
+- Attachments still deploy from allowed sources.
+
+### Security behavior to verify
+- `localhost`, loopback, private IP, link-local, metadata IP, and DNS resolving to private ranges are rejected unless a deliberate unsafe override exists.
+- Non-allowlisted external registries are rejected before Docker pull.
+- Error messages do not leak sensitive network details.
+
+### Suggested tests
+- Image reference validation table tests.
+- Config tests for `allowed_registries`.
+- Container service tests ensuring rejected images do not call `PullImage`.
+
+## Docker networks and runtime hardening
+
+### Normal behavior to preserve
+- Default/compat profile keeps common apps and attachments working.
+- Attachments remain reachable by service alias where intended.
+- Network groups still work when configured.
+
+### Security behavior to verify
+- `internal` network option is applied when configured.
+- Strict profile applies readonly rootfs/user/caps as designed.
+- `no-new-privileges:true` and cap dropping are preserved.
+- Compat profile behavior is documented and tested.
+
+### Suggested tests
+- Docker adapter config construction tests.
+- Container service tests for network option propagation.
+- Manual smoke: deploy app + postgres attachment in compat profile.
+- Manual smoke: deploy simple read-only app in strict profile.
+
+## Install, Dockerfile, and supply-chain
+
+### Normal behavior to preserve
+- `install.sh` installs the binary on Linux/macOS.
+- GitHub composite action installs Gordon in CI.
+- Dockerfile builds successfully.
+
+### Security behavior to verify
+- Tar extraction only extracts `gordon`.
+- Installed binary must be a regular file, not symlink/directory.
+- Permissions are explicit (`0755`).
+- Checksums/signatures are verified consistently.
+- Gitleaks output is clean or only contains allowlisted examples.
+
+### Suggested tests
+- Shellcheck/manual review for install script.
+- Action script dry-run if practical.
+- Docker build smoke after version alignment.
+- Gitleaks on `git archive HEAD`, not local `.worktrees`.

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -1,0 +1,94 @@
+# Gordon example configuration
+# Copy this file to ~/.config/gordon/gordon.toml and adjust for your domain.
+
+[server]
+port = 8088
+registry_port = 5000
+gordon_domain = "gordon.example.com"
+# data_dir = "~/.gordon"
+
+[auth]
+enabled = true
+# Use "pass" or "sops" in production. The unsafe backend reads a local file
+# under server.data_dir/secrets and is intended for development only.
+secrets_backend = "pass"
+token_secret = "gordon/auth/token_secret"
+token_expiry = "30d"
+access_token_ttl = "15m"
+
+[api.rate_limit]
+enabled = true
+global_rps = 500
+per_ip_rps = 50
+burst = 100
+trusted_proxies = []
+
+[deploy]
+pull_policy = "if-tag-changed"
+readiness_mode = "auto"
+health_timeout = "90s"
+readiness_delay = "5s"
+drain_mode = "auto"
+drain_timeout = "30s"
+drain_delay = "2s"
+
+[containers]
+# "compat" preserves broad image compatibility. "strict" enables a read-only
+# root filesystem and narrower Linux capabilities.
+security_profile = "compat"
+
+[network_isolation]
+enabled = true
+network_prefix = "gordon"
+# Set true to create Docker internal networks without direct external egress.
+internal = false
+
+[volumes]
+auto_create = true
+prefix = "gordon"
+preserve = true
+
+[images]
+# Explicit external registries must be listed here. Gordon's own registry is
+# always allowed; localhost/private/link-local registries are always rejected.
+allowed_registries = []
+# Require @sha256:<digest> for allowlisted external registries.
+require_digest = false
+
+[images.prune]
+enabled = false
+schedule = "daily"
+keep_last = 3
+
+[auto_route]
+enabled = false
+
+[logging]
+level = "info"
+format = "console"
+
+[logging.container_logs]
+enabled = true
+
+[backups]
+enabled = false
+schedule = "daily"
+storage_dir = ""
+
+[backups.retention]
+hourly = 0
+daily = 0
+weekly = 0
+monthly = 0
+
+[routes]
+# "app.example.com" = { image = "myapp:latest" }
+
+[external_routes]
+# "status.example.com" = "127.0.0.1:9000"
+
+[network_groups]
+# "backend" = ["app.example.com", "api.example.com"]
+
+[attachments]
+# "app.example.com" = ["postgres:18"]

--- a/install.sh
+++ b/install.sh
@@ -101,11 +101,13 @@ fi
 
 # Verify checksum
 echo "Verifying checksum..."
-EXPECTED_CHECKSUM=$(grep -E "[[:space:]]${TARBALL}\$" "$TMP_DIR/checksums.txt" | awk '{print $1}')
-if [ -z "$EXPECTED_CHECKSUM" ]; then
-    echo "Error: Could not find checksum for ${TARBALL} in checksums.txt"
+CHECKSUM_LINES=$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\*?${TARBALL}\$" "$TMP_DIR/checksums.txt" || true)
+CHECKSUM_COUNT=$(printf '%s\n' "$CHECKSUM_LINES" | sed '/^$/d' | wc -l | tr -d ' ')
+if [ "$CHECKSUM_COUNT" != "1" ]; then
+    echo "Error: Expected exactly one checksum for ${TARBALL} in checksums.txt"
     exit 1
 fi
+EXPECTED_CHECKSUM=$(printf '%s\n' "$CHECKSUM_LINES" | awk '{print $1}')
 
 # Calculate actual checksum (works on both Linux and macOS)
 if command -v sha256sum >/dev/null 2>&1; then
@@ -132,15 +134,23 @@ if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
 fi
 echo "Checksum verified successfully."
 
-echo "Extracting..."
-tar -xzf "$TMP_DIR/$TARBALL" -C "$TMP_DIR"
+echo "Extracting Gordon binary..."
+EXTRACT_DIR="$TMP_DIR/extract"
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$TMP_DIR/$TARBALL" -C "$EXTRACT_DIR" gordon
+
+BINARY="$EXTRACT_DIR/gordon"
+if [ ! -f "$BINARY" ] || [ -L "$BINARY" ]; then
+    echo "Error: Archive did not contain a regular Gordon binary"
+    exit 1
+fi
 
 echo "Installing to ${INSTALL_DIR}..."
 if [ -w "$INSTALL_DIR" ]; then
-    mv "$TMP_DIR/gordon" "$INSTALL_DIR/gordon"
+    install -m 0755 "$BINARY" "$INSTALL_DIR/gordon"
 else
     echo "sudo required to install to ${INSTALL_DIR}"
-    sudo mv "$TMP_DIR/gordon" "$INSTALL_DIR/gordon"
+    sudo install -m 0755 "$BINARY" "$INSTALL_DIR/gordon"
 fi
 
 # Verify installation

--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,8 @@ fi
 
 # Verify checksum
 echo "Verifying checksum..."
-CHECKSUM_LINES=$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\*?${TARBALL}\$" "$TMP_DIR/checksums.txt" || true)
+TARBALL_ESCAPED=$(printf '%s\n' "$TARBALL" | sed 's/[.[\*^$()+?{|]/\\&/g')
+CHECKSUM_LINES=$(grep -E "^[0-9a-fA-F]{64}[[:space:]]+\*?${TARBALL_ESCAPED}\$" "$TMP_DIR/checksums.txt" || true)
 CHECKSUM_COUNT=$(printf '%s\n' "$CHECKSUM_LINES" | sed '/^$/d' | wc -l | tr -d ' ')
 if [ "$CHECKSUM_COUNT" != "1" ]; then
     echo "Error: Expected exactly one checksum for ${TARBALL} in checksums.txt"

--- a/internal/adapters/dto/admin_config.go
+++ b/internal/adapters/dto/admin_config.go
@@ -14,7 +14,7 @@ type ServerConfig struct {
 	Port           int    `json:"port"`
 	RegistryPort   int    `json:"registry_port"`
 	RegistryDomain string `json:"registry_domain"`
-	DataDir        string `json:"data_dir"`
+	DataDir        string `json:"data_dir,omitempty"`
 }
 
 // AutoRouteConfig represents auto-route config details.
@@ -31,5 +31,5 @@ type NetworkIsolationConfig struct {
 // ExternalRoute represents an external route config entry.
 type ExternalRoute struct {
 	Domain string `json:"domain"`
-	Target string `json:"target"`
+	Target string `json:"target,omitempty"`
 }

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -84,7 +84,7 @@ Registry scopes (for Docker push/pull):
 Admin scopes (for remote CLI access):
   Format: admin:<resource>:<actions>
 
-  Resources: routes, secrets, config, status, logs, * (all)
+  Resources: routes, secrets, config, status, logs, volumes, * (all)
   Actions:   read, write, * (all)
 
   Examples:
@@ -92,6 +92,8 @@ Admin scopes (for remote CLI access):
     admin:routes:read      Read-only routes access
     admin:status:read      Read-only status access
     admin:logs:read        Read-only log access
+    admin:volumes:read     Read-only volume access
+    admin:volumes:write    Volume management access
 
 Repository scoping:
   --repo myapp           Scope to specific repository

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -84,13 +84,14 @@ Registry scopes (for Docker push/pull):
 Admin scopes (for remote CLI access):
   Format: admin:<resource>:<actions>
 
-  Resources: routes, secrets, config, status, * (all)
+  Resources: routes, secrets, config, status, logs, * (all)
   Actions:   read, write, * (all)
 
   Examples:
     admin:*:*              Full admin access (recommended for CLI)
     admin:routes:read      Read-only routes access
     admin:status:read      Read-only status access
+    admin:logs:read        Read-only log access
 
 Repository scoping:
   --repo myapp           Scope to specific repository

--- a/internal/adapters/in/cli/config.go
+++ b/internal/adapters/in/cli/config.go
@@ -94,8 +94,10 @@ func renderConfigSummary(out io.Writer, config *remote.Config) error {
 	if err := cliWriteLine(out, cliRenderMeta("Registry Domain:", config.Server.RegistryDomain)); err != nil {
 		return err
 	}
-	if err := cliWriteLine(out, cliRenderMeta("Data Directory:", config.Server.DataDir)); err != nil {
-		return err
+	if config.Server.DataDir != "" {
+		if err := cliWriteLine(out, cliRenderMeta("Data Directory:", config.Server.DataDir)); err != nil {
+			return err
+		}
 	}
 	if err := cliWriteLine(out, cliRenderMeta("Auto-Route:", fmt.Sprintf("%v", config.AutoRoute.Enabled))); err != nil {
 		return err
@@ -155,15 +157,16 @@ func renderConfigExternalRoutes(out io.Writer, config *remote.Config) error {
 	if err := cliWriteLine(out, cliRenderTitle("External Routes")); err != nil {
 		return err
 	}
-	domains := make([]string, 0, len(config.ExternalRoutes))
-	for d := range config.ExternalRoutes {
-		domains = append(domains, d)
-	}
-	sort.Strings(domains)
+	routes := append([]remote.ExternalRoute(nil), config.ExternalRoutes...)
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
 
-	rows := make([][]string, 0, len(domains))
-	for _, d := range domains {
-		rows = append(rows, []string{d, config.ExternalRoutes[d]})
+	rows := make([][]string, 0, len(routes))
+	for _, route := range routes {
+		target := route.Target
+		if target == "" {
+			target = "[redacted]"
+		}
+		rows = append(rows, []string{route.Domain, target})
 	}
 	table := components.NewTable(
 		components.WithColumns([]components.TableColumn{

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -372,14 +372,18 @@ func (l *localControlPlane) GetConfig(ctx context.Context) (*remote.Config, erro
 	if l.configSvc == nil {
 		return nil, fmt.Errorf("config service unavailable")
 	}
+	externalRoutes := l.configSvc.GetExternalRoutes()
+	externalResponses := make([]remote.ExternalRoute, 0, len(externalRoutes))
+	for domainName := range externalRoutes {
+		externalResponses = append(externalResponses, remote.ExternalRoute{Domain: domainName})
+	}
 	cfg := &remote.Config{
 		Routes:         l.configSvc.GetRoutes(ctx),
-		ExternalRoutes: l.configSvc.GetExternalRoutes(),
+		ExternalRoutes: externalResponses,
 	}
 	cfg.Server.Port = l.configSvc.GetServerPort()
 	cfg.Server.RegistryPort = l.configSvc.GetRegistryPort()
 	cfg.Server.RegistryDomain = l.configSvc.GetRegistryDomain()
-	cfg.Server.DataDir = l.configSvc.GetDataDir()
 	cfg.AutoRoute.Enabled = l.configSvc.IsAutoRouteEnabled()
 	cfg.NetworkIsolation.Enabled = l.configSvc.IsNetworkIsolationEnabled()
 	cfg.NetworkIsolation.Prefix = l.configSvc.GetNetworkPrefix()

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
@@ -377,6 +378,9 @@ func (l *localControlPlane) GetConfig(ctx context.Context) (*remote.Config, erro
 	for domainName := range externalRoutes {
 		externalResponses = append(externalResponses, remote.ExternalRoute{Domain: domainName})
 	}
+	sort.Slice(externalResponses, func(i, j int) bool {
+		return externalResponses[i].Domain < externalResponses[j].Domain
+	})
 	cfg := &remote.Config{
 		Routes:         l.configSvc.GetRoutes(ctx),
 		ExternalRoutes: externalResponses,

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -826,7 +826,7 @@ type Config struct {
 		Port           int    `json:"port"`
 		RegistryPort   int    `json:"registry_port"`
 		RegistryDomain string `json:"registry_domain"`
-		DataDir        string `json:"data_dir"`
+		DataDir        string `json:"data_dir,omitempty"`
 	} `json:"server"`
 	AutoRoute struct {
 		Enabled bool `json:"enabled"`
@@ -835,8 +835,14 @@ type Config struct {
 		Enabled bool   `json:"enabled"`
 		Prefix  string `json:"prefix"`
 	} `json:"network_isolation"`
-	Routes         []domain.Route    `json:"routes"`
-	ExternalRoutes map[string]string `json:"external_routes"`
+	Routes         []domain.Route  `json:"routes"`
+	ExternalRoutes []ExternalRoute `json:"external_routes"`
+}
+
+// ExternalRoute represents a redacted external route config entry.
+type ExternalRoute struct {
+	Domain string `json:"domain"`
+	Target string `json:"target,omitempty"`
 }
 
 // GetConfig returns the Gordon configuration.

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -1250,10 +1250,9 @@ func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
 
 	externalRoutes := h.configSvc.GetExternalRoutes()
 	externalResponses := make([]dto.ExternalRoute, 0, len(externalRoutes))
-	for domain, target := range externalRoutes {
+	for domain := range externalRoutes {
 		externalResponses = append(externalResponses, dto.ExternalRoute{
 			Domain: domain,
-			Target: target,
 		})
 	}
 
@@ -1262,7 +1261,6 @@ func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
 			Port:           h.configSvc.GetServerPort(),
 			RegistryPort:   h.configSvc.GetRegistryPort(),
 			RegistryDomain: h.configSvc.GetRegistryDomain(),
-			DataDir:        h.configSvc.GetDataDir(),
 		},
 		AutoRoute: dto.AutoRouteConfig{
 			Enabled: h.configSvc.IsAutoRouteEnabled(),

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -1319,12 +1319,15 @@ func (h *Handler) handleDeploy(w http.ResponseWriter, r *http.Request, path stri
 		log.Error().Err(err).Str("domain", deployDomain).Msg("failed to deploy container")
 		var deployErr *domain.DeployFailureError
 		if errors.As(err, &deployErr) {
-			h.sendJSON(w, http.StatusInternalServerError, dto.DeployErrorResponse{
+			response := dto.DeployErrorResponse{
 				Error: deployErr.Error(),
 				Cause: deployErr.Cause,
 				Hint:  deployErr.Hint,
-				Logs:  deployErr.Logs,
-			})
+			}
+			if HasAccess(ctx, domain.AdminResourceLogs, domain.AdminActionRead) {
+				response.Logs = domain.RedactSecretLines(deployErr.Logs)
+			}
+			h.sendJSON(w, http.StatusInternalServerError, response)
 			return
 		}
 		h.sendError(w, http.StatusInternalServerError, "failed to deploy container")
@@ -1455,8 +1458,8 @@ func (h *Handler) handleLogs(w http.ResponseWriter, r *http.Request, path string
 	log := zerowrap.FromCtx(ctx)
 
 	// Check read permission
-	if !HasAccess(ctx, domain.AdminResourceStatus, domain.AdminActionRead) {
-		h.sendError(w, http.StatusForbidden, "insufficient permissions for status:read")
+	if !HasAccess(ctx, domain.AdminResourceLogs, domain.AdminActionRead) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for logs:read")
 		return
 	}
 
@@ -1522,7 +1525,7 @@ func (h *Handler) handleProcessLogs(w http.ResponseWriter, r *http.Request, line
 		return
 	}
 
-	h.sendJSON(w, http.StatusOK, dto.ProcessLogsResponse{Lines: logLines})
+	h.sendJSON(w, http.StatusOK, dto.ProcessLogsResponse{Lines: domain.RedactSecretLines(logLines)})
 }
 
 // handleContainerLogs handles container logs for a specific domain.
@@ -1546,7 +1549,7 @@ func (h *Handler) handleContainerLogs(w http.ResponseWriter, r *http.Request, lo
 
 	h.sendJSON(w, http.StatusOK, dto.ContainerLogsResponse{
 		Domain: logDomain,
-		Lines:  logLines,
+		Lines:  domain.RedactSecretLines(logLines),
 	})
 }
 
@@ -1582,6 +1585,7 @@ func (h *Handler) streamProcessLogs(w http.ResponseWriter, r *http.Request, line
 			if !ok {
 				return
 			}
+			line = domain.RedactSecrets(line)
 			// SECURITY: Normalize line endings and escape newlines in log lines to prevent SSE event injection.
 			// First normalize CRLF (\r\n) and CR (\r) to LF (\n), then escape newlines.
 			// Per the SSE spec, multi-line data must use separate "data:" prefixes.
@@ -1628,6 +1632,7 @@ func (h *Handler) streamContainerLogs(w http.ResponseWriter, r *http.Request, lo
 			if !ok {
 				return
 			}
+			line = domain.RedactSecrets(line)
 			// SECURITY: Normalize line endings and escape newlines in log lines to prevent SSE event injection.
 			// First normalize CRLF (\r\n) and CR (\r) to LF (\n), then escape newlines.
 			// Per the SSE spec, multi-line data must use separate "data:" prefixes.

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -389,6 +389,10 @@ func (h *Handler) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 		addStep("route", "failed")
 		h.sendError(w, http.StatusBadRequest, err.Error())
 		return
+	case errors.Is(err, domain.ErrRouteConflict):
+		addStep("route", "failed")
+		h.sendError(w, http.StatusConflict, err.Error())
+		return
 	default:
 		addStep("route", "failed")
 		log.Error().Err(err).Str("domain", req.Domain).Str("image", req.Image).Msg("failed to bootstrap route")
@@ -594,6 +598,8 @@ func (h *Handler) handleRoutesPost(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, domain.ErrRouteDomainEmpty), errors.Is(err, domain.ErrRouteDomainInvalid), errors.Is(err, domain.ErrRouteImageEmpty):
 			h.sendError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, domain.ErrRouteConflict):
+			h.sendError(w, http.StatusConflict, err.Error())
 		default:
 			h.sendError(w, http.StatusInternalServerError, "failed to add route")
 		}

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -118,11 +118,11 @@ func TestHandler_VolumesGet_RequiresVolumesReadScope(t *testing.T) {
 			if tt.wantStatus == http.StatusOK {
 				volumeSvc.EXPECT().ListVolumes(mock.Anything).Return([]*domain.VolumeInfo{}, nil).Once()
 			}
-			req := httptest.NewRequest(http.MethodGet, "/admin/volumes", nil)
-			req = req.WithContext(ctxWithScopes(tt.scopes...))
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			assert.Equal(t, tt.wantStatus, rec.Code)
+			server := newScopedTestServer(t, handler, tt.scopes...)
+			resp, err := http.Get(server.URL + "/admin/volumes")
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
 		})
 	}
 }
@@ -147,11 +147,11 @@ func TestHandler_VolumesPrune_RequiresVolumesWriteScope(t *testing.T) {
 			if tt.wantStatus == http.StatusOK {
 				volumeSvc.EXPECT().PruneVolumes(mock.Anything, true).Return(&domain.VolumePruneReport{}, []*domain.VolumeInfo{}, nil).Once()
 			}
-			req := httptest.NewRequest(http.MethodPost, "/admin/volumes/prune", bytes.NewBufferString(`{"dry_run":true}`))
-			req = req.WithContext(ctxWithScopes(tt.scopes...))
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			assert.Equal(t, tt.wantStatus, rec.Code)
+			server := newScopedTestServer(t, handler, tt.scopes...)
+			resp, err := http.Post(server.URL+"/admin/volumes/prune", "application/json", bytes.NewBufferString(`{"dry_run":true}`))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
 		})
 	}
 }
@@ -1135,18 +1135,19 @@ func TestHandler_Config_HidesSensitiveInventoryByDefault(t *testing.T) {
 	configSvc.EXPECT().GetRoutes(mock.Anything).Return([]domain.Route{}).Once()
 	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{"db.example.com": "http://10.0.0.5:5432"}).Once()
 
-	req := httptest.NewRequest("GET", "/admin/config", nil)
-	req = req.WithContext(ctxWithScopes("admin:config:read"))
-	rec := httptest.NewRecorder()
+	server := newScopedTestServer(t, handler, "admin:config:read")
+	resp, err := http.Get(server.URL + "/admin/config")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 
-	handler.ServeHTTP(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	body := rec.Body.String()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := string(bodyBytes)
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal([]byte(body), &raw))
-	server := raw["server"].(map[string]any)
-	assert.NotContains(t, server, "data_dir")
+	serverConfig := raw["server"].(map[string]any)
+	assert.NotContains(t, serverConfig, "data_dir")
 	assert.NotContains(t, body, "/var/lib/gordon")
 	assert.NotContains(t, body, "10.0.0.5")
 }
@@ -1650,16 +1651,18 @@ func TestHandler_Deploy_ConfigWriteOnlyOmitsDeployFailureLogs(t *testing.T) {
 	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
 	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/deploy/app.example.com", nil)
-	req = req.WithContext(ctxWithScopes("admin:config:write"))
-	rec := httptest.NewRecorder()
+	server := newScopedTestServer(t, handler, "admin:config:write")
+	resp, err := http.Post(server.URL+"/admin/deploy/app.example.com", "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	body := string(bodyBytes)
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusInternalServerError, rec.Code)
-	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying"}`, rec.Body.String())
-	assert.NotContains(t, rec.Body.String(), "hunter2")
-	assert.NotContains(t, rec.Body.String(), "abc123")
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying"}`, body)
+	assert.NotContains(t, body, "hunter2")
+	assert.NotContains(t, body, "abc123")
 }
 
 func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
@@ -2174,30 +2177,33 @@ func TestHandler_LogsRequireLogsReadAndRedact(t *testing.T) {
 	})
 
 	t.Run("status read denied", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/logs", nil)
-		req = req.WithContext(ctxWithScopes("admin:status:read"))
-		rec := httptest.NewRecorder()
+		server := newScopedTestServer(t, handler, "admin:status:read")
+		resp, err := http.Get(server.URL + "/admin/logs")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
 
-		handler.ServeHTTP(rec, req)
-
-		assert.Equal(t, http.StatusForbidden, rec.Code)
-		assert.Contains(t, rec.Body.String(), "insufficient permissions for logs:read")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Contains(t, string(bodyBytes), "insufficient permissions for logs:read")
 	})
 
 	t.Run("logs read allowed and redacted", func(t *testing.T) {
 		logSvc.EXPECT().GetProcessLogs(mock.Anything, 50).Return([]string{"PASSWORD=hunter2", `{"API_KEY":"abc123"}`}, nil).Once()
 
-		req := httptest.NewRequest(http.MethodGet, "/admin/logs", nil)
-		req = req.WithContext(ctxWithScopes("admin:logs:read"))
-		rec := httptest.NewRecorder()
+		server := newScopedTestServer(t, handler, "admin:logs:read")
+		resp, err := http.Get(server.URL + "/admin/logs")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		body := string(bodyBytes)
 
-		handler.ServeHTTP(rec, req)
-
-		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Contains(t, rec.Body.String(), "PASSWORD=[REDACTED]")
-		assert.Contains(t, rec.Body.String(), `\"API_KEY\":\"[REDACTED]\"`)
-		assert.NotContains(t, rec.Body.String(), "hunter2")
-		assert.NotContains(t, rec.Body.String(), "abc123")
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Contains(t, body, "PASSWORD=[REDACTED]")
+		assert.Contains(t, body, `\"API_KEY\":\"[REDACTED]\"`)
+		assert.NotContains(t, body, "hunter2")
+		assert.NotContains(t, body, "abc123")
 	})
 }
 

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -1122,6 +1122,35 @@ func TestHandler_Status_RequiresReadScope(t *testing.T) {
 
 // Config endpoint tests
 
+func TestHandler_Config_HidesSensitiveInventoryByDefault(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	handler := newTestHandler(t, func(d *HandlerDeps) { d.ConfigSvc = configSvc })
+
+	configSvc.EXPECT().GetServerPort().Return(8080).Once()
+	configSvc.EXPECT().GetRegistryPort().Return(5000).Once()
+	configSvc.EXPECT().GetRegistryDomain().Return("registry.example.com").Once()
+	configSvc.EXPECT().IsAutoRouteEnabled().Return(true).Once()
+	configSvc.EXPECT().IsNetworkIsolationEnabled().Return(false).Once()
+	configSvc.EXPECT().GetNetworkPrefix().Return("gordon").Once()
+	configSvc.EXPECT().GetRoutes(mock.Anything).Return([]domain.Route{}).Once()
+	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{"db.example.com": "http://10.0.0.5:5432"}).Once()
+
+	req := httptest.NewRequest("GET", "/admin/config", nil)
+	req = req.WithContext(ctxWithScopes("admin:config:read"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &raw))
+	server := raw["server"].(map[string]any)
+	assert.NotContains(t, server, "data_dir")
+	assert.NotContains(t, body, "/var/lib/gordon")
+	assert.NotContains(t, body, "10.0.0.5")
+}
+
 func TestHandler_Config_RequiresReadScope(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	authSvc := inmocks.NewMockAuthService(t)

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -98,6 +98,64 @@ func newTestHandler(t *testing.T, opts ...func(*HandlerDeps)) *Handler {
 	return NewHandler(deps)
 }
 
+func TestHandler_VolumesGet_RequiresVolumesReadScope(t *testing.T) {
+	volumeSvc := inmocks.NewMockVolumeService(t)
+	handler := newTestHandler(t, func(d *HandlerDeps) { d.VolumeSvc = volumeSvc })
+
+	tests := []struct {
+		name       string
+		scopes     []string
+		wantStatus int
+	}{
+		{name: "volumes read access granted", scopes: []string{"admin:volumes:read"}, wantStatus: http.StatusOK},
+		{name: "all admin access granted", scopes: []string{"admin:*:*"}, wantStatus: http.StatusOK},
+		{name: "status read denied", scopes: []string{"admin:status:read"}, wantStatus: http.StatusForbidden},
+		{name: "volumes write denied", scopes: []string{"admin:volumes:write"}, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantStatus == http.StatusOK {
+				volumeSvc.EXPECT().ListVolumes(mock.Anything).Return([]*domain.VolumeInfo{}, nil).Once()
+			}
+			req := httptest.NewRequest(http.MethodGet, "/admin/volumes", nil)
+			req = req.WithContext(ctxWithScopes(tt.scopes...))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+func TestHandler_VolumesPrune_RequiresVolumesWriteScope(t *testing.T) {
+	volumeSvc := inmocks.NewMockVolumeService(t)
+	handler := newTestHandler(t, func(d *HandlerDeps) { d.VolumeSvc = volumeSvc })
+
+	tests := []struct {
+		name       string
+		scopes     []string
+		wantStatus int
+	}{
+		{name: "volumes write access granted", scopes: []string{"admin:volumes:write"}, wantStatus: http.StatusOK},
+		{name: "all admin access granted", scopes: []string{"admin:*:*"}, wantStatus: http.StatusOK},
+		{name: "config write denied", scopes: []string{"admin:config:write"}, wantStatus: http.StatusForbidden},
+		{name: "volumes read denied", scopes: []string{"admin:volumes:read"}, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantStatus == http.StatusOK {
+				volumeSvc.EXPECT().PruneVolumes(mock.Anything, true).Return(&domain.VolumePruneReport{}, []*domain.VolumeInfo{}, nil).Once()
+			}
+			req := httptest.NewRequest(http.MethodPost, "/admin/volumes/prune", bytes.NewBufferString(`{"dry_run":true}`))
+			req = req.WithContext(ctxWithScopes(tt.scopes...))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
 // Routes endpoint tests
 
 func TestHandler_RoutesGet_RequiresReadScope(t *testing.T) {

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -1542,6 +1542,39 @@ func TestHandler_Restart_InvalidDomain(t *testing.T) {
 	}
 }
 
+func TestHandler_Deploy_ConfigWriteOnlyOmitsDeployFailureLogs(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+	route := &domain.Route{Domain: "app.example.com", Image: "registry.local/myapp:latest"}
+	deployErr := &domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "image pull failed",
+		Hint:    "push the image before retrying",
+		Logs:    []string{"PASSWORD=hunter2", "TOKEN=abc123"},
+	}
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+	})
+
+	configSvc.EXPECT().GetRoute(mock.Anything, "app.example.com").Return(route, nil).Once()
+	containerSvc.EXPECT().Deploy(mock.Anything, *route).Return(nil, deployErr).Once()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/deploy/app.example.com", nil)
+	req = req.WithContext(ctxWithScopes("admin:config:write"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying"}`, rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "hunter2")
+	assert.NotContains(t, rec.Body.String(), "abc123")
+}
+
 func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	authSvc := inmocks.NewMockAuthService(t)
@@ -1553,8 +1586,8 @@ func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
 		Cause:   "image pull failed",
 		Hint:    "push the image before retrying",
 		Logs: []string{
-			"pulling manifest",
-			"manifest unknown",
+			"pulling manifest PASSWORD=hunter2",
+			`{"TOKEN":"abc123"}`,
 		},
 		Err: errors.New("manifest unknown: internal registry detail"),
 	}
@@ -1566,7 +1599,7 @@ func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
 		d.SecretSvc = secretSvc
 	})
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handler.ServeHTTP(w, r.WithContext(ctxWithScopes("admin:config:write")))
+		handler.ServeHTTP(w, r.WithContext(ctxWithScopes("admin:config:write", "admin:logs:read")))
 	}))
 	defer s.Close()
 
@@ -1582,8 +1615,10 @@ func TestHandler_Deploy_StructuredDeployFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying","logs":["pulling manifest","manifest unknown"]}`, string(body))
+	assert.JSONEq(t, `{"error":"failed to deploy","cause":"image pull failed","hint":"push the image before retrying","logs":["pulling manifest PASSWORD=[REDACTED]","{\"TOKEN\":\"[REDACTED]\"}"]}`, string(body))
 	assert.NotContains(t, string(body), "internal registry detail")
+	assert.NotContains(t, string(body), "hunter2")
+	assert.NotContains(t, string(body), "abc123")
 }
 
 func TestHandler_Deploy_GenericErrorStillUsesLegacyBody(t *testing.T) {
@@ -2043,6 +2078,40 @@ func TestHandler_BackupsRunDomain_ChunkedBodyIsDecoded(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "completed")
+}
+
+func TestHandler_LogsRequireLogsReadAndRedact(t *testing.T) {
+	logSvc := inmocks.NewMockLogService(t)
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.LogSvc = logSvc
+	})
+
+	t.Run("status read denied", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/logs", nil)
+		req = req.WithContext(ctxWithScopes("admin:status:read"))
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "insufficient permissions for logs:read")
+	})
+
+	t.Run("logs read allowed and redacted", func(t *testing.T) {
+		logSvc.EXPECT().GetProcessLogs(mock.Anything, 50).Return([]string{"PASSWORD=hunter2", `{"API_KEY":"abc123"}`}, nil).Once()
+
+		req := httptest.NewRequest(http.MethodGet, "/admin/logs", nil)
+		req = req.WithContext(ctxWithScopes("admin:logs:read"))
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "PASSWORD=[REDACTED]")
+		assert.Contains(t, rec.Body.String(), `\"API_KEY\":\"[REDACTED]\"`)
+		assert.NotContains(t, rec.Body.String(), "hunter2")
+		assert.NotContains(t, rec.Body.String(), "abc123")
+	})
 }
 
 func TestHandler_BackupsDetectDomain(t *testing.T) {

--- a/internal/adapters/in/http/admin/handler_volumes.go
+++ b/internal/adapters/in/http/admin/handler_volumes.go
@@ -19,8 +19,8 @@ func (h *Handler) handleListVolumes(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	if !HasAccess(ctx, domain.AdminResourceStatus, domain.AdminActionRead) {
-		h.sendError(w, http.StatusForbidden, "insufficient permissions for status:read")
+	if !HasAccess(ctx, domain.AdminResourceVolumes, domain.AdminActionRead) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for volumes:read")
 		return
 	}
 
@@ -63,8 +63,8 @@ func (h *Handler) handlePruneVolumes(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	if !HasAccess(ctx, domain.AdminResourceConfig, domain.AdminActionWrite) {
-		h.sendError(w, http.StatusForbidden, "insufficient permissions for config:write")
+	if !HasAccess(ctx, domain.AdminResourceVolumes, domain.AdminActionWrite) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for volumes:write")
 		return
 	}
 

--- a/internal/adapters/in/http/middleware/cidr.go
+++ b/internal/adapters/in/http/middleware/cidr.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/bnema/zerowrap"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
 	"github.com/bnema/gordon/internal/adapters/in/http/httphelper"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // cidrAllowlist is the shared implementation for CIDR-based access control middleware.
@@ -67,7 +69,7 @@ func RegistryCIDRAllowlist(allowedNets, trustedNets []*net.IPNet, log zerowrap.L
 // httpPort is the configured HTTP listener port (cfg.Server.Port) so the redirect
 // helper can map it to tlsPort. Hosts with no explicit port omit the TLS port from
 // the public URL; hosts with an unknown explicit port preserve it as-is.
-func HTTPSRedirect(proxyNets []*net.IPNet, httpPort, tlsPort int, forceAll bool, log zerowrap.Logger) func(http.Handler) http.Handler {
+func HTTPSRedirect(proxyNets []*net.IPNet, httpPort, tlsPort int, forceAll bool, log zerowrap.Logger, isHostAllowed func(string) bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		if tlsPort == 0 {
 			return next
@@ -88,7 +90,11 @@ func HTTPSRedirect(proxyNets []*net.IPNet, httpPort, tlsPort int, forceAll bool,
 				}
 			}
 
-			target := httpsRedirectTarget(r.Host, r.RequestURI, httpPort, tlsPort)
+			target, ok := httpsRedirectTarget(r.Host, r.RequestURI, httpPort, tlsPort, isHostAllowed)
+			if !ok {
+				http.Error(w, "Bad Request", http.StatusBadRequest)
+				return
+			}
 
 			log.Debug().
 				Str("target", target).
@@ -99,14 +105,40 @@ func HTTPSRedirect(proxyNets []*net.IPNet, httpPort, tlsPort int, forceAll bool,
 	}
 }
 
-// httpsRedirectTarget derives the HTTPS redirect URL from the request Host.
-func httpsRedirectTarget(host, requestURI string, httpPort, tlsPort int) string {
+// httpsRedirectTarget derives the HTTPS redirect URL from a validated request Host.
+func httpsRedirectTarget(host, requestURI string, httpPort, tlsPort int, isHostAllowed func(string) bool) (string, bool) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return "", false
+	}
+	hostname, portStr, err := net.SplitHostPort(host)
+	if err != nil {
+		if strings.Contains(host, ":") {
+			return "", false
+		}
+		hostname = host
+	} else if port, err := strconv.Atoi(portStr); err != nil || port < 1 || port > 65535 {
+		return "", false
+	}
+	hostname = strings.TrimSuffix(hostname, ".")
+	canonicalHost, ok := domain.CanonicalRouteDomain(hostname)
+	if !ok {
+		return "", false
+	}
+	if isHostAllowed == nil || !isHostAllowed(canonicalHost) {
+		return "", false
+	}
+
 	path := requestURI
 	if !strings.HasPrefix(path, "/") {
 		path = "/"
 	}
 
-	return fmt.Sprintf("https://%s%s", httphelper.HTTPSAuthority(host, httpPort, tlsPort), path)
+	canonicalAuthority := canonicalHost
+	if portStr != "" {
+		canonicalAuthority = net.JoinHostPort(canonicalHost, portStr)
+	}
+	return fmt.Sprintf("https://%s%s", httphelper.HTTPSAuthority(canonicalAuthority, httpPort, tlsPort), path), true
 }
 
 // ProxyCIDRAllowlist returns middleware that restricts proxy access to the given CIDR ranges.

--- a/internal/adapters/in/http/middleware/cidr_test.go
+++ b/internal/adapters/in/http/middleware/cidr_test.go
@@ -187,15 +187,20 @@ func TestHTTPSRedirect_TrailingDotHostRedirectsToCanonicalHost(t *testing.T) {
 	})
 	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 
-	req := httptest.NewRequest(http.MethodGet, "http://example.test/path", nil)
-	req.RequestURI = "/path"
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+	client := srv.Client()
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/path", nil)
+	require.NoError(t, err)
 	req.Host = "O2.Bnema.Dev.:8088"
-	rec := httptest.NewRecorder()
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusPermanentRedirect, rec.Code)
-	assert.Equal(t, "https://o2.bnema.dev:8443/path", rec.Header().Get("Location"))
+	assert.Equal(t, http.StatusPermanentRedirect, resp.StatusCode)
+	assert.Equal(t, "https://o2.bnema.dev:8443/path", resp.Header.Get("Location"))
 }
 
 func TestHTTPSRedirect_RejectsInvalidHost(t *testing.T) {
@@ -218,14 +223,17 @@ func TestHTTPSRedirect_RejectsInvalidHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+			require.NoError(t, err)
 			req.Host = tt.host
-			rec := httptest.NewRecorder()
+			resp, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 
-			handler.ServeHTTP(rec, req)
-
-			assert.Equal(t, http.StatusBadRequest, rec.Code)
-			assert.Empty(t, rec.Header().Get("Location"))
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Empty(t, resp.Header.Get("Location"))
 		})
 	}
 }

--- a/internal/adapters/in/http/middleware/cidr_test.go
+++ b/internal/adapters/in/http/middleware/cidr_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -118,7 +117,7 @@ func TestHTTPSRedirect_NoPortHost_OmitsTLSPort(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := HTTPSRedirect(nil, 8088, 8443, true, log)(ok)
+	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -141,7 +140,7 @@ func TestHTTPSRedirect_HTTPListenerPort_MapsToTLSPort(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := HTTPSRedirect(nil, 8088, 8443, true, log)(ok)
+	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -164,7 +163,7 @@ func TestHTTPSRedirect_UnknownExplicitPort_IsPreserved(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := HTTPSRedirect(nil, 8088, 8443, true, log)(ok)
+	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
@@ -181,31 +180,54 @@ func TestHTTPSRedirect_UnknownExplicitPort_IsPreserved(t *testing.T) {
 	assert.Equal(t, "https://o2.bnema.dev:9999/", resp.Header.Get("Location"))
 }
 
-func TestHTTPSRedirect_InvalidExplicitPort_IsPreserved(t *testing.T) {
+func TestHTTPSRedirect_TrailingDotHostRedirectsToCanonicalHost(t *testing.T) {
 	log := testLogger()
 	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 
-	handler := HTTPSRedirect(nil, 8088, 8443, true, log)(ok)
-	srv := httptest.NewServer(handler)
-	defer srv.Close()
+	req := httptest.NewRequest(http.MethodGet, "http://example.test/path", nil)
+	req.RequestURI = "/path"
+	req.Host = "O2.Bnema.Dev.:8088"
+	rec := httptest.NewRecorder()
 
-	// Use a raw TCP connection because Go's HTTP client rejects the
-	// invalid port in the Location header before CheckRedirect fires.
-	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
-	require.NoError(t, err)
-	defer conn.Close()
+	handler.ServeHTTP(rec, req)
 
-	_, err = fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: o2.bnema.dev:abcd\r\nConnection: close\r\n\r\n")
-	require.NoError(t, err)
+	assert.Equal(t, http.StatusPermanentRedirect, rec.Code)
+	assert.Equal(t, "https://o2.bnema.dev:8443/path", rec.Header().Get("Location"))
+}
 
-	var buf [4096]byte
-	n, _ := conn.Read(buf[:])
-	raw := string(buf[:n])
+func TestHTTPSRedirect_RejectsInvalidHost(t *testing.T) {
+	log := testLogger()
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := HTTPSRedirect(nil, 8088, 8443, true, log, func(host string) bool { return host == "o2.bnema.dev" })(ok)
 
-	assert.Contains(t, raw, "308")
-	assert.Contains(t, raw, "Location: https://o2.bnema.dev:abcd/")
+	tests := []struct {
+		name string
+		host string
+	}{
+		{name: "invalid port", host: "o2.bnema.dev:abcd"},
+
+		{name: "localhost", host: "localhost"},
+		{name: "ipv6", host: "[::1]:8088"},
+		{name: "unconfigured public host", host: "evil.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Empty(t, rec.Header().Get("Location"))
+		})
+	}
 }
 
 func TestProxyCIDRAllowlist(t *testing.T) {

--- a/internal/adapters/in/http/proxy/handler.go
+++ b/internal/adapters/in/http/proxy/handler.go
@@ -111,6 +111,12 @@ func normalizeRequestHost(host string) string {
 			return ""
 		}
 		host = h
+	} else if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		if ip := net.ParseIP(inner); ip == nil || ip.To4() != nil {
+			return ""
+		}
+		host = inner
 	} else if strings.Contains(host, ":") {
 		return ""
 	}

--- a/internal/adapters/in/http/proxy/handler.go
+++ b/internal/adapters/in/http/proxy/handler.go
@@ -4,6 +4,8 @@ package proxy
 import (
 	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync/atomic"
 
 	"github.com/bnema/zerowrap"
@@ -70,16 +72,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(ctx)
 	log := zerowrap.FromCtx(ctx)
 
+	host := normalizeRequestHost(r.Host)
+	if host == "" {
+		proxyError(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
 	// Check if this is the registry domain
-	if h.proxySvc.IsRegistryDomain(r.Host) {
+	if h.proxySvc.IsRegistryDomain(host) {
 		log.Debug().Msg("routing request to registry")
 		h.forwardToRegistry(w, r, cfg.RegistryPort)
 		return
 	}
 
 	// Get target for this domain
-	log.Debug().Str("resolving_target_for", r.Host).Msg("looking up proxy target")
-	target, err := h.proxySvc.GetTarget(ctx, r.Host)
+	log.Debug().Str("resolving_target_for", host).Msg("looking up proxy target")
+	target, err := h.proxySvc.GetTarget(ctx, host)
 	if err != nil {
 		log.Warn().Err(err).Msg("no route found for domain")
 		proxyError(w, "404 page not found", http.StatusNotFound)
@@ -93,4 +101,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Msg("resolved proxy target")
 
 	h.forwardToTarget(w, r, target, cfg.MaxResponseSize)
+}
+
+func normalizeRequestHost(host string) string {
+	host = strings.TrimSpace(host)
+	if h, port, err := net.SplitHostPort(host); err == nil {
+		portNum, err := strconv.Atoi(port)
+		if err != nil || portNum < 1 || portNum > 65535 {
+			return ""
+		}
+		host = h
+	} else if strings.Contains(host, ":") {
+		return ""
+	}
+	host = strings.ToLower(host)
+	host = strings.TrimSuffix(host, ".")
+	return host
 }

--- a/internal/adapters/in/http/proxy/handler_test.go
+++ b/internal/adapters/in/http/proxy/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/gordon/internal/boundaries/in"
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
@@ -80,13 +81,16 @@ func TestHandler_NormalizesRequestHostForLookup(t *testing.T) {
 			proxySvc.EXPECT().GetTarget(mock.Anything, tt.wantHost).Return(nil, domain.ErrNoTargetAvailable)
 
 			handler := NewHandler(proxySvc, nil, testLogger())
-			req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+			require.NoError(t, err)
 			req.Host = tt.host
-			w := httptest.NewRecorder()
+			resp, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 
-			handler.ServeHTTP(w, req)
-
-			assert.Equal(t, http.StatusNotFound, w.Code)
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 		})
 	}
 }
@@ -96,14 +100,17 @@ func TestHandler_RejectsInvalidRequestHost(t *testing.T) {
 	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
 
 	handler := NewHandler(proxySvc, nil, testLogger())
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
 	for _, host := range []string{"app.example.com:bad", "app.example.com:0", "app.example.com:99999"} {
-		req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+		req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+		require.NoError(t, err)
 		req.Host = host
-		w := httptest.NewRecorder()
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
 
-		handler.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	}
 }
 

--- a/internal/adapters/in/http/proxy/handler_test.go
+++ b/internal/adapters/in/http/proxy/handler_test.go
@@ -61,6 +61,52 @@ func TestHandler_RoutesToRegistry(t *testing.T) {
 	assert.True(t, w.Code == http.StatusBadGateway || w.Code == http.StatusServiceUnavailable)
 }
 
+func TestHandler_NormalizesRequestHostForLookup(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHost string
+	}{
+		{name: "mixed case", host: "App.Example.com", wantHost: "app.example.com"},
+		{name: "explicit port", host: "App.Example.com:8080", wantHost: "app.example.com"},
+		{name: "trailing dot", host: "App.Example.com.", wantHost: "app.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxySvc := inmocks.NewMockProxyService(t)
+			proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+			proxySvc.EXPECT().IsRegistryDomain(tt.wantHost).Return(false)
+			proxySvc.EXPECT().GetTarget(mock.Anything, tt.wantHost).Return(nil, domain.ErrNoTargetAvailable)
+
+			handler := NewHandler(proxySvc, nil, testLogger())
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+			req.Host = tt.host
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+func TestHandler_RejectsInvalidRequestHost(t *testing.T) {
+	proxySvc := inmocks.NewMockProxyService(t)
+	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+
+	handler := NewHandler(proxySvc, nil, testLogger())
+	for _, host := range []string{"app.example.com:bad", "app.example.com:0", "app.example.com:99999"} {
+		req := httptest.NewRequest(http.MethodGet, "http://example.test/", nil)
+		req.Host = host
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	}
+}
+
 func TestHandler_Returns404WhenNoTarget(t *testing.T) {
 	proxySvc := inmocks.NewMockProxyService(t)
 

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -32,12 +32,17 @@ const (
 	DefaultMaxBlobSize = 1024 * 1024 * 1024
 )
 
+// blobLimits holds consistent blob size limits.
+type blobLimits struct {
+	MaxChunkSize int64
+	MaxBlobSize  int64
+}
+
 // Handler implements the HTTP handler for Docker Registry API v2.
 type Handler struct {
-	registrySvc      in.RegistryService
-	log              zerowrap.Logger
-	maxBlobChunkSize atomic.Int64
-	maxBlobSize      atomic.Int64
+	registrySvc in.RegistryService
+	log         zerowrap.Logger
+	blobLimits  atomic.Value // stores *blobLimits
 }
 
 // NewHandler creates a new registry HTTP handler.
@@ -59,7 +64,10 @@ func NewHandler(
 		registrySvc: registrySvc,
 		log:         log,
 	}
-	h.UpdateBlobLimits(maxBlobChunkSize, blobSizeLimit)
+	h.blobLimits.Store(&blobLimits{
+		MaxChunkSize: maxBlobChunkSize,
+		MaxBlobSize:  blobSizeLimit,
+	})
 	return h
 }
 
@@ -71,8 +79,10 @@ func (h *Handler) UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64) {
 	if maxBlobSize <= 0 {
 		maxBlobSize = DefaultMaxBlobSize
 	}
-	h.maxBlobChunkSize.Store(maxBlobChunkSize)
-	h.maxBlobSize.Store(maxBlobSize)
+	h.blobLimits.Store(&blobLimits{
+		MaxChunkSize: maxBlobChunkSize,
+		MaxBlobSize:  maxBlobSize,
+	})
 }
 
 // RegisterRoutes registers the registry routes on the given mux.
@@ -430,8 +440,10 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	maxBlobChunkSize := h.maxBlobChunkSize.Load()
-	maxBlobSize := h.maxBlobSize.Load()
+	// Load a consistent snapshot of both blob limits atomically
+	limits := h.blobLimits.Load().(*blobLimits)
+	maxBlobChunkSize := limits.MaxChunkSize
+	maxBlobSize := limits.MaxBlobSize
 
 	// Limit blob chunk size to prevent excessive uploads.
 	// MaxBytesReader wraps the body so the downstream io.Copy stops at the limit.

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -26,6 +26,8 @@ const (
 	// Kept at 95MB to stay within Cloudflare's 100MB per-request limit.
 	// Users who need larger chunks can configure it explicitly via max_blob_chunk_size.
 	DefaultMaxBlobChunkSize = 95 * 1024 * 1024
+	// DefaultMaxBlobSize is the default maximum cumulative size for a blob upload.
+	DefaultMaxBlobSize = 1024 * 1024 * 1024
 )
 
 // Handler implements the HTTP handler for Docker Registry API v2.
@@ -33,6 +35,7 @@ type Handler struct {
 	registrySvc      in.RegistryService
 	log              zerowrap.Logger
 	maxBlobChunkSize int64
+	maxBlobSize      int64
 }
 
 // NewHandler creates a new registry HTTP handler.
@@ -40,15 +43,21 @@ func NewHandler(
 	registrySvc in.RegistryService,
 	log zerowrap.Logger,
 	maxBlobChunkSize int64,
+	maxBlobSize ...int64,
 ) *Handler {
 	if maxBlobChunkSize <= 0 {
 		maxBlobChunkSize = DefaultMaxBlobChunkSize
+	}
+	blobSizeLimit := int64(DefaultMaxBlobSize)
+	if len(maxBlobSize) > 0 && maxBlobSize[0] > 0 {
+		blobSizeLimit = maxBlobSize[0]
 	}
 
 	return &Handler{
 		registrySvc:      registrySvc,
 		log:              log,
 		maxBlobChunkSize: maxBlobChunkSize,
+		maxBlobSize:      blobSizeLimit,
 	}
 }
 
@@ -413,12 +422,18 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 
 	// Stream the body directly to storage — memory usage is bounded to a small
 	// copy buffer (~32KB) regardless of chunk size.
-	length, err := h.registrySvc.AppendBlobChunk(ctx, name, uuid, r.Body)
+	length, err := h.registrySvc.AppendBlobChunk(ctx, name, uuid, r.Body, r.ContentLength, h.maxBlobSize)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			log.Warn().Int64("max_size", h.maxBlobChunkSize).Msg("blob chunk too large")
 			h.sendRegistryError(w, http.StatusRequestEntityTooLarge, "SIZE_INVALID", "blob chunk exceeds maximum size")
+			return
+		}
+		if errors.Is(err, domain.ErrBlobSizeExceeded) {
+			log.Warn().Int64("max_size", h.maxBlobSize).Msg("blob upload too large")
+			_ = h.registrySvc.CancelUpload(ctx, uuid)
+			h.sendRegistryError(w, http.StatusRequestEntityTooLarge, "SIZE_INVALID", "blob exceeds maximum size")
 			return
 		}
 		log.Error().Err(err).Msg("failed to append blob chunk")

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -2,6 +2,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/bnema/zerowrap"
 
@@ -34,8 +36,8 @@ const (
 type Handler struct {
 	registrySvc      in.RegistryService
 	log              zerowrap.Logger
-	maxBlobChunkSize int64
-	maxBlobSize      int64
+	maxBlobChunkSize atomic.Int64
+	maxBlobSize      atomic.Int64
 }
 
 // NewHandler creates a new registry HTTP handler.
@@ -53,12 +55,24 @@ func NewHandler(
 		blobSizeLimit = maxBlobSize[0]
 	}
 
-	return &Handler{
-		registrySvc:      registrySvc,
-		log:              log,
-		maxBlobChunkSize: maxBlobChunkSize,
-		maxBlobSize:      blobSizeLimit,
+	h := &Handler{
+		registrySvc: registrySvc,
+		log:         log,
 	}
+	h.UpdateBlobLimits(maxBlobChunkSize, blobSizeLimit)
+	return h
+}
+
+// UpdateBlobLimits updates request-size limits used by live upload handlers.
+func (h *Handler) UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64) {
+	if maxBlobChunkSize <= 0 {
+		maxBlobChunkSize = DefaultMaxBlobChunkSize
+	}
+	if maxBlobSize <= 0 {
+		maxBlobSize = DefaultMaxBlobSize
+	}
+	h.maxBlobChunkSize.Store(maxBlobChunkSize)
+	h.maxBlobSize.Store(maxBlobSize)
 }
 
 // RegisterRoutes registers the registry routes on the given mux.
@@ -416,24 +430,31 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	maxBlobChunkSize := h.maxBlobChunkSize.Load()
+	maxBlobSize := h.maxBlobSize.Load()
+
 	// Limit blob chunk size to prevent excessive uploads.
 	// MaxBytesReader wraps the body so the downstream io.Copy stops at the limit.
-	r.Body = http.MaxBytesReader(w, r.Body, h.maxBlobChunkSize)
+	r.Body = http.MaxBytesReader(w, r.Body, maxBlobChunkSize)
 
 	// Stream the body directly to storage — memory usage is bounded to a small
 	// copy buffer (~32KB) regardless of chunk size.
-	length, err := h.registrySvc.AppendBlobChunk(ctx, name, uuid, r.Body, r.ContentLength, h.maxBlobSize)
+	length, err := h.registrySvc.AppendBlobChunk(ctx, name, uuid, r.Body, r.ContentLength, maxBlobSize)
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
-			log.Warn().Int64("max_size", h.maxBlobChunkSize).Msg("blob chunk too large")
-			_ = h.registrySvc.CancelUpload(ctx, uuid)
+			log.Warn().Int64("max_size", maxBlobChunkSize).Msg("blob chunk too large")
+			if !h.cancelUploadAfterError(w, ctx, uuid, "failed to cancel oversized blob upload") {
+				return
+			}
 			h.sendRegistryError(w, http.StatusRequestEntityTooLarge, "SIZE_INVALID", "blob chunk exceeds maximum size")
 			return
 		}
 		if errors.Is(err, domain.ErrBlobSizeExceeded) {
-			log.Warn().Int64("max_size", h.maxBlobSize).Msg("blob upload too large")
-			_ = h.registrySvc.CancelUpload(ctx, uuid)
+			log.Warn().Int64("max_size", maxBlobSize).Msg("blob upload too large")
+			if !h.cancelUploadAfterError(w, ctx, uuid, "failed to cancel oversized blob upload") {
+				return
+			}
 			h.sendRegistryError(w, http.StatusRequestEntityTooLarge, "SIZE_INVALID", "blob exceeds maximum size")
 			return
 		}
@@ -446,7 +467,9 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "PUT" && digest != "" {
 		if err := h.registrySvc.FinishUpload(ctx, uuid, digest); err != nil {
 			log.Error().Err(err).Str("digest", digest).Msg("failed to finalize blob upload")
-			_ = h.registrySvc.CancelUpload(ctx, uuid)
+			if !h.cancelUploadAfterError(w, ctx, uuid, "failed to cancel invalid blob upload") {
+				return
+			}
 			h.sendRegistryError(w, http.StatusBadRequest, "DIGEST_INVALID", "digest mismatch")
 			return
 		}
@@ -464,6 +487,16 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Docker-Upload-UUID", uuid)
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *Handler) cancelUploadAfterError(w http.ResponseWriter, ctx context.Context, uuid, message string) bool {
+	if err := h.registrySvc.CancelUpload(ctx, uuid); err != nil {
+		log := zerowrap.FromCtx(ctx)
+		log.Error().Err(err).Str("uuid", uuid).Msg(message)
+		h.sendRegistryError(w, http.StatusInternalServerError, "UNKNOWN", "failed to cancel upload")
+		return false
+	}
+	return true
 }
 
 func (h *Handler) handleListTags(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -253,7 +253,7 @@ func (h *Handler) handleTagListRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) handleBase(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) handleBase(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
 	w.WriteHeader(http.StatusOK)
 }
@@ -427,6 +427,7 @@ func (h *Handler) handleBlobUpload(w http.ResponseWriter, r *http.Request) {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
 			log.Warn().Int64("max_size", h.maxBlobChunkSize).Msg("blob chunk too large")
+			_ = h.registrySvc.CancelUpload(ctx, uuid)
 			h.sendRegistryError(w, http.StatusRequestEntityTooLarge, "SIZE_INVALID", "blob chunk exceeds maximum size")
 			return
 		}

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -293,7 +293,7 @@ func TestHandler_BlobUpload_PATCH(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
 
 	chunkData := []byte("chunk content")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).Return(int64(len(chunkData)), nil)
 
 	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
@@ -310,7 +310,7 @@ func TestHandler_BlobUpload_PUT_Finalize(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
 
 	chunkData := []byte("final chunk")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).Return(int64(len(chunkData)), nil)
 	registrySvc.EXPECT().FinishUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(nil)
 
 	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000?digest=sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", bytes.NewReader(chunkData))
@@ -432,7 +432,7 @@ func TestHandler_BlobUpload_PATCH_ReturnsDockerUploadUUID(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
 
 	chunkData := []byte("chunk content")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).Return(int64(len(chunkData)), nil)
 
 	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
@@ -453,8 +453,8 @@ func TestHandler_BlobUpload_PATCH_RespectsConfiguredMaxBlobChunkSize(t *testing.
 
 	// The handler wraps r.Body in MaxBytesReader and passes it to AppendBlobChunk.
 	// The mock must read the body to trigger MaxBytesError, which the handler detects.
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything).
-		Run(func(_ context.Context, _ string, _ string, data io.Reader) {
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, _ string, data io.Reader, _ int64, _ int64) {
 			// Drain the reader to trigger MaxBytesError
 			_, _ = io.ReadAll(data)
 		}).
@@ -473,7 +473,7 @@ func TestHandler_BlobUpload_PATCH_ReturnsRangeHeader(t *testing.T) {
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
 
 	chunkData := []byte("chunk content")
-	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).Return(int64(len(chunkData)), nil)
 
 	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader(chunkData))
 	rec := httptest.NewRecorder()
@@ -483,4 +483,78 @@ func TestHandler_BlobUpload_PATCH_ReturnsRangeHeader(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 	// OCI spec: Range header should reflect total received bytes
 	assert.Equal(t, "0-12", rec.Header().Get("Range"))
+}
+
+func TestDefaultMaxBlobSize_Is1GB(t *testing.T) {
+	assert.Equal(t, int64(1024*1024*1024), int64(DefaultMaxBlobSize))
+}
+
+func TestHandler_BlobUpload_PATCH_MaxBlobSizeExceededReturnsSizeInvalidAndCancels(t *testing.T) {
+	registrySvc := inmocks.NewMockRegistryService(t)
+	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize, 10)
+
+	registrySvc.EXPECT().AppendBlobChunk(
+		mock.Anything,
+		"myapp",
+		"550e8400-e29b-41d4-a716-446655440000",
+		mock.Anything,
+		int64(6),
+		int64(10),
+	).Return(int64(0), domain.ErrBlobSizeExceeded)
+	registrySvc.EXPECT().CancelUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000").Return(nil)
+
+	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader([]byte("123456")))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "SIZE_INVALID")
+}
+
+func TestHandler_BlobUpload_PATCH_ContentLengthTooLargeReturnsSizeInvalidAndCancels(t *testing.T) {
+	registrySvc := inmocks.NewMockRegistryService(t)
+	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize, 10)
+
+	registrySvc.EXPECT().AppendBlobChunk(
+		mock.Anything,
+		"myapp",
+		"550e8400-e29b-41d4-a716-446655440000",
+		mock.Anything,
+		int64(11),
+		int64(10),
+	).Return(int64(0), domain.ErrBlobSizeExceeded)
+	registrySvc.EXPECT().CancelUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000").Return(nil)
+
+	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader([]byte("12345678901")))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "SIZE_INVALID")
+}
+
+func TestHandler_BlobUpload_PUT_FinalizeUnderMaxBlobSize(t *testing.T) {
+	registrySvc := inmocks.NewMockRegistryService(t)
+	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize, 10)
+
+	chunkData := []byte("1234567890")
+	registrySvc.EXPECT().AppendBlobChunk(
+		mock.Anything,
+		"myapp",
+		"550e8400-e29b-41d4-a716-446655440000",
+		mock.Anything,
+		int64(len(chunkData)),
+		int64(10),
+	).Return(int64(len(chunkData)), nil)
+	registrySvc.EXPECT().FinishUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(nil)
+
+	req := httptest.NewRequest("PUT", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000?digest=sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", bytes.NewReader(chunkData))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Equal(t, "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", rec.Header().Get("Docker-Content-Digest"))
 }

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -455,10 +455,12 @@ func TestHandler_BlobUpload_PATCH_RespectsConfiguredMaxBlobChunkSize(t *testing.
 	// The mock must read the body to trigger MaxBytesError, which the handler detects.
 	registrySvc.EXPECT().AppendBlobChunk(mock.Anything, "myapp", "550e8400-e29b-41d4-a716-446655440000", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(_ context.Context, _ string, _ string, data io.Reader, _ int64, _ int64) {
-			// Drain the reader to trigger MaxBytesError
+			// Drain the reader to trigger MaxBytesError after the storage layer may
+			// have written the limit-sized prefix.
 			_, _ = io.ReadAll(data)
 		}).
 		Return(int64(0), &http.MaxBytesError{Limit: 5})
+	registrySvc.EXPECT().CancelUpload(mock.Anything, "550e8400-e29b-41d4-a716-446655440000").Return(nil)
 
 	req := httptest.NewRequest("PATCH", "/v2/myapp/blobs/uploads/550e8400-e29b-41d4-a716-446655440000", bytes.NewReader([]byte("chunk content")))
 	rec := httptest.NewRecorder()

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -1269,10 +1269,11 @@ func (r *Runtime) CreateNetwork(ctx context.Context, name string, config domain.
 	if driver == "" {
 		driver = "bridge"
 	}
-	labels := map[string]string{domain.LabelManaged: "true"}
+	labels := make(map[string]string, len(config.Labels)+1)
 	for key, value := range config.Labels {
 		labels[key] = value
 	}
+	labels[domain.LabelManaged] = "true"
 
 	createOptions := network.CreateOptions{
 		Driver:   driver,

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -1503,10 +1503,7 @@ func (r *Runtime) CopyFromContainer(ctx context.Context, containerID, srcPath st
 // extractFileFromTar extracts a single file from a tar archive.
 func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser, error) {
 	tr := tar.NewReader(reader)
-
-	// The path in the tar may be relative or absolute
-	// We need to match based on the filename
-	targetName := filepath.Base(targetPath)
+	targetName := normalizedTarPath(targetPath)
 
 	for {
 		header, err := tr.Next()
@@ -1517,28 +1514,43 @@ func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser,
 			return nil, err
 		}
 
-		// Check if this is our target file
-		if header.Typeflag == tar.TypeReg {
-			headerName := filepath.Base(header.Name)
-			if headerName == targetName {
-				size := header.Size
-				pr, pw := io.Pipe()
-				go func() {
-					defer reader.Close()
-					_, copyErr := io.CopyN(pw, tr, size)
-					if copyErr != nil {
-						_ = pw.CloseWithError(copyErr)
-						return
-					}
-					_ = pw.Close()
-				}()
-				return &pipeReadCloser{pr: pr, pw: pw, original: reader}, nil
-			}
+		if header.Typeflag == tar.TypeReg && normalizedTarPath(header.Name) == targetName {
+			size := header.Size
+			pr, pw := io.Pipe()
+			go func() {
+				defer reader.Close()
+				_, copyErr := io.CopyN(pw, tr, size)
+				if copyErr != nil {
+					_ = pw.CloseWithError(copyErr)
+					return
+				}
+				_ = pw.Close()
+			}()
+			return &pipeReadCloser{pr: pr, pw: pw, original: reader}, nil
 		}
 	}
 
 	_ = reader.Close()
 	return nil, fmt.Errorf("file not found in container: %s", targetPath)
+}
+
+func normalizedTarPath(path string) string {
+	path = filepath.ToSlash(filepath.Clean(path))
+	return strings.TrimPrefix(path, "/")
+}
+
+const maxExtractedEnvFileSize = 1 << 20 // 1 MiB
+
+func readExtractedEnvFile(reader io.Reader) ([]byte, error) {
+	limited := io.LimitReader(reader, maxExtractedEnvFileSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxExtractedEnvFileSize {
+		return nil, fmt.Errorf("extracted env file exceeds %d bytes", maxExtractedEnvFileSize)
+	}
+	return data, nil
 }
 
 // ExtractEnvFileFromImage extracts an env file from an image.
@@ -1583,7 +1595,7 @@ func (r *Runtime) ExtractEnvFileFromImage(ctx context.Context, imageRef, envFile
 	}
 	defer reader.Close()
 
-	data, err := io.ReadAll(reader)
+	data, err := readExtractedEnvFile(reader)
 	if err != nil {
 		return nil, log.WrapErr(err, "failed to read extracted env file")
 	}

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -161,6 +161,7 @@ func (r *Runtime) CreateContainer(ctx context.Context, config *domain.ContainerC
 		WorkingDir:   config.WorkingDir,
 		Cmd:          config.Cmd,
 		Labels:       config.Labels,
+		User:         config.User,
 	}
 
 	resources := container.Resources{
@@ -173,20 +174,24 @@ func (r *Runtime) CreateContainer(ctx context.Context, config *domain.ContainerC
 	if config.PidsLimit > 0 {
 		resources.PidsLimit = &config.PidsLimit
 	}
+	capDrop := strslice.StrSlice{"ALL"}
+	capAdd := strslice.StrSlice{"CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "NET_BIND_SERVICE"}
+	if config.CapDrop != nil {
+		capDrop = strslice.StrSlice(config.CapDrop)
+	}
+	if config.CapAdd != nil {
+		capAdd = strslice.StrSlice(config.CapAdd)
+	}
 	hostConfig := &container.HostConfig{
-		PortBindings: portBindings,
-		AutoRemove:   config.AutoRemove,
-		Binds:        binds,
-		NetworkMode:  container.NetworkMode(config.NetworkMode),
-		Resources:    resources,
-		SecurityOpt:  []string{"no-new-privileges:true"},
-		CapDrop:      strslice.StrSlice{"ALL"},
-		// Re-add the minimal set of capabilities that standard images need.
-		// CHOWN/FOWNER/DAC_OVERRIDE: postgres, mysql etc. chown/chmod data dirs
-		// owned by their service user during entrypoint init.
-		// SETUID/SETGID: gosu/su-exec to drop privileges after init.
-		// NET_BIND_SERVICE: nginx etc. binding to ports < 1024.
-		CapAdd: strslice.StrSlice{"CHOWN", "DAC_OVERRIDE", "FOWNER", "SETUID", "SETGID", "NET_BIND_SERVICE"},
+		PortBindings:   portBindings,
+		AutoRemove:     config.AutoRemove,
+		Binds:          binds,
+		NetworkMode:    container.NetworkMode(config.NetworkMode),
+		Resources:      resources,
+		SecurityOpt:    []string{"no-new-privileges:true"},
+		CapDrop:        capDrop,
+		CapAdd:         capAdd,
+		ReadonlyRootfs: config.ReadOnlyRootFS,
 	}
 
 	// Create network configuration for container
@@ -1251,7 +1256,7 @@ func (r *Runtime) GetImageID(ctx context.Context, imageRef string) (string, erro
 }
 
 // CreateNetwork creates a new Docker network.
-func (r *Runtime) CreateNetwork(ctx context.Context, name string, options map[string]string) error {
+func (r *Runtime) CreateNetwork(ctx context.Context, name string, config domain.NetworkConfig) error {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "adapter",
 		zerowrap.FieldAdapter: "docker",
@@ -1260,24 +1265,19 @@ func (r *Runtime) CreateNetwork(ctx context.Context, name string, options map[st
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	// Set default driver to bridge if not specified
-	driver := "bridge"
-	if driverOption, exists := options["driver"]; exists {
-		driver = driverOption
+	driver := config.Driver
+	if driver == "" {
+		driver = "bridge"
+	}
+	labels := map[string]string{domain.LabelManaged: "true"}
+	for key, value := range config.Labels {
+		labels[key] = value
 	}
 
 	createOptions := network.CreateOptions{
-		Driver: driver,
-		Labels: map[string]string{
-			domain.LabelManaged: "true",
-		},
-	}
-
-	// Add any additional options to labels
-	for key, value := range options {
-		if key != "driver" {
-			createOptions.Labels["gordon."+key] = value
-		}
+		Driver:   driver,
+		Internal: config.Internal,
+		Labels:   labels,
 	}
 
 	_, err := r.client.NetworkCreate(ctx, name, createOptions)

--- a/internal/adapters/out/docker/runtime_exec_test.go
+++ b/internal/adapters/out/docker/runtime_exec_test.go
@@ -1,9 +1,12 @@
 package docker
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +49,31 @@ func frameDockerStream(streamID byte, payload []byte) []byte {
 	binary.BigEndian.PutUint32(frame[4:8], uint32(len(payload)))
 	copy(frame[8:], payload)
 	return frame
+}
+
+func TestExtractFileFromTarMatchesFullCleanPath(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "other/.env", Typeflag: tar.TypeReg, Size: int64(len("wrong"))}))
+	_, err := tw.Write([]byte("wrong"))
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "app/.env", Typeflag: tar.TypeReg, Size: int64(len("right"))}))
+	_, err = tw.Write([]byte("right"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/app/.env")
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "right", string(data))
+}
+
+func TestReadExtractedEnvFileRejectsOversizedContent(t *testing.T) {
+	data, err := readExtractedEnvFile(io.NopCloser(strings.NewReader(strings.Repeat("a", maxExtractedEnvFileSize+1))))
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "exceeds")
 }

--- a/internal/adapters/out/domainsecrets/pass_store.go
+++ b/internal/adapters/out/domainsecrets/pass_store.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bnema/zerowrap"
@@ -27,6 +28,7 @@ const (
 
 // PassStore implements the DomainSecretStore interface using the pass password manager.
 type PassStore struct {
+	mu      sync.Mutex
 	timeout time.Duration
 	log     zerowrap.Logger
 }
@@ -136,6 +138,26 @@ func (s *PassStore) GetAll(domainName string) (map[string]string, error) {
 	}
 
 	return secretsMap, nil
+}
+
+// SetIfEmpty sets multiple secrets for a domain only when no keys already exist.
+// It performs the precondition check inside the store adapter so migration
+// callers cannot accidentally split the check and write into separate steps.
+func (s *PassStore) SetIfEmpty(domainName string, secretsMap map[string]string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existingKeys, err := s.ListKeys(domainName)
+	if err != nil {
+		return nil, err
+	}
+	if len(existingKeys) > 0 {
+		return nil, fmt.Errorf("%w: pass secrets already exist for %s (found %d keys)", domain.ErrSecretsAlreadyExist, domainName, len(existingKeys))
+	}
+	if err := s.Set(domainName, secretsMap); err != nil {
+		return nil, err
+	}
+	return sortedMapKeys(secretsMap), nil
 }
 
 // Set sets or updates multiple secrets for a domain.
@@ -251,6 +273,26 @@ func (s *PassStore) Delete(domainName, key string) error {
 	}
 
 	return nil
+}
+
+// SetAttachmentIfEmpty sets attachment secrets only when no keys already exist.
+// It performs the precondition check inside the store adapter so migration
+// callers cannot accidentally split the check and write into separate steps.
+func (s *PassStore) SetAttachmentIfEmpty(containerName string, secretsMap map[string]string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existingKeys, err := s.listAttachmentKeysRecover(containerName)
+	if err != nil {
+		return nil, err
+	}
+	if len(existingKeys) > 0 {
+		return nil, fmt.Errorf("%w: pass secrets already exist for attachment %s (found %d keys)", domain.ErrSecretsAlreadyExist, containerName, len(existingKeys))
+	}
+	if err := s.SetAttachment(containerName, secretsMap); err != nil {
+		return nil, err
+	}
+	return sortedMapKeys(secretsMap), nil
 }
 
 // SetAttachment sets or updates multiple secrets for an attachment container.
@@ -613,6 +655,66 @@ func (s *PassStore) listAttachmentKeys(containerName string) ([]string, error) {
 		keys = append(keys, key)
 	}
 
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func (s *PassStore) listAttachmentKeysRecover(containerName string) ([]string, error) {
+	keys, err := s.listAttachmentKeys(containerName)
+	if err != nil {
+		return nil, err
+	}
+	discovered, err := s.discoverAttachmentKeys(containerName)
+	if err != nil {
+		return nil, err
+	}
+	merged, changed := mergeUniqueKeys(keys, discovered)
+	if changed {
+		manifestPath, err := s.attachmentManifestPath(containerName)
+		if err != nil {
+			return nil, err
+		}
+		writeCtx, writeCancel := context.WithTimeout(context.Background(), s.timeout)
+		writeErr := s.passInsert(writeCtx, manifestPath, strings.Join(merged, "\n"))
+		writeCancel()
+		if writeErr != nil {
+			s.log.Warn().
+				Str(zerowrap.FieldLayer, "adapter").
+				Str(zerowrap.FieldAdapter, "domainsecrets").
+				Str("container", containerName).
+				Err(writeErr).
+				Msg("failed to self-heal attachment pass manifest, continuing with recovered keys")
+		}
+	}
+	return merged, nil
+}
+
+func (s *PassStore) discoverAttachmentKeys(containerName string) ([]string, error) {
+	basePath, err := s.attachmentPath(containerName)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+	defer cancel()
+
+	entries, err := s.listTopLevelEntries(ctx, basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == ".keys" {
+			continue
+		}
+		if err := domain.ValidateEnvKey(entry); err != nil {
+			continue
+		}
+		keys = append(keys, entry)
+	}
+
+	sort.Strings(keys)
 	return keys, nil
 }
 
@@ -776,6 +878,15 @@ func passEntryMissing(output string) bool {
 	lower := strings.ToLower(clean)
 	return strings.Contains(lower, "not in the password store") ||
 		strings.Contains(lower, "password store is empty")
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func mergeUniqueKeys(primary, secondary []string) ([]string, bool) {

--- a/internal/adapters/out/filesystem/backup_storage.go
+++ b/internal/adapters/out/filesystem/backup_storage.go
@@ -2,6 +2,8 @@ package filesystem
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -62,11 +64,12 @@ func (s *BackupStorage) Store(_ context.Context, domainName, dbName string, sche
 		return "", fmt.Errorf("failed to create backup path: %w", err)
 	}
 
-	fileName := timestamp.UTC().Format(backupTimestampLayout) + ".bak"
+	fileName := timestamp.UTC().Format(time.RFC3339Nano) + "-" + randomBackupSuffix() + ".bak"
+	fileName = sanitizeBackupFileName(fileName)
 	finalPath := filepath.Join(backupDir, fileName)
 	tmpPath := finalPath + ".tmp"
 
-	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp backup file: %w", err)
 	}
@@ -118,7 +121,7 @@ func (s *BackupStorage) List(_ context.Context, domainName string, schedule *dom
 		if walkErr != nil {
 			return walkErr
 		}
-		if d.IsDir() {
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".bak") {
 			return nil
 		}
 
@@ -144,7 +147,7 @@ func (s *BackupStorage) List(_ context.Context, domainName string, schedule *dom
 
 		startedAt := info.ModTime().UTC()
 		base := filepath.Base(path)
-		if ts, err := time.Parse(backupTimestampLayout+".bak", base); err == nil {
+		if ts, ok := parseBackupStartedAt(base); ok {
 			startedAt = ts.UTC()
 		}
 
@@ -265,6 +268,35 @@ func retentionKeepCount(policy domain.RetentionPolicy, schedule domain.BackupSch
 	default:
 		return -1
 	}
+}
+
+func parseBackupStartedAt(base string) (time.Time, bool) {
+	if !strings.HasSuffix(base, ".bak") {
+		return time.Time{}, false
+	}
+	if ts, err := time.Parse(backupTimestampLayout+".bak", base); err == nil {
+		return ts, true
+	}
+	trimmed := strings.TrimSuffix(base, ".bak")
+	if idx := strings.LastIndex(trimmed, "-"); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	if ts, err := time.Parse(time.RFC3339Nano, strings.ReplaceAll(trimmed, "_", ":")); err == nil {
+		return ts, true
+	}
+	return time.Time{}, false
+}
+
+func randomBackupSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func sanitizeBackupFileName(input string) string {
+	return strings.NewReplacer(":", "_").Replace(input)
 }
 
 func sanitizeBackupPathComponent(input string) string {

--- a/internal/adapters/out/filesystem/backup_storage_test.go
+++ b/internal/adapters/out/filesystem/backup_storage_test.go
@@ -31,6 +31,39 @@ func TestBackupStorage_StoreAndGet(t *testing.T) {
 	assert.Equal(t, payload, data)
 }
 
+func TestBackupStorage_StoreSameSecondBackupsUseDistinctFinalAndTempPaths(t *testing.T) {
+	rootDir := t.TempDir()
+	storage, err := NewBackupStorage(rootDir, testLogger())
+	require.NoError(t, err)
+
+	now := time.Date(2026, 2, 7, 11, 0, 0, 0, time.UTC)
+	firstPayload := []byte("first-backup")
+	secondPayload := []byte("second-backup")
+
+	firstPath, err := storage.Store(context.Background(), "app.example.com", "postgres", domain.ScheduleDaily, now, bytes.NewReader(firstPayload))
+	require.NoError(t, err)
+	secondPath, err := storage.Store(context.Background(), "app.example.com", "postgres", domain.ScheduleDaily, now, bytes.NewReader(secondPayload))
+	require.NoError(t, err)
+
+	assert.NotEqual(t, firstPath, secondPath)
+	assert.NoFileExists(t, firstPath+".tmp")
+	assert.NoFileExists(t, secondPath+".tmp")
+
+	firstRead, err := storage.Get(context.Background(), firstPath)
+	require.NoError(t, err)
+	defer firstRead.Close()
+	firstData, err := io.ReadAll(firstRead)
+	require.NoError(t, err)
+	assert.Equal(t, firstPayload, firstData)
+
+	secondRead, err := storage.Get(context.Background(), secondPath)
+	require.NoError(t, err)
+	defer secondRead.Close()
+	secondData, err := io.ReadAll(secondRead)
+	require.NoError(t, err)
+	assert.Equal(t, secondPayload, secondData)
+}
+
 func TestBackupStorage_ListWithScheduleFilter(t *testing.T) {
 	storage, err := NewBackupStorage(t.TempDir(), testLogger())
 	require.NoError(t, err)
@@ -71,7 +104,7 @@ func TestBackupStorage_ApplyRetention(t *testing.T) {
 	require.NoError(t, err)
 
 	base := time.Date(2026, 2, 7, 6, 0, 0, 0, time.UTC)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		_, err := storage.Store(context.Background(), "app.example.com", "postgres", domain.ScheduleDaily, base.Add(time.Duration(i)*time.Hour), bytes.NewReader([]byte("data")))
 		require.NoError(t, err)
 	}

--- a/internal/adapters/out/filesystem/blob.go
+++ b/internal/adapters/out/filesystem/blob.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/google/uuid"
 
+	"github.com/bnema/gordon/internal/domain"
 	"github.com/bnema/gordon/pkg/validation"
 )
 
@@ -254,7 +255,7 @@ func (s *BlobStorage) StartBlobUpload(name string) (string, error) {
 }
 
 // AppendBlobChunk appends data to an in-progress upload.
-func (s *BlobStorage) AppendBlobChunk(name, uuid string, data io.Reader) (int64, error) {
+func (s *BlobStorage) AppendBlobChunk(name, uuid string, data io.Reader, contentLength, maxBlobSize int64) (int64, error) {
 	uploadPath, err := s.getUploadPath(uuid)
 	if err != nil {
 		return 0, fmt.Errorf("invalid upload path: %w", err)
@@ -274,12 +275,33 @@ func (s *BlobStorage) AppendBlobChunk(name, uuid string, data io.Reader) (int64,
 	}
 	defer file.Close()
 
+	fi, err := file.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get file info: %w", err)
+	}
+	originalSize := fi.Size()
+
+	if maxBlobSize > 0 {
+		remaining := maxBlobSize - originalSize
+		if remaining < 0 || (contentLength >= 0 && contentLength > remaining) {
+			return 0, domain.ErrBlobSizeExceeded
+		}
+		data = io.LimitReader(data, remaining+1)
+	}
+
 	written, err := io.Copy(file, data)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write chunk to upload file: %w", err)
 	}
 
-	fi, err := file.Stat()
+	if maxBlobSize > 0 && originalSize+written > maxBlobSize {
+		if err := file.Truncate(originalSize); err != nil {
+			return 0, fmt.Errorf("failed to truncate oversized upload: %w", err)
+		}
+		return 0, domain.ErrBlobSizeExceeded
+	}
+
+	fi, err = file.Stat()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get file info: %w", err)
 	}

--- a/internal/adapters/out/filesystem/blob_test.go
+++ b/internal/adapters/out/filesystem/blob_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 const (
@@ -24,6 +27,15 @@ const (
 
 func testLogger() zerowrap.Logger {
 	return zerowrap.Default()
+}
+
+type readFailer struct {
+	read bool
+}
+
+func (r *readFailer) Read(_ []byte) (int, error) {
+	r.read = true
+	return 0, io.ErrUnexpectedEOF
 }
 
 func TestNewBlobStorage(t *testing.T) {
@@ -280,13 +292,13 @@ func TestBlobStorage_AppendBlobChunk(t *testing.T) {
 
 	// Append first chunk
 	chunk1 := []byte("first chunk")
-	size1, err := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk1))
+	size1, err := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk1), -1, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(chunk1)), size1)
 
 	// Append second chunk
 	chunk2 := []byte(" second chunk")
-	size2, err := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk2))
+	size2, err := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk2), -1, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(chunk1)+len(chunk2)), size2)
 }
@@ -298,10 +310,81 @@ func TestBlobStorage_AppendBlobChunk_NotFound(t *testing.T) {
 	storage, err := NewBlobStorage(tmpDir, log)
 	require.NoError(t, err)
 
-	_, err = storage.AppendBlobChunk("myapp", "00000000-0000-4000-a000-000000000000", bytes.NewReader([]byte("data")))
+	_, err = storage.AppendBlobChunk("myapp", "00000000-0000-4000-a000-000000000000", bytes.NewReader([]byte("data")), -1, 100)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")
+}
+
+func TestBlobStorage_AppendBlobChunk_MaxBlobSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := testLogger()
+
+	storage, err := NewBlobStorage(tmpDir, log)
+	require.NoError(t, err)
+
+	uuid, err := storage.StartBlobUpload("myapp")
+	require.NoError(t, err)
+
+	size, err := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("12345")), -1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), size)
+
+	size, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("67890")), -1, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), size)
+
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("x")), -1, 10)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, domain.ErrBlobSizeExceeded))
+
+	uploadPath := filepath.Join(tmpDir, "uploads", uuid)
+	info, statErr := os.Stat(uploadPath)
+	require.NoError(t, statErr)
+	assert.Equal(t, int64(10), info.Size())
+}
+
+func TestBlobStorage_AppendBlobChunk_MaxBlobSizeContentLengthTooLargeDoesNotRead(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := testLogger()
+
+	storage, err := NewBlobStorage(tmpDir, log)
+	require.NoError(t, err)
+
+	uuid, err := storage.StartBlobUpload("myapp")
+	require.NoError(t, err)
+
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("12345")), 5, 10)
+	require.NoError(t, err)
+
+	reader := &readFailer{}
+	_, err = storage.AppendBlobChunk("myapp", uuid, reader, 6, 10)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrBlobSizeExceeded)
+	assert.False(t, reader.read)
+}
+
+func TestBlobStorage_AppendBlobChunk_MaxBlobSizeOverflowMidReadTruncates(t *testing.T) {
+	tmpDir := t.TempDir()
+	log := testLogger()
+
+	storage, err := NewBlobStorage(tmpDir, log)
+	require.NoError(t, err)
+
+	uuid, err := storage.StartBlobUpload("myapp")
+	require.NoError(t, err)
+
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("12345")), -1, 10)
+	require.NoError(t, err)
+
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("6789012345")), -1, 10)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, domain.ErrBlobSizeExceeded))
+
+	uploadPath := filepath.Join(tmpDir, "uploads", uuid)
+	info, statErr := os.Stat(uploadPath)
+	require.NoError(t, statErr)
+	assert.Equal(t, int64(5), info.Size())
 }
 
 func TestBlobStorage_GetBlobUpload(t *testing.T) {
@@ -350,7 +433,7 @@ func TestBlobStorage_FinishBlobUpload(t *testing.T) {
 
 	// Append data - content that hashes to testDigest1
 	blobData := []byte("complete blob content")
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData), -1, 0)
 	require.NoError(t, err)
 
 	// Finish upload - use testDigest1 (validation will pass, but hash won't match)
@@ -477,7 +560,7 @@ func TestBlobStorage_CompleteUploadFlow(t *testing.T) {
 
 	var totalSize int64
 	for _, chunk := range chunks {
-		size, err := storage.AppendBlobChunk(repoName, uuid, bytes.NewReader(chunk))
+		size, err := storage.AppendBlobChunk(repoName, uuid, bytes.NewReader(chunk), -1, 0)
 		require.NoError(t, err)
 		totalSize = size
 	}
@@ -501,7 +584,7 @@ func TestBlobStorage_ConcurrentAppendAndFinalize(t *testing.T) {
 	require.NoError(t, err)
 
 	initialData := []byte("initial-")
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(initialData))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(initialData), -1, 0)
 	require.NoError(t, err)
 
 	appendChunk := []byte("chunk")
@@ -516,7 +599,7 @@ func TestBlobStorage_ConcurrentAppendAndFinalize(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-appendReady
-			_, appendErr := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(appendChunk))
+			_, appendErr := storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(appendChunk), -1, 0)
 			appendErrs <- appendErr
 		}()
 	}
@@ -570,7 +653,7 @@ func TestBlobStorage_ConcurrentAppendAndFinalize(t *testing.T) {
 		assert.Equal(t, fullyAppended, blobData)
 	}
 
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("after")))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("after")), -1, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")
 }
@@ -586,13 +669,13 @@ func TestBlobStorage_AppendAfterFinalize(t *testing.T) {
 	require.NoError(t, err)
 
 	blobData := []byte("finalized content")
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData), -1, 0)
 	require.NoError(t, err)
 
 	err = storage.FinishBlobUpload(uuid, digestForData(blobData))
 	require.NoError(t, err)
 
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("more")))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader([]byte("more")), -1, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload not found")
 }
@@ -608,7 +691,7 @@ func TestBlobStorage_FailedFinalizeRetryable(t *testing.T) {
 	require.NoError(t, err)
 
 	blobData := []byte("retryable finalize")
-	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData))
+	_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(blobData), -1, 0)
 	require.NoError(t, err)
 
 	err = storage.FinishBlobUpload(uuid, testDigest1)
@@ -638,7 +721,7 @@ func TestBlobStorage_SequentialFlow(t *testing.T) {
 	var blobData []byte
 	for _, chunk := range chunks {
 		blobData = append(blobData, chunk...)
-		_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk))
+		_, err = storage.AppendBlobChunk("myapp", uuid, bytes.NewReader(chunk), -1, 0)
 		require.NoError(t, err)
 	}
 

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -94,7 +94,7 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 
 	if err := os.Remove(filePath); err != nil {
 		// Check if the stored secrets match what we just wrote
-		storedSecrets, getErr := passStore.Get(domainName)
+		storedSecrets, getErr := passStore.GetAll(domainName)
 		if getErr == nil && secretsMatch(storedSecrets, secrets) {
 			// Migration was successful, removal failed but secrets are stored
 			log.Warn().
@@ -104,11 +104,17 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 			return nil
 		}
 		// Attempt rollback: remove the pass entry we just wrote
-		if delErr := passStore.Delete(domainName); delErr != nil {
-			log.Error().
-				Err(delErr).
-				Str("domain", domainName).
-				Msg("failed to rollback pass entry after file removal failure")
+		rollbackKeys, listErr := passStore.ListKeys(domainName)
+		if listErr == nil {
+			for _, key := range rollbackKeys {
+				if delErr := passStore.Delete(domainName, key); delErr != nil {
+					log.Error().
+						Err(delErr).
+						Str("domain", domainName).
+						Str("key", key).
+						Msg("failed to rollback pass entry after file removal failure")
+				}
+			}
 		}
 		return fmt.Errorf("failed to remove migrated env file %s: %w", filePath, err)
 	}
@@ -198,11 +204,17 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 			return nil
 		}
 		// Attempt rollback: remove the pass entry we just wrote
-		if delErr := passStore.DeleteAttachment(containerName); delErr != nil {
-			log.Error().
-				Err(delErr).
-				Str("container", containerName).
-				Msg("failed to rollback pass entry after file removal failure")
+		rollbackSecrets, listErr := passStore.GetAllAttachment(containerName)
+		if listErr == nil {
+			for key := range rollbackSecrets {
+				if delErr := passStore.DeleteAttachment(containerName, key); delErr != nil {
+					log.Error().
+						Err(delErr).
+						Str("container", containerName).
+						Str("key", key).
+						Msg("failed to rollback pass entry after file removal failure")
+				}
+			}
 		}
 		return fmt.Errorf("failed to remove migrated attachment env file %s: %w", filePath, err)
 	}

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -84,52 +84,23 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 		return fmt.Errorf("failed to read pass keys for %s: %w", domainName, err)
 	}
 
-	missing := missingSecrets(existingKeys, secrets)
-	if len(missing) > 0 {
-		if err := passStore.Set(domainName, missing); err != nil {
-			return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
-		}
+	if len(existingKeys) > 0 {
+		return fmt.Errorf("pass secrets already exist for %s; refusing to delete plaintext env file automatically", domainName)
+	}
+	if err := passStore.Set(domainName, secrets); err != nil {
+		return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
 	}
 
-	migratedPath := filePath + ".migrated"
-	if err := os.Rename(filePath, migratedPath); err != nil {
-		return fmt.Errorf("failed to rename env file %s: %w", filePath, err)
+	if err := os.Remove(filePath); err != nil {
+		return fmt.Errorf("failed to remove migrated env file %s: %w", filePath, err)
 	}
 
 	log.Info().
-		Int(zerowrap.FieldCount, len(missing)).
+		Int(zerowrap.FieldCount, len(secrets)).
 		Str("domain", domainName).
-		Msg("migrated secrets for domain from plain text to pass")
-	log.Info().
-		Str("file", migratedPath).
-		Msg("original file renamed to .env.migrated - you can safely remove it")
+		Msg("migrated secrets for domain from plain text to pass and removed original env file")
 
 	return nil
-}
-
-func missingSecrets(existingKeys []string, secrets map[string]string) map[string]string {
-	if len(secrets) == 0 {
-		return nil
-	}
-
-	existingSet := make(map[string]struct{}, len(existingKeys))
-	for _, key := range existingKeys {
-		existingSet[key] = struct{}{}
-	}
-
-	missing := make(map[string]string)
-	for key, value := range secrets {
-		if _, exists := existingSet[key]; exists {
-			continue
-		}
-		missing[key] = value
-	}
-
-	if len(missing) == 0 {
-		return nil
-	}
-
-	return missing
 }
 
 func migrateAttachmentEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
@@ -190,29 +161,24 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 		existingKeys = append(existingKeys, key)
 	}
 
-	missing := missingSecrets(existingKeys, secrets)
-	if len(missing) > 0 {
-		if err := passStore.SetAttachment(containerName, missing); err != nil {
-			return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
-		}
-		log.Info().
-			Int(zerowrap.FieldCount, len(missing)).
-			Str("container", containerName).
-			Msg("migrated secrets for attachment container from plain text to pass")
-	} else {
-		log.Info().
-			Str("container", containerName).
-			Msg("all attachment secrets already exist in pass; no migration needed")
+	if len(existingKeys) > 0 {
+		return fmt.Errorf("pass secrets already exist for attachment %s; refusing to delete plaintext env file automatically", containerName)
 	}
+	if err := passStore.SetAttachment(containerName, secrets); err != nil {
+		return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
+	}
+	log.Info().
+		Int(zerowrap.FieldCount, len(secrets)).
+		Str("container", containerName).
+		Msg("migrated secrets for attachment container from plain text to pass")
 
-	migratedPath := filePath + ".migrated"
-	if err := os.Rename(filePath, migratedPath); err != nil {
-		return fmt.Errorf("failed to rename attachment env file %s: %w", filePath, err)
+	if err := os.Remove(filePath); err != nil {
+		return fmt.Errorf("failed to remove migrated attachment env file %s: %w", filePath, err)
 	}
 
 	log.Info().
-		Str("file", migratedPath).
-		Msg("original attachment file renamed to .env.migrated - you can safely remove it")
+		Str("file", filePath).
+		Msg("removed original attachment env file after migration to pass")
 
 	return nil
 }

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,15 +80,11 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 		return nil
 	}
 
-	existingKeys, err := passStore.ListKeys(domainName)
+	writtenKeys, err := passStore.SetIfEmpty(domainName, secrets)
 	if err != nil {
-		return fmt.Errorf("failed to read pass keys for %s: %w", domainName, err)
-	}
-
-	if len(existingKeys) > 0 {
-		return fmt.Errorf("%w: pass secrets already exist for %s (found %d keys); refusing to delete plaintext env file automatically", domain.ErrSecretsAlreadyExist, domainName, len(existingKeys))
-	}
-	if err := passStore.Set(domainName, secrets); err != nil {
+		if errors.Is(err, domain.ErrSecretsAlreadyExist) {
+			return fmt.Errorf("%w; refusing to delete plaintext env file automatically", err)
+		}
 		return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
 	}
 
@@ -102,17 +99,14 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 				Msg("secrets migrated successfully but failed to remove original file; treating as success")
 			return nil
 		}
-		// Attempt rollback: remove the pass entry we just wrote
-		rollbackKeys, listErr := passStore.ListKeys(domainName)
-		if listErr == nil {
-			for _, key := range rollbackKeys {
-				if delErr := passStore.Delete(domainName, key); delErr != nil {
-					log.Error().
-						Err(delErr).
-						Str("domain", domainName).
-						Str("key", key).
-						Msg("failed to rollback pass entry after file removal failure")
-				}
+		// Attempt rollback: remove only the pass entries this migration wrote.
+		for _, key := range writtenKeys {
+			if delErr := passStore.Delete(domainName, key); delErr != nil {
+				log.Error().
+					Err(delErr).
+					Str("domain", domainName).
+					Str("key", key).
+					Msg("failed to rollback pass entry after file removal failure")
 			}
 		}
 		return fmt.Errorf("failed to remove migrated env file %s: %w", filePath, err)
@@ -174,20 +168,11 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 		return nil
 	}
 
-	existingSecrets, err := passStore.GetAllAttachment(containerName)
+	writtenKeys, err := passStore.SetAttachmentIfEmpty(containerName, secrets)
 	if err != nil {
-		return fmt.Errorf("failed to read pass secrets for attachment %s: %w", containerName, err)
-	}
-
-	existingKeys := make([]string, 0, len(existingSecrets))
-	for key := range existingSecrets {
-		existingKeys = append(existingKeys, key)
-	}
-
-	if len(existingKeys) > 0 {
-		return fmt.Errorf("%w: pass secrets already exist for attachment %s (found %d keys); refusing to delete plaintext env file automatically", domain.ErrSecretsAlreadyExist, containerName, len(existingKeys))
-	}
-	if err := passStore.SetAttachment(containerName, secrets); err != nil {
+		if errors.Is(err, domain.ErrSecretsAlreadyExist) {
+			return fmt.Errorf("%w; refusing to delete plaintext env file automatically", err)
+		}
 		return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
 	}
 
@@ -202,17 +187,14 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 				Msg("attachment secrets migrated successfully but failed to remove original file; treating as success")
 			return nil
 		}
-		// Attempt rollback: remove the pass entry we just wrote
-		rollbackSecrets, listErr := passStore.GetAllAttachment(containerName)
-		if listErr == nil {
-			for key := range rollbackSecrets {
-				if delErr := passStore.DeleteAttachment(containerName, key); delErr != nil {
-					log.Error().
-						Err(delErr).
-						Str("container", containerName).
-						Str("key", key).
-						Msg("failed to rollback pass entry after file removal failure")
-				}
+		// Attempt rollback: remove only the pass entries this migration wrote.
+		for _, key := range writtenKeys {
+			if delErr := passStore.DeleteAttachment(containerName, key); delErr != nil {
+				log.Error().
+					Err(delErr).
+					Str("container", containerName).
+					Str("key", key).
+					Msg("failed to rollback pass entry after file removal failure")
 			}
 		}
 		return fmt.Errorf("failed to remove migrated attachment env file %s: %w", filePath, err)
@@ -237,7 +219,8 @@ func secretsMatch(a, b map[string]string) bool {
 		return false
 	}
 	for k, v := range a {
-		if b[k] != v {
+		bv, ok := b[k]
+		if !ok || bv != v {
 			return false
 		}
 	}

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
 	"github.com/bnema/gordon/internal/domain"
-	domainerrors "github.com/bnema/gordon/internal/domain"
 )
 
 func migrateEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
@@ -86,7 +85,7 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 	}
 
 	if len(existingKeys) > 0 {
-		return fmt.Errorf("%w: pass secrets already exist for %s (found %d keys); refusing to delete plaintext env file automatically", domainerrors.ErrSecretNotFound, domainName, len(existingKeys))
+		return fmt.Errorf("%w: pass secrets already exist for %s (found %d keys); refusing to delete plaintext env file automatically", domain.ErrSecretsAlreadyExist, domainName, len(existingKeys))
 	}
 	if err := passStore.Set(domainName, secrets); err != nil {
 		return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
@@ -186,7 +185,7 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 	}
 
 	if len(existingKeys) > 0 {
-		return fmt.Errorf("%w: pass secrets already exist for attachment %s (found %d keys); refusing to delete plaintext env file automatically", domainerrors.ErrSecretNotFound, containerName, len(existingKeys))
+		return fmt.Errorf("%w: pass secrets already exist for attachment %s (found %d keys); refusing to delete plaintext env file automatically", domain.ErrSecretsAlreadyExist, containerName, len(existingKeys))
 	}
 	if err := passStore.SetAttachment(containerName, secrets); err != nil {
 		return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -167,18 +167,16 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 	if err := passStore.SetAttachment(containerName, secrets); err != nil {
 		return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
 	}
-	log.Info().
-		Int(zerowrap.FieldCount, len(secrets)).
-		Str("container", containerName).
-		Msg("migrated secrets for attachment container from plain text to pass")
 
 	if err := os.Remove(filePath); err != nil {
 		return fmt.Errorf("failed to remove migrated attachment env file %s: %w", filePath, err)
 	}
 
 	log.Info().
+		Int(zerowrap.FieldCount, len(secrets)).
+		Str("container", containerName).
 		Str("file", filePath).
-		Msg("removed original attachment env file after migration to pass")
+		Msg("migrated attachment secrets to pass and removed original env file")
 
 	return nil
 }

--- a/internal/app/migrate_env.go
+++ b/internal/app/migrate_env.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/out/domainsecrets"
 	"github.com/bnema/gordon/internal/domain"
+	domainerrors "github.com/bnema/gordon/internal/domain"
 )
 
 func migrateEnvFilesToPass(envDir string, passStore *domainsecrets.PassStore, log zerowrap.Logger) error {
@@ -85,13 +86,30 @@ func migrateEnvFile(envDir, name string, passStore *domainsecrets.PassStore, log
 	}
 
 	if len(existingKeys) > 0 {
-		return fmt.Errorf("pass secrets already exist for %s; refusing to delete plaintext env file automatically", domainName)
+		return fmt.Errorf("%w: pass secrets already exist for %s (found %d keys); refusing to delete plaintext env file automatically", domainerrors.ErrSecretNotFound, domainName, len(existingKeys))
 	}
 	if err := passStore.Set(domainName, secrets); err != nil {
 		return fmt.Errorf("failed to migrate secrets for %s: %w", domainName, err)
 	}
 
 	if err := os.Remove(filePath); err != nil {
+		// Check if the stored secrets match what we just wrote
+		storedSecrets, getErr := passStore.Get(domainName)
+		if getErr == nil && secretsMatch(storedSecrets, secrets) {
+			// Migration was successful, removal failed but secrets are stored
+			log.Warn().
+				Str("file", filePath).
+				Str("domain", domainName).
+				Msg("secrets migrated successfully but failed to remove original file; treating as success")
+			return nil
+		}
+		// Attempt rollback: remove the pass entry we just wrote
+		if delErr := passStore.Delete(domainName); delErr != nil {
+			log.Error().
+				Err(delErr).
+				Str("domain", domainName).
+				Msg("failed to rollback pass entry after file removal failure")
+		}
 		return fmt.Errorf("failed to remove migrated env file %s: %w", filePath, err)
 	}
 
@@ -162,13 +180,30 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 	}
 
 	if len(existingKeys) > 0 {
-		return fmt.Errorf("pass secrets already exist for attachment %s; refusing to delete plaintext env file automatically", containerName)
+		return fmt.Errorf("%w: pass secrets already exist for attachment %s (found %d keys); refusing to delete plaintext env file automatically", domainerrors.ErrSecretNotFound, containerName, len(existingKeys))
 	}
 	if err := passStore.SetAttachment(containerName, secrets); err != nil {
 		return fmt.Errorf("failed to migrate attachment secrets for %s: %w", containerName, err)
 	}
 
 	if err := os.Remove(filePath); err != nil {
+		// Check if the stored secrets match what we just wrote
+		storedSecrets, getErr := passStore.GetAllAttachment(containerName)
+		if getErr == nil && secretsMatch(storedSecrets, secrets) {
+			// Migration was successful, removal failed but secrets are stored
+			log.Warn().
+				Str("file", filePath).
+				Str("container", containerName).
+				Msg("attachment secrets migrated successfully but failed to remove original file; treating as success")
+			return nil
+		}
+		// Attempt rollback: remove the pass entry we just wrote
+		if delErr := passStore.DeleteAttachment(containerName); delErr != nil {
+			log.Error().
+				Err(delErr).
+				Str("container", containerName).
+				Msg("failed to rollback pass entry after file removal failure")
+		}
 		return fmt.Errorf("failed to remove migrated attachment env file %s: %w", filePath, err)
 	}
 
@@ -184,4 +219,16 @@ func migrateAttachmentEnvFile(envDir, name string, passStore *domainsecrets.Pass
 func extractContainerNameFromAttachmentFile(filename string) string {
 	name := strings.TrimSuffix(filename, ".env")
 	return name
+}
+
+func secretsMatch(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/app/migrate_env_test.go
+++ b/internal/app/migrate_env_test.go
@@ -71,12 +71,11 @@ func TestMigrateEnvFile(t *testing.T) {
 	err = migrateEnvFile(tmpDir, envFileName, store, logger)
 	require.NoError(t, err)
 
-	migratedPath := envFilePath + ".migrated"
 	_, err = os.Stat(envFilePath)
 	assert.True(t, os.IsNotExist(err), "original .env file should be removed")
 
-	_, err = os.Stat(migratedPath)
-	assert.NoError(t, err, ".env.migrated file should exist")
+	_, err = os.Stat(envFilePath + ".migrated")
+	assert.True(t, os.IsNotExist(err), ".env.migrated plaintext should not be preserved by default")
 
 	passKeys, err := store.ListKeys(domainName)
 	require.NoError(t, err)
@@ -125,12 +124,11 @@ func TestMigrateAttachmentEnvFile(t *testing.T) {
 	err = migrateAttachmentEnvFile(tmpDir, envFileName, store, logger)
 	require.NoError(t, err)
 
-	migratedPath := envFilePath + ".migrated"
 	_, err = os.Stat(envFilePath)
 	assert.True(t, os.IsNotExist(err), "original .env file should be removed")
 
-	_, err = os.Stat(migratedPath)
-	assert.NoError(t, err, ".env.migrated file should exist")
+	_, err = os.Stat(envFilePath + ".migrated")
+	assert.True(t, os.IsNotExist(err), ".env.migrated plaintext should not be preserved by default")
 
 	values, err := store.GetAllAttachment(storedContainerName)
 	require.NoError(t, err)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bnema/zerowrap"
 	zerowrapotel "github.com/bnema/zerowrap/otel"
 	"github.com/spf13/viper"
+	"golang.org/x/sys/unix"
 
 	// Adapters - Output
 	"github.com/bnema/gordon/internal/adapters/out/accesslog"
@@ -1336,16 +1337,69 @@ func loadSecret(ctx context.Context, backend domain.SecretsBackend, path, dataDi
 		provider := secrets.NewSopsProvider(log)
 		return provider.GetSecret(ctx, path)
 	case domain.SecretsBackendUnsafe:
-		// For unsafe backend, path is relative to dataDir/secrets/
-		secretFile := filepath.Join(dataDir, "secrets", path)
-		data, err := os.ReadFile(secretFile)
-		if err != nil {
-			return "", fmt.Errorf("failed to read secret file: %w", err)
-		}
-		return string(data), nil
+		// For unsafe backend, path is relative to dataDir/secrets/.
+		return readUnsafeSecret(dataDir, path)
 	default:
 		return "", fmt.Errorf("unknown secrets backend: %s", backend)
 	}
+}
+
+func readFileBeneath(root, cleanedRelPath string) ([]byte, error) {
+	rootFD, err := unix.Open(root, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open secrets root: %w", err)
+	}
+	defer unix.Close(rootFD)
+
+	parts := strings.Split(filepath.ToSlash(cleanedRelPath), "/")
+	dirFD := rootFD
+	var closeDirFDs []int
+	defer func() {
+		for i := len(closeDirFDs) - 1; i >= 0; i-- {
+			_ = unix.Close(closeDirFDs[i])
+		}
+	}()
+
+	for i, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return nil, fmt.Errorf("invalid secret path: path must stay under dataDir/secrets")
+		}
+		last := i == len(parts)-1
+		if last {
+			fd, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read secret file: %w", err)
+			}
+			defer unix.Close(fd)
+			return os.ReadFile(fmt.Sprintf("/proc/self/fd/%d", fd))
+		}
+
+		nextFD, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open secret path component: %w", err)
+		}
+		closeDirFDs = append(closeDirFDs, nextFD)
+		dirFD = nextFD
+	}
+
+	return nil, fmt.Errorf("invalid secret path: empty path")
+}
+
+func readUnsafeSecret(dataDir, secretPath string) (string, error) {
+	if filepath.IsAbs(secretPath) {
+		return "", fmt.Errorf("invalid secret path: absolute paths are not allowed")
+	}
+	cleaned := filepath.Clean(secretPath)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid secret path: path must stay under dataDir/secrets")
+	}
+
+	root := filepath.Clean(filepath.Join(dataDir, "secrets"))
+	data, err := readFileBeneath(root, cleaned)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 // proxyConfigResult holds parsed proxy and blob chunk size config.

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -224,6 +224,9 @@ type services struct {
 	caAdapter         *pkiadapter.CA
 	pkiSvc            *pkiusecase.Service
 	reloadCoordinator *reloadCoordinator
+	registryHandler   interface {
+		UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
+	}
 }
 
 // Run initializes and starts the Gordon application.
@@ -466,7 +469,7 @@ func createServices(ctx context.Context, v *viper.Viper, cfg Config, log zerowra
 		return nil, err
 	}
 
-	si.svc.reloadCoordinator = newReloadCoordinator(v, si.svc.configSvc, si.svc.proxySvc, si.svc.eventBus, log)
+	si.svc.reloadCoordinator = newReloadCoordinator(v, si.svc.configSvc, si.svc.proxySvc, nil, si.svc.eventBus, log)
 
 	si.initHandlers()
 
@@ -1369,11 +1372,18 @@ func readFileBeneath(root, cleanedRelPath string) ([]byte, error) {
 		}
 		last := i == len(parts)-1
 		if last {
-			fd, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+			fd, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read secret file: %w", err)
 			}
 			defer unix.Close(fd)
+			var st unix.Stat_t
+			if err := unix.Fstat(fd, &st); err != nil {
+				return nil, fmt.Errorf("failed to stat secret file: %w", err)
+			}
+			if st.Mode&unix.S_IFMT != unix.S_IFREG {
+				return nil, fmt.Errorf("invalid secret path: secret must be a regular file")
+			}
 			return os.ReadFile(fmt.Sprintf("/proc/self/fd/%d", fd))
 		}
 
@@ -1437,22 +1447,36 @@ type reloadCoordinator struct {
 	lastRun  time.Time
 	debounce time.Duration
 
-	configSvc configReloader
-	v         *viper.Viper
-	proxySvc  proxyConfigUpdater
-	eventBus  out.EventPublisher
-	log       zerowrap.Logger
+	configSvc      configReloader
+	v              *viper.Viper
+	proxySvc       proxyConfigUpdater
+	registryLimits interface {
+		UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
+	}
+	eventBus out.EventPublisher
+	log      zerowrap.Logger
 }
 
-func newReloadCoordinator(v *viper.Viper, configSvc configReloader, proxySvc proxyConfigUpdater, eventBus out.EventPublisher, log zerowrap.Logger) *reloadCoordinator {
+func newReloadCoordinator(v *viper.Viper, configSvc configReloader, proxySvc proxyConfigUpdater, registryLimits interface {
+	UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
+}, eventBus out.EventPublisher, log zerowrap.Logger) *reloadCoordinator {
 	return &reloadCoordinator{
-		debounce:  500 * time.Millisecond,
-		configSvc: configSvc,
-		v:         v,
-		proxySvc:  proxySvc,
-		eventBus:  eventBus,
-		log:       log,
+		debounce:       500 * time.Millisecond,
+		configSvc:      configSvc,
+		v:              v,
+		proxySvc:       proxySvc,
+		registryLimits: registryLimits,
+		eventBus:       eventBus,
+		log:            log,
 	}
+}
+
+func (c *reloadCoordinator) SetRegistryLimits(limits interface {
+	UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
+}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.registryLimits = limits
 }
 
 func (c *reloadCoordinator) Trigger(ctx context.Context) error {
@@ -1504,6 +1528,9 @@ func (c *reloadCoordinator) applyLoadedConfig(now time.Time) error {
 	}
 
 	c.proxySvc.UpdateConfig(reloadedProxy.proxyConfig)
+	if c.registryLimits != nil {
+		c.registryLimits.UpdateBlobLimits(reloadedProxy.maxBlobChunkSize, reloadedProxy.maxBlobSize)
+	}
 
 	if c.eventBus != nil {
 		if err := c.eventBus.Publish(domain.EventConfigReload, nil); err != nil {
@@ -1835,6 +1862,10 @@ func createHTTPHandlers(svc *services, cfg Config, log zerowrap.Logger, accessWr
 
 	// Registry handler
 	registryHandler := registry.NewHandler(svc.registrySvc, log, svc.maxBlobChunkSize, svc.maxBlobSize)
+	svc.registryHandler = registryHandler
+	if svc.reloadCoordinator != nil {
+		svc.reloadCoordinator.SetRegistryLimits(registryHandler)
+	}
 	registryWithMiddleware, cidrAllowlistMiddleware, rateLimitMiddleware := buildRegistryHandlerWithMiddleware(
 		svc,
 		cfg,

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -172,7 +172,9 @@ type Config struct {
 	} `mapstructure:"backups"`
 
 	Images struct {
-		Prune struct {
+		AllowedRegistries []string `mapstructure:"allowed_registries"`
+		RequireDigest     bool     `mapstructure:"require_digest"`
+		Prune             struct {
 			Enabled  bool   `mapstructure:"enabled"`
 			Schedule string `mapstructure:"schedule"`
 			KeepLast int    `mapstructure:"keep_last"`
@@ -180,9 +182,10 @@ type Config struct {
 	} `mapstructure:"images"`
 
 	Containers struct {
-		MemoryLimit string  `mapstructure:"memory_limit"` // e.g., "512MB", "1GB"
-		CPULimit    float64 `mapstructure:"cpu_limit"`    // CPU cores, e.g., 1.0 = 1 core
-		PidsLimit   int64   `mapstructure:"pids_limit"`   // e.g., 512
+		MemoryLimit     string  `mapstructure:"memory_limit"`     // e.g., "512MB", "1GB"
+		CPULimit        float64 `mapstructure:"cpu_limit"`        // CPU cores, e.g., 1.0 = 1 core
+		PidsLimit       int64   `mapstructure:"pids_limit"`       // e.g., 512
+		SecurityProfile string  `mapstructure:"security_profile"` // compat or strict
 	} `mapstructure:"containers"`
 
 	Telemetry telemetry.Config `mapstructure:"telemetry"`
@@ -1612,7 +1615,11 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 		NetworkIsolation:           v.GetBool("network_isolation.enabled"),
 		NetworkPrefix:              v.GetString("network_isolation.network_prefix"),
 		NetworkGroups:              attachmentConfig.NetworkGroups,
+		NetworkInternal:            v.GetBool("network_isolation.internal"),
 		Attachments:                attachmentConfig.Attachments,
+		AllowedRegistries:          cfg.Images.AllowedRegistries,
+		RequireImageDigest:         cfg.Images.RequireDigest,
+		SecurityProfile:            cfg.Containers.SecurityProfile,
 		ReadinessDelay:             v.GetDuration("deploy.readiness_delay"),
 		ReadinessMode:              v.GetString("deploy.readiness_mode"),
 		HealthTimeout:              v.GetDuration("deploy.health_timeout"),
@@ -2959,6 +2966,7 @@ func loadConfig(v *viper.Viper, configPath string) error {
 	v.SetDefault("auto_route.enabled", false)
 	v.SetDefault("network_isolation.enabled", true)
 	v.SetDefault("network_isolation.network_prefix", "gordon")
+	v.SetDefault("network_isolation.internal", false)
 	v.SetDefault("volumes.auto_create", true)
 	v.SetDefault("volumes.prefix", "gordon")
 	v.SetDefault("volumes.preserve", true)
@@ -2970,9 +2978,12 @@ func loadConfig(v *viper.Viper, configPath string) error {
 	v.SetDefault("backups.retention.daily", 0)
 	v.SetDefault("backups.retention.weekly", 0)
 	v.SetDefault("backups.retention.monthly", 0)
+	v.SetDefault("images.allowed_registries", []string{})
+	v.SetDefault("images.require_digest", false)
 	v.SetDefault("images.prune.enabled", false)
 	v.SetDefault("images.prune.schedule", string(domain.ScheduleDaily))
 	v.SetDefault("images.prune.keep_last", domain.DefaultImagePruneKeepLast)
+	v.SetDefault("containers.security_profile", "compat")
 	v.SetDefault("telemetry.enabled", false)
 	v.SetDefault("telemetry.endpoint", "")
 	v.SetDefault("telemetry.auth_token", "")

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1384,7 +1384,11 @@ func readFileBeneath(root, cleanedRelPath string) ([]byte, error) {
 			if st.Mode&unix.S_IFMT != unix.S_IFREG {
 				return nil, fmt.Errorf("invalid secret path: secret must be a regular file")
 			}
-			return os.ReadFile(fmt.Sprintf("/proc/self/fd/%d", fd))
+			data, err := os.ReadFile(fmt.Sprintf("/proc/self/fd/%d", fd))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read secret file: %w", err)
+			}
+			return data, nil
 		}
 
 		nextFD, err := unix.Openat(dirFD, part, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1797,7 +1797,9 @@ func createHTTPHandlers(svc *services, cfg Config, log zerowrap.Logger, accessWr
 		middleware.PanicRecovery(log),
 		middleware.RequestLogger(log, trustedNets),
 		middleware.SecurityHeaders,
-		middleware.HTTPSRedirect(proxyAllowedNets, cfg.Server.Port, cfg.Server.TLSPort, cfg.Server.ForceHTTPSRedirect, log),
+		middleware.HTTPSRedirect(proxyAllowedNets, cfg.Server.Port, cfg.Server.TLSPort, cfg.Server.ForceHTTPSRedirect, log, func(host string) bool {
+			return svc.proxySvc.IsKnownHost(context.Background(), host)
+		}),
 	}
 	if proxyCIDRMiddleware != nil {
 		httpProxyMiddlewares = append(httpProxyMiddlewares, proxyCIDRMiddleware)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -96,6 +96,7 @@ type Config struct {
 		DataDir              string   `mapstructure:"data_dir"`
 		MaxProxyBodySize     string   `mapstructure:"max_proxy_body_size"`     // e.g., "512MB", "1GB"
 		MaxBlobChunkSize     string   `mapstructure:"max_blob_chunk_size"`     // e.g., "512MB", "1GB"
+		MaxBlobSize          string   `mapstructure:"max_blob_size"`           // e.g., "1GB", "2GB"
 		MaxProxyResponseSize string   `mapstructure:"max_proxy_response_size"` // e.g., "1GB", "0" for no limit
 		MaxConcurrentConns   int      `mapstructure:"max_concurrent_connections"`
 		RegistryAllowedIPs   []string `mapstructure:"registry_allowed_ips"`
@@ -215,6 +216,7 @@ type services struct {
 	previewService    *preview.Service
 	envDir            string
 	maxBlobChunkSize  int64
+	maxBlobSize       int64
 	caAdapter         *pkiadapter.CA
 	pkiSvc            *pkiusecase.Service
 	reloadCoordinator *reloadCoordinator
@@ -526,6 +528,7 @@ func (si *serviceInit) initRuntimeAndProxy() error {
 		return err
 	}
 	si.svc.maxBlobChunkSize = proxyCfg.maxBlobChunkSize
+	si.svc.maxBlobSize = proxyCfg.maxBlobSize
 	si.svc.proxySvc = proxy.NewService(si.svc.runtime, si.svc.containerSvc, si.svc.configSvc, proxyCfg.proxyConfig)
 
 	// Wire synchronous proxy cache invalidation for zero-downtime deployments.
@@ -1349,6 +1352,7 @@ func loadSecret(ctx context.Context, backend domain.SecretsBackend, path, dataDi
 type proxyConfigResult struct {
 	proxyConfig      proxy.Config
 	maxBlobChunkSize int64
+	maxBlobSize      int64
 }
 
 type configWatcher interface {
@@ -1477,6 +1481,15 @@ func buildProxyConfig(cfg Config, log zerowrap.Logger) (*proxyConfigResult, erro
 		maxBlobChunkSize = parsedSize
 	}
 
+	maxBlobSize := int64(registry.DefaultMaxBlobSize)
+	if cfg.Server.MaxBlobSize != "" {
+		parsedSize, err := bytesize.Parse(cfg.Server.MaxBlobSize)
+		if err != nil {
+			return nil, log.WrapErrWithFields(err, "invalid server.max_blob_size configuration", map[string]any{"value": cfg.Server.MaxBlobSize})
+		}
+		maxBlobSize = parsedSize
+	}
+
 	maxProxyResponseSize := int64(1 << 30) // 1GB default
 	if cfg.Server.MaxProxyResponseSize != "" {
 		parsedSize, err := bytesize.Parse(cfg.Server.MaxProxyResponseSize)
@@ -1501,6 +1514,7 @@ func buildProxyConfig(cfg Config, log zerowrap.Logger) (*proxyConfigResult, erro
 			MaxConcurrentConns: maxConcurrentConns,
 		},
 		maxBlobChunkSize: maxBlobChunkSize,
+		maxBlobSize:      maxBlobSize,
 	}, nil
 }
 
@@ -1758,8 +1772,8 @@ func createHTTPHandlers(svc *services, cfg Config, log zerowrap.Logger, accessWr
 	// This ensures consistent IP extraction across logging, rate limiting, and auth.
 	trustedNets := httphelper.ParseTrustedProxies(cfg.API.RateLimit.TrustedProxies)
 
-	// Registry handler (unchanged)
-	registryHandler := registry.NewHandler(svc.registrySvc, log, svc.maxBlobChunkSize)
+	// Registry handler
+	registryHandler := registry.NewHandler(svc.registrySvc, log, svc.maxBlobChunkSize, svc.maxBlobSize)
 	registryWithMiddleware, cidrAllowlistMiddleware, rateLimitMiddleware := buildRegistryHandlerWithMiddleware(
 		svc,
 		cfg,

--- a/internal/app/run_auth_config_test.go
+++ b/internal/app/run_auth_config_test.go
@@ -7,12 +7,13 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/bnema/gordon/internal/domain"
 	"github.com/bnema/zerowrap"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestBuildAuthConfig_UsesConfigEnabledFlag(t *testing.T) {

--- a/internal/app/run_auth_config_test.go
+++ b/internal/app/run_auth_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/bnema/gordon/internal/domain"
@@ -11,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestBuildAuthConfig_UsesConfigEnabledFlag(t *testing.T) {
@@ -118,6 +120,20 @@ func TestLoadSecretUnsafeRejectsIntermediateSymlinkEscape(t *testing.T) {
 	_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "linkdir/token", dataDir, zerowrap.Default())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to open secret path component")
+}
+
+func TestLoadSecretUnsafeRejectsNonRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mkfifo is not available on windows")
+	}
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+	require.NoError(t, unix.Mkfifo(filepath.Join(secretsDir, "token"), 0600))
+
+	_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "token", dataDir, zerowrap.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret must be a regular file")
 }
 
 func TestLoadSecretUnsafeRejectsSymlinkEscape(t *testing.T) {

--- a/internal/app/run_auth_config_test.go
+++ b/internal/app/run_auth_config_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bnema/gordon/internal/domain"
@@ -64,4 +66,69 @@ func TestLoadConfig_DoesNotDefaultSecretsBackendToUnsafe(t *testing.T) {
 	err := loadConfig(v, "")
 	require.NoError(t, err)
 	assert.Empty(t, v.GetString("auth.secrets_backend"), "expected empty default for auth.secrets_backend")
+}
+
+func TestLoadSecretUnsafeRejectsTraversalAndAbsolutePaths(t *testing.T) {
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(secretsDir, "token"), []byte("safe-secret"), 0600))
+	outside := filepath.Join(dataDir, "outside")
+	require.NoError(t, os.WriteFile(outside, []byte("outside-secret"), 0600))
+
+	for _, path := range []string{"../outside", filepath.Join(dataDir, "outside")} {
+		t.Run(path, func(t *testing.T) {
+			_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, path, dataDir, zerowrap.Default())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid secret path")
+		})
+	}
+}
+
+func TestLoadSecretUnsafeAllowsRelativePathUnderSecretsDir(t *testing.T) {
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets", "auth")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(secretsDir, "token"), []byte("safe-secret"), 0600))
+
+	secret, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "auth/token", dataDir, zerowrap.Default())
+	require.NoError(t, err)
+	assert.Equal(t, "safe-secret", secret)
+}
+
+func TestLoadSecretUnsafeRejectsMissingCandidate(t *testing.T) {
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+
+	_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "missing", dataDir, zerowrap.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read secret file")
+}
+
+func TestLoadSecretUnsafeRejectsIntermediateSymlinkEscape(t *testing.T) {
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets")
+	outsideDir := filepath.Join(dataDir, "outside")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+	require.NoError(t, os.MkdirAll(outsideDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "token"), []byte("outside-secret"), 0600))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(secretsDir, "linkdir")))
+
+	_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "linkdir/token", dataDir, zerowrap.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open secret path component")
+}
+
+func TestLoadSecretUnsafeRejectsSymlinkEscape(t *testing.T) {
+	dataDir := t.TempDir()
+	secretsDir := filepath.Join(dataDir, "secrets")
+	require.NoError(t, os.MkdirAll(secretsDir, 0700))
+	outside := filepath.Join(dataDir, "outside")
+	require.NoError(t, os.WriteFile(outside, []byte("outside-secret"), 0600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(secretsDir, "token")))
+
+	_, err := loadSecret(context.Background(), domain.SecretsBackendUnsafe, "token", dataDir, zerowrap.Default())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read secret file")
 }

--- a/internal/app/run_reload_test.go
+++ b/internal/app/run_reload_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bnema/gordon/internal/adapters/in/http/registry"
 	"github.com/bnema/gordon/internal/domain"
 	"github.com/bnema/gordon/internal/usecase/proxy"
 )
@@ -136,6 +137,24 @@ func TestSetupConfigHotReload_WatchCallbackInvokesCoordinator(t *testing.T) {
 	configSvc.onChange()
 	require.Equal(t, 1, coordinator.ApplyCalls())
 	require.Equal(t, 0, coordinator.TriggerCalls())
+}
+
+func TestBuildProxyConfig_ParsesMaxBlobSizeWithoutChangingChunkDefault(t *testing.T) {
+	cfg := Config{}
+	cfg.Server.MaxBlobSize = "2GB"
+
+	result, err := buildProxyConfig(cfg, zerowrap.Default())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(2<<30), result.maxBlobSize)
+	assert.Equal(t, int64(registry.DefaultMaxBlobChunkSize), result.maxBlobChunkSize)
+}
+
+func TestBuildProxyConfig_DefaultMaxBlobSize(t *testing.T) {
+	result, err := buildProxyConfig(Config{}, zerowrap.Default())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(registry.DefaultMaxBlobSize), result.maxBlobSize)
 }
 
 func TestReloadCoordinator_ApplyLoadedConfig_RebuildsProxyConfigAndPublishesEvent(t *testing.T) {

--- a/internal/app/run_reload_test.go
+++ b/internal/app/run_reload_test.go
@@ -100,6 +100,18 @@ func (p *proxyRecorder) UpdateConfig(config proxy.Config) {
 	p.config = config
 }
 
+type registryLimitsRecorder struct {
+	calls            int
+	maxBlobChunkSize int64
+	maxBlobSize      int64
+}
+
+func (r *registryLimitsRecorder) UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64) {
+	r.calls++
+	r.maxBlobChunkSize = maxBlobChunkSize
+	r.maxBlobSize = maxBlobSize
+}
+
 type eventBusRecorder struct {
 	mu        sync.Mutex
 	calls     int
@@ -164,6 +176,7 @@ func TestReloadCoordinator_ApplyLoadedConfig_RebuildsProxyConfigAndPublishesEven
 	v.Set("server.registry_port", 5000)
 	v.Set("server.max_proxy_body_size", "5MB")
 	v.Set("server.max_blob_chunk_size", "6MB")
+	v.Set("server.max_blob_size", "8MB")
 	v.Set("server.max_proxy_response_size", "7MB")
 	v.Set("server.max_concurrent_connections", 99)
 
@@ -171,12 +184,16 @@ func TestReloadCoordinator_ApplyLoadedConfig_RebuildsProxyConfigAndPublishesEven
 	proxySvc := &proxyRecorder{}
 	events := &eventBusRecorder{}
 
-	coord := newReloadCoordinator(v, reloadSvc, proxySvc, events, zerowrap.Default())
+	registryLimits := &registryLimitsRecorder{}
+	coord := newReloadCoordinator(v, reloadSvc, proxySvc, registryLimits, events, zerowrap.Default())
 	require.NoError(t, coord.ApplyLoadedConfig(ctx))
 
 	require.Equal(t, 0, reloadSvc.Calls())
 	require.Equal(t, 1, proxySvc.calls)
 	require.Equal(t, 1, events.Calls())
+	require.Equal(t, 1, registryLimits.calls)
+	require.Equal(t, int64(6<<20), registryLimits.maxBlobChunkSize)
+	require.Equal(t, int64(8<<20), registryLimits.maxBlobSize)
 	require.Equal(t, domain.EventConfigReload, events.eventType)
 	require.Equal(t, proxy.Config{
 		RegistryDomain:     "reload.example.com",
@@ -194,6 +211,7 @@ func TestReloadCoordinator_DebouncesRepeatedWatchCallbacks(t *testing.T) {
 	v.Set("server.registry_port", 5000)
 	v.Set("server.max_proxy_body_size", "5MB")
 	v.Set("server.max_blob_chunk_size", "6MB")
+	v.Set("server.max_blob_size", "8MB")
 	v.Set("server.max_proxy_response_size", "7MB")
 	v.Set("server.max_concurrent_connections", 99)
 
@@ -201,13 +219,17 @@ func TestReloadCoordinator_DebouncesRepeatedWatchCallbacks(t *testing.T) {
 	proxySvc := &proxyRecorder{}
 	events := &eventBusRecorder{}
 
-	coord := newReloadCoordinator(v, reloadSvc, proxySvc, events, zerowrap.Default())
+	registryLimits := &registryLimitsRecorder{}
+	coord := newReloadCoordinator(v, reloadSvc, proxySvc, registryLimits, events, zerowrap.Default())
 	require.NoError(t, coord.Trigger(ctx))
 	require.NoError(t, coord.Trigger(ctx))
 
 	require.Equal(t, 1, reloadSvc.Calls())
 	require.Equal(t, 1, proxySvc.calls)
 	require.Equal(t, 1, events.Calls())
+	require.Equal(t, 1, registryLimits.calls)
+	require.Equal(t, int64(6<<20), registryLimits.maxBlobChunkSize)
+	require.Equal(t, int64(8<<20), registryLimits.maxBlobSize)
 	require.Equal(t, domain.EventConfigReload, events.eventType)
 	require.Equal(t, proxy.Config{
 		RegistryDomain:     "new.example.com",
@@ -231,7 +253,7 @@ func TestReloadCoordinator_RetriesImmediatelyAfterFailedReload(t *testing.T) {
 	reloadErr := errors.New("reload failed")
 	reloadSvc := &reloadRecorder{err: reloadErr}
 	proxySvc := &proxyRecorder{}
-	coord := newReloadCoordinator(v, reloadSvc, proxySvc, nil, zerowrap.Default())
+	coord := newReloadCoordinator(v, reloadSvc, proxySvc, nil, nil, zerowrap.Default())
 
 	err := coord.Trigger(ctx)
 	require.ErrorIs(t, err, reloadErr)
@@ -260,7 +282,7 @@ func TestReloadCoordinator_PublishErrorDoesNotAdvanceDebounceState(t *testing.T)
 	proxySvc := &proxyRecorder{}
 	events := &eventBusRecorder{err: publishErr}
 
-	coord := newReloadCoordinator(v, reloadSvc, proxySvc, events, zerowrap.Default())
+	coord := newReloadCoordinator(v, reloadSvc, proxySvc, nil, events, zerowrap.Default())
 
 	err := coord.Trigger(ctx)
 	require.ErrorIs(t, err, publishErr)
@@ -292,7 +314,7 @@ func TestReloadCoordinator_SerializesOverlappingReloadRequests(t *testing.T) {
 		<-release
 	}}
 	proxySvc := &proxyRecorder{}
-	coord := newReloadCoordinator(v, reloadSvc, proxySvc, nil, zerowrap.Default())
+	coord := newReloadCoordinator(v, reloadSvc, proxySvc, nil, nil, zerowrap.Default())
 
 	firstDone := make(chan struct{})
 	go func() {

--- a/internal/boundaries/in/mocks/mock_proxy_service.go
+++ b/internal/boundaries/in/mocks/mock_proxy_service.go
@@ -107,6 +107,63 @@ func (_c *MockProxyService_GetTarget_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// IsKnownHost provides a mock function for the type MockProxyService
+func (_mock *MockProxyService) IsKnownHost(ctx context.Context, host string) bool {
+	ret := _mock.Called(ctx, host)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsKnownHost")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, host)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockProxyService_IsKnownHost_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsKnownHost'
+type MockProxyService_IsKnownHost_Call struct {
+	*mock.Call
+}
+
+// IsKnownHost is a helper method to define mock.On call
+//   - ctx context.Context
+//   - host string
+func (_e *MockProxyService_Expecter) IsKnownHost(ctx interface{}, host interface{}) *MockProxyService_IsKnownHost_Call {
+	return &MockProxyService_IsKnownHost_Call{Call: _e.mock.On("IsKnownHost", ctx, host)}
+}
+
+func (_c *MockProxyService_IsKnownHost_Call) Run(run func(ctx context.Context, host string)) *MockProxyService_IsKnownHost_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockProxyService_IsKnownHost_Call) Return(b bool) *MockProxyService_IsKnownHost_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockProxyService_IsKnownHost_Call) RunAndReturn(run func(ctx context.Context, host string) bool) *MockProxyService_IsKnownHost_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsRegistryDomain provides a mock function for the type MockProxyService
 func (_mock *MockProxyService) IsRegistryDomain(host string) bool {
 	ret := _mock.Called(host)

--- a/internal/boundaries/in/mocks/mock_registry_service.go
+++ b/internal/boundaries/in/mocks/mock_registry_service.go
@@ -40,8 +40,8 @@ func (_m *MockRegistryService) EXPECT() *MockRegistryService_Expecter {
 }
 
 // AppendBlobChunk provides a mock function for the type MockRegistryService
-func (_mock *MockRegistryService) AppendBlobChunk(ctx context.Context, name string, uuid string, data io.Reader) (int64, error) {
-	ret := _mock.Called(ctx, name, uuid, data)
+func (_mock *MockRegistryService) AppendBlobChunk(ctx context.Context, name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64) (int64, error) {
+	ret := _mock.Called(ctx, name, uuid, data, contentLength, maxBlobSize)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AppendBlobChunk")
@@ -49,16 +49,16 @@ func (_mock *MockRegistryService) AppendBlobChunk(ctx context.Context, name stri
 
 	var r0 int64
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, io.Reader) (int64, error)); ok {
-		return returnFunc(ctx, name, uuid, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, io.Reader, int64, int64) (int64, error)); ok {
+		return returnFunc(ctx, name, uuid, data, contentLength, maxBlobSize)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, io.Reader) int64); ok {
-		r0 = returnFunc(ctx, name, uuid, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, io.Reader, int64, int64) int64); ok {
+		r0 = returnFunc(ctx, name, uuid, data, contentLength, maxBlobSize)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, io.Reader) error); ok {
-		r1 = returnFunc(ctx, name, uuid, data)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, io.Reader, int64, int64) error); ok {
+		r1 = returnFunc(ctx, name, uuid, data, contentLength, maxBlobSize)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -75,11 +75,13 @@ type MockRegistryService_AppendBlobChunk_Call struct {
 //   - name string
 //   - uuid string
 //   - data io.Reader
-func (_e *MockRegistryService_Expecter) AppendBlobChunk(ctx interface{}, name interface{}, uuid interface{}, data interface{}) *MockRegistryService_AppendBlobChunk_Call {
-	return &MockRegistryService_AppendBlobChunk_Call{Call: _e.mock.On("AppendBlobChunk", ctx, name, uuid, data)}
+//   - contentLength int64
+//   - maxBlobSize int64
+func (_e *MockRegistryService_Expecter) AppendBlobChunk(ctx interface{}, name interface{}, uuid interface{}, data interface{}, contentLength interface{}, maxBlobSize interface{}) *MockRegistryService_AppendBlobChunk_Call {
+	return &MockRegistryService_AppendBlobChunk_Call{Call: _e.mock.On("AppendBlobChunk", ctx, name, uuid, data, contentLength, maxBlobSize)}
 }
 
-func (_c *MockRegistryService_AppendBlobChunk_Call) Run(run func(ctx context.Context, name string, uuid string, data io.Reader)) *MockRegistryService_AppendBlobChunk_Call {
+func (_c *MockRegistryService_AppendBlobChunk_Call) Run(run func(ctx context.Context, name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64)) *MockRegistryService_AppendBlobChunk_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -97,11 +99,21 @@ func (_c *MockRegistryService_AppendBlobChunk_Call) Run(run func(ctx context.Con
 		if args[3] != nil {
 			arg3 = args[3].(io.Reader)
 		}
+		var arg4 int64
+		if args[4] != nil {
+			arg4 = args[4].(int64)
+		}
+		var arg5 int64
+		if args[5] != nil {
+			arg5 = args[5].(int64)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -112,7 +124,7 @@ func (_c *MockRegistryService_AppendBlobChunk_Call) Return(n int64, err error) *
 	return _c
 }
 
-func (_c *MockRegistryService_AppendBlobChunk_Call) RunAndReturn(run func(ctx context.Context, name string, uuid string, data io.Reader) (int64, error)) *MockRegistryService_AppendBlobChunk_Call {
+func (_c *MockRegistryService_AppendBlobChunk_Call) RunAndReturn(run func(ctx context.Context, name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64) (int64, error)) *MockRegistryService_AppendBlobChunk_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/in/proxy.go
+++ b/internal/boundaries/in/proxy.go
@@ -24,6 +24,9 @@ type ProxyService interface {
 	// IsRegistryDomain returns true if the host matches the configured registry domain.
 	IsRegistryDomain(host string) bool
 
+	// IsKnownHost returns true if the host is configured as registry, route, or external route.
+	IsKnownHost(ctx context.Context, host string) bool
+
 	// TrackInFlight records an in-flight request for a container.
 	// Returns a release function that must be called when the request completes.
 	TrackInFlight(containerID string) func()

--- a/internal/boundaries/in/registry.go
+++ b/internal/boundaries/in/registry.go
@@ -22,7 +22,7 @@ type RegistryService interface {
 
 	// Upload operations
 	StartUpload(ctx context.Context, name string) (string, error)
-	AppendBlobChunk(ctx context.Context, name, uuid string, data io.Reader) (int64, error)
+	AppendBlobChunk(ctx context.Context, name, uuid string, data io.Reader, contentLength, maxBlobSize int64) (int64, error)
 	FinishUpload(ctx context.Context, uuid, digest string) error
 	CancelUpload(ctx context.Context, uuid string) error
 

--- a/internal/boundaries/out/mocks/mock_blob_storage.go
+++ b/internal/boundaries/out/mocks/mock_blob_storage.go
@@ -39,8 +39,8 @@ func (_m *MockBlobStorage) EXPECT() *MockBlobStorage_Expecter {
 }
 
 // AppendBlobChunk provides a mock function for the type MockBlobStorage
-func (_mock *MockBlobStorage) AppendBlobChunk(name string, uuid string, data io.Reader) (int64, error) {
-	ret := _mock.Called(name, uuid, data)
+func (_mock *MockBlobStorage) AppendBlobChunk(name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64) (int64, error) {
+	ret := _mock.Called(name, uuid, data, contentLength, maxBlobSize)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AppendBlobChunk")
@@ -48,16 +48,16 @@ func (_mock *MockBlobStorage) AppendBlobChunk(name string, uuid string, data io.
 
 	var r0 int64
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, io.Reader) (int64, error)); ok {
-		return returnFunc(name, uuid, data)
+	if returnFunc, ok := ret.Get(0).(func(string, string, io.Reader, int64, int64) (int64, error)); ok {
+		return returnFunc(name, uuid, data, contentLength, maxBlobSize)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, io.Reader) int64); ok {
-		r0 = returnFunc(name, uuid, data)
+	if returnFunc, ok := ret.Get(0).(func(string, string, io.Reader, int64, int64) int64); ok {
+		r0 = returnFunc(name, uuid, data, contentLength, maxBlobSize)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, io.Reader) error); ok {
-		r1 = returnFunc(name, uuid, data)
+	if returnFunc, ok := ret.Get(1).(func(string, string, io.Reader, int64, int64) error); ok {
+		r1 = returnFunc(name, uuid, data, contentLength, maxBlobSize)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -73,11 +73,13 @@ type MockBlobStorage_AppendBlobChunk_Call struct {
 //   - name string
 //   - uuid string
 //   - data io.Reader
-func (_e *MockBlobStorage_Expecter) AppendBlobChunk(name interface{}, uuid interface{}, data interface{}) *MockBlobStorage_AppendBlobChunk_Call {
-	return &MockBlobStorage_AppendBlobChunk_Call{Call: _e.mock.On("AppendBlobChunk", name, uuid, data)}
+//   - contentLength int64
+//   - maxBlobSize int64
+func (_e *MockBlobStorage_Expecter) AppendBlobChunk(name interface{}, uuid interface{}, data interface{}, contentLength interface{}, maxBlobSize interface{}) *MockBlobStorage_AppendBlobChunk_Call {
+	return &MockBlobStorage_AppendBlobChunk_Call{Call: _e.mock.On("AppendBlobChunk", name, uuid, data, contentLength, maxBlobSize)}
 }
 
-func (_c *MockBlobStorage_AppendBlobChunk_Call) Run(run func(name string, uuid string, data io.Reader)) *MockBlobStorage_AppendBlobChunk_Call {
+func (_c *MockBlobStorage_AppendBlobChunk_Call) Run(run func(name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64)) *MockBlobStorage_AppendBlobChunk_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -91,10 +93,20 @@ func (_c *MockBlobStorage_AppendBlobChunk_Call) Run(run func(name string, uuid s
 		if args[2] != nil {
 			arg2 = args[2].(io.Reader)
 		}
+		var arg3 int64
+		if args[3] != nil {
+			arg3 = args[3].(int64)
+		}
+		var arg4 int64
+		if args[4] != nil {
+			arg4 = args[4].(int64)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -105,7 +117,7 @@ func (_c *MockBlobStorage_AppendBlobChunk_Call) Return(n int64, err error) *Mock
 	return _c
 }
 
-func (_c *MockBlobStorage_AppendBlobChunk_Call) RunAndReturn(run func(name string, uuid string, data io.Reader) (int64, error)) *MockBlobStorage_AppendBlobChunk_Call {
+func (_c *MockBlobStorage_AppendBlobChunk_Call) RunAndReturn(run func(name string, uuid string, data io.Reader, contentLength int64, maxBlobSize int64) (int64, error)) *MockBlobStorage_AppendBlobChunk_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/out/mocks/mock_container_runtime.go
+++ b/internal/boundaries/out/mocks/mock_container_runtime.go
@@ -246,16 +246,16 @@ func (_c *MockContainerRuntime_CreateContainer_Call) RunAndReturn(run func(ctx c
 }
 
 // CreateNetwork provides a mock function for the type MockContainerRuntime
-func (_mock *MockContainerRuntime) CreateNetwork(ctx context.Context, name string, options map[string]string) error {
-	ret := _mock.Called(ctx, name, options)
+func (_mock *MockContainerRuntime) CreateNetwork(ctx context.Context, name string, config domain.NetworkConfig) error {
+	ret := _mock.Called(ctx, name, config)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateNetwork")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]string) error); ok {
-		r0 = returnFunc(ctx, name, options)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, domain.NetworkConfig) error); ok {
+		r0 = returnFunc(ctx, name, config)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -270,12 +270,12 @@ type MockContainerRuntime_CreateNetwork_Call struct {
 // CreateNetwork is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - options map[string]string
-func (_e *MockContainerRuntime_Expecter) CreateNetwork(ctx interface{}, name interface{}, options interface{}) *MockContainerRuntime_CreateNetwork_Call {
-	return &MockContainerRuntime_CreateNetwork_Call{Call: _e.mock.On("CreateNetwork", ctx, name, options)}
+//   - config domain.NetworkConfig
+func (_e *MockContainerRuntime_Expecter) CreateNetwork(ctx interface{}, name interface{}, config interface{}) *MockContainerRuntime_CreateNetwork_Call {
+	return &MockContainerRuntime_CreateNetwork_Call{Call: _e.mock.On("CreateNetwork", ctx, name, config)}
 }
 
-func (_c *MockContainerRuntime_CreateNetwork_Call) Run(run func(ctx context.Context, name string, options map[string]string)) *MockContainerRuntime_CreateNetwork_Call {
+func (_c *MockContainerRuntime_CreateNetwork_Call) Run(run func(ctx context.Context, name string, config domain.NetworkConfig)) *MockContainerRuntime_CreateNetwork_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -285,9 +285,9 @@ func (_c *MockContainerRuntime_CreateNetwork_Call) Run(run func(ctx context.Cont
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 map[string]string
+		var arg2 domain.NetworkConfig
 		if args[2] != nil {
-			arg2 = args[2].(map[string]string)
+			arg2 = args[2].(domain.NetworkConfig)
 		}
 		run(
 			arg0,
@@ -303,7 +303,7 @@ func (_c *MockContainerRuntime_CreateNetwork_Call) Return(err error) *MockContai
 	return _c
 }
 
-func (_c *MockContainerRuntime_CreateNetwork_Call) RunAndReturn(run func(ctx context.Context, name string, options map[string]string) error) *MockContainerRuntime_CreateNetwork_Call {
+func (_c *MockContainerRuntime_CreateNetwork_Call) RunAndReturn(run func(ctx context.Context, name string, config domain.NetworkConfig) error) *MockContainerRuntime_CreateNetwork_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/out/runtime.go
+++ b/internal/boundaries/out/runtime.go
@@ -70,7 +70,7 @@ type ContainerRuntime interface {
 	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, error)
 
 	// Network management
-	CreateNetwork(ctx context.Context, name string, options map[string]string) error
+	CreateNetwork(ctx context.Context, name string, config domain.NetworkConfig) error
 	RemoveNetwork(ctx context.Context, name string) error
 	ListNetworks(ctx context.Context) ([]*domain.NetworkInfo, error)
 	NetworkExists(ctx context.Context, name string) (bool, error)

--- a/internal/boundaries/out/storage.go
+++ b/internal/boundaries/out/storage.go
@@ -30,7 +30,7 @@ type BlobStorage interface {
 	StartBlobUpload(name string) (string, error)
 
 	// AppendBlobChunk appends data to an in-progress upload.
-	AppendBlobChunk(name, uuid string, data io.Reader) (int64, error)
+	AppendBlobChunk(name, uuid string, data io.Reader, contentLength, maxBlobSize int64) (int64, error)
 
 	// GetBlobUpload returns a writer for the upload.
 	GetBlobUpload(uuid string) (io.WriteCloser, error)

--- a/internal/domain/auth.go
+++ b/internal/domain/auth.go
@@ -79,6 +79,7 @@ const (
 	AdminResourceSecrets = "secrets"
 	AdminResourceConfig  = "config"
 	AdminResourceStatus  = "status"
+	AdminResourceLogs    = "logs"
 	AdminResourceAll     = "*"
 )
 
@@ -300,6 +301,11 @@ func AdminScopeConfig(actions ...string) string {
 // AdminScopeStatus creates an admin scope for status with the given actions.
 func AdminScopeStatus(actions ...string) string {
 	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceStatus, strings.Join(actions, ","))
+}
+
+// AdminScopeLogs creates an admin scope for logs with the given actions.
+func AdminScopeLogs(actions ...string) string {
+	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceLogs, strings.Join(actions, ","))
 }
 
 // AuthStatus represents status of an authentication session.

--- a/internal/domain/auth.go
+++ b/internal/domain/auth.go
@@ -80,6 +80,7 @@ const (
 	AdminResourceConfig  = "config"
 	AdminResourceStatus  = "status"
 	AdminResourceLogs    = "logs"
+	AdminResourceVolumes = "volumes"
 	AdminResourceAll     = "*"
 )
 
@@ -167,7 +168,7 @@ func (s *Scope) IsRepositoryScope() bool {
 // AdminScope represents an admin API scope (admin:resource:actions).
 // Format: admin:routes:read,write or admin:*:* for full access.
 type AdminScope struct {
-	Resource string   // routes, secrets, config, status, or *
+	Resource string   // routes, secrets, config, status, logs, volumes, or *
 	Actions  []string // read, write, or *
 }
 
@@ -306,6 +307,11 @@ func AdminScopeStatus(actions ...string) string {
 // AdminScopeLogs creates an admin scope for logs with the given actions.
 func AdminScopeLogs(actions ...string) string {
 	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceLogs, strings.Join(actions, ","))
+}
+
+// AdminScopeVolumes creates an admin scope for volumes with the given actions.
+func AdminScopeVolumes(actions ...string) string {
+	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceVolumes, strings.Join(actions, ","))
 }
 
 // AuthStatus represents status of an authentication session.

--- a/internal/domain/auth_test.go
+++ b/internal/domain/auth_test.go
@@ -513,6 +513,13 @@ func TestScopesGrantAdminAccess(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "volumes read grants volumes resource",
+			granted:  []string{"admin:volumes:read"},
+			resource: AdminResourceVolumes,
+			action:   AdminActionRead,
+			want:     true,
+		},
+		{
 			name:     "repository scope is ignored for admin access",
 			granted:  []string{"repository:myrepo:push"},
 			resource: "routes",

--- a/internal/domain/auth_test.go
+++ b/internal/domain/auth_test.go
@@ -492,6 +492,27 @@ func TestScopesGrantAdminAccess(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "logs read grants logs resource",
+			granted:  []string{"admin:logs:read"},
+			resource: AdminResourceLogs,
+			action:   AdminActionRead,
+			want:     true,
+		},
+		{
+			name:     "status read does not grant logs resource",
+			granted:  []string{"admin:status:read"},
+			resource: AdminResourceLogs,
+			action:   AdminActionRead,
+			want:     false,
+		},
+		{
+			name:     "full admin wildcard grants logs resource",
+			granted:  []string{"admin:*:*"},
+			resource: AdminResourceLogs,
+			action:   AdminActionRead,
+			want:     true,
+		},
+		{
 			name:     "repository scope is ignored for admin access",
 			granted:  []string{"repository:myrepo:push"},
 			resource: "routes",

--- a/internal/domain/container.go
+++ b/internal/domain/container.go
@@ -26,6 +26,13 @@ type NetworkInfo struct {
 	Labels     map[string]string
 }
 
+// NetworkConfig holds options for creating a container network.
+type NetworkConfig struct {
+	Driver   string
+	Internal bool
+	Labels   map[string]string
+}
+
 // Attachment represents an attached service container.
 type Attachment struct {
 	Name        string
@@ -64,6 +71,10 @@ type ContainerConfig struct {
 	MemoryLimit     int64             // Memory limit in bytes (0 = no limit)
 	NanoCPUs        int64             // CPU quota in nanoseconds (1e9 = 1 core, 0 = no limit)
 	PidsLimit       int64             // Max number of PIDs (0 = no limit)
+	ReadOnlyRootFS  bool              // Mount container root filesystem read-only
+	User            string            // User to run as
+	CapDrop         []string          // Linux capabilities to drop; nil uses runtime compat defaults
+	CapAdd          []string          // Linux capabilities to add; nil uses runtime compat defaults
 }
 
 // ContainerStatus represents the current state of a container.

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -57,6 +57,7 @@ var (
 	// Environment errors
 	ErrEnvFileNotFound      = errors.New("environment file not found")
 	ErrSecretNotFound       = errors.New("secret not found")
+	ErrSecretsAlreadyExist  = errors.New("secrets already exist")
 	ErrProviderNotFound     = errors.New("secret provider not found")
 	ErrInvalidContainerName = errors.New("invalid container name")
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrInvalidDigest    = errors.New("invalid digest")
 	ErrDigestMismatch   = errors.New("digest mismatch")
 	ErrUnauthorized     = errors.New("unauthorized")
+	ErrBlobSizeExceeded = errors.New("blob size exceeds maximum")
 
 	// Network errors
 	ErrNetworkNotFound = errors.New("network not found")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -52,6 +52,7 @@ var (
 	ErrInvalidConfig        = errors.New("invalid configuration")
 	ErrConfigLoadFailed     = errors.New("failed to load configuration")
 	ErrInvalidDomainPattern = errors.New("invalid domain pattern")
+	ErrRouteConflict        = errors.New("route conflicts with existing configuration")
 
 	// Environment errors
 	ErrEnvFileNotFound      = errors.New("environment file not found")

--- a/internal/domain/redact.go
+++ b/internal/domain/redact.go
@@ -11,7 +11,7 @@ const secretKeyPattern = `[A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|API[_-]?KEY|DATABAS
 
 var secretValuePatterns = []secretRedactionPattern{
 	{
-		re:   regexp.MustCompile(`(?i)(\b` + secretKeyPattern + `\b\s*=\s*)([^\s]+)`),
+		re:   regexp.MustCompile(`(?i)(\b` + secretKeyPattern + `\b\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s]+)`),
 		repl: `${1}[REDACTED]`,
 	},
 	{
@@ -35,7 +35,7 @@ func RedactSecrets(line string) string {
 
 // RedactSecretLines redacts common secret values from log or diagnostic lines.
 func RedactSecretLines(lines []string) []string {
-	if len(lines) == 0 {
+	if lines == nil {
 		return nil
 	}
 	redacted := make([]string, len(lines))

--- a/internal/domain/redact.go
+++ b/internal/domain/redact.go
@@ -11,11 +11,11 @@ const secretKeyPattern = `[A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|API[_-]?KEY|DATABAS
 
 var secretValuePatterns = []secretRedactionPattern{
 	{
-		re:   regexp.MustCompile(`(?i)(\b` + secretKeyPattern + `\b\s*=\s*)(?:"[^"]*"|'[^']*'|[^\s]+)`),
+		re:   regexp.MustCompile(`(?i)(\b` + secretKeyPattern + `\b\s*=\s*)(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|[^\s]+)`),
 		repl: `${1}[REDACTED]`,
 	},
 	{
-		re:   regexp.MustCompile(`(?i)("` + secretKeyPattern + `"\s*:\s*")([^"]*)(")`),
+		re:   regexp.MustCompile(`(?i)("` + secretKeyPattern + `"\s*:\s*")((?:\\.|[^"])*)(")`),
 		repl: `${1}[REDACTED]${3}`,
 	},
 	{

--- a/internal/domain/redact.go
+++ b/internal/domain/redact.go
@@ -1,0 +1,46 @@
+package domain
+
+import "regexp"
+
+type secretRedactionPattern struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+const secretKeyPattern = `[A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|API[_-]?KEY|DATABASE[_-]?URL)[A-Z0-9_]*` //nolint:gosec // Regex pattern for secret-like key names, not a credential.
+
+var secretValuePatterns = []secretRedactionPattern{
+	{
+		re:   regexp.MustCompile(`(?i)(\b` + secretKeyPattern + `\b\s*=\s*)([^\s]+)`),
+		repl: `${1}[REDACTED]`,
+	},
+	{
+		re:   regexp.MustCompile(`(?i)("` + secretKeyPattern + `"\s*:\s*")([^"]*)(")`),
+		repl: `${1}[REDACTED]${3}`,
+	},
+	{
+		re:   regexp.MustCompile(`(?i)(\bAuthorization\s*:\s*Bearer\s+)([^\s]+)`),
+		repl: `${1}[REDACTED]`,
+	},
+}
+
+// RedactSecrets redacts common secret values from a single log or diagnostic line.
+func RedactSecrets(line string) string {
+	redacted := line
+	for _, pattern := range secretValuePatterns {
+		redacted = pattern.re.ReplaceAllString(redacted, pattern.repl)
+	}
+	return redacted
+}
+
+// RedactSecretLines redacts common secret values from log or diagnostic lines.
+func RedactSecretLines(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	redacted := make([]string, len(lines))
+	for i, line := range lines {
+		redacted[i] = RedactSecrets(line)
+	}
+	return redacted
+}

--- a/internal/domain/redact_test.go
+++ b/internal/domain/redact_test.go
@@ -17,6 +17,8 @@ func TestRedactSecrets(t *testing.T) {
 		{"secret env", "SECRET=shh", "SECRET=[REDACTED]"},
 		{"api key env", "API_KEY=key-value", "API_KEY=[REDACTED]"},
 		{"database url env", "DATABASE_URL=postgres://user:pass@db/app", "DATABASE_URL=[REDACTED]"},
+		{"quoted password env with spaces", `PASSWORD="hunter 2"`, "PASSWORD=[REDACTED]"},
+		{"single quoted token env with spaces", `TOKEN='abc 123'`, "TOKEN=[REDACTED]"},
 		{"json password field", `{"PASSWORD":"hunter2","ok":"value"}`, `{"PASSWORD":"[REDACTED]","ok":"value"}`},
 		{"json token field with spaces", `{"TOKEN": "abc123"}`, `{"TOKEN": "[REDACTED]"}`},
 		{"case insensitive", "database_url=postgres://user:pass@db/app", "database_url=[REDACTED]"},
@@ -34,4 +36,10 @@ func TestRedactSecrets(t *testing.T) {
 			assert.Equal(t, tt.want, RedactSecrets(tt.in))
 		})
 	}
+}
+
+func TestRedactSecretLinesPreservesEmptySlice(t *testing.T) {
+	assert.Nil(t, RedactSecretLines(nil))
+	assert.Empty(t, RedactSecretLines([]string{}))
+	assert.NotNil(t, RedactSecretLines([]string{}))
 }

--- a/internal/domain/redact_test.go
+++ b/internal/domain/redact_test.go
@@ -1,0 +1,37 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"password env", "PASSWORD=hunter2", "PASSWORD=[REDACTED]"},
+		{"token env", "TOKEN=abc123", "TOKEN=[REDACTED]"},
+		{"secret env", "SECRET=shh", "SECRET=[REDACTED]"},
+		{"api key env", "API_KEY=key-value", "API_KEY=[REDACTED]"},
+		{"database url env", "DATABASE_URL=postgres://user:pass@db/app", "DATABASE_URL=[REDACTED]"},
+		{"json password field", `{"PASSWORD":"hunter2","ok":"value"}`, `{"PASSWORD":"[REDACTED]","ok":"value"}`},
+		{"json token field with spaces", `{"TOKEN": "abc123"}`, `{"TOKEN": "[REDACTED]"}`},
+		{"case insensitive", "database_url=postgres://user:pass@db/app", "database_url=[REDACTED]"},
+		{"prefixed password env", "POSTGRES_PASSWORD=hunter2", "POSTGRES_PASSWORD=[REDACTED]"},
+		{"prefixed token env", "GORDON_TOKEN=abc123", "GORDON_TOKEN=[REDACTED]"},
+		{"secret key env", "SECRET_KEY=shh", "SECRET_KEY=[REDACTED]"},
+		{"api token env", "API_TOKEN=abc123", "API_TOKEN=[REDACTED]"},
+		{"authorization bearer", "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.secret", "Authorization: Bearer [REDACTED]"},
+		{"json prefixed password field", `{"POSTGRES_PASSWORD":"hunter2"}`, `{"POSTGRES_PASSWORD":"[REDACTED]"}`},
+		{"json secret key field", `{"secret_key": "shh"}`, `{"secret_key": "[REDACTED]"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RedactSecrets(tt.in))
+		})
+	}
+}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -17,6 +17,14 @@ var hostnamePattern = regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
 //
 // Valid: app.example.com, api.site.org, my-app.co.uk
 // Invalid: 192.168.1.1, localhost, myapp.local, example.com:8080
+func CanonicalRouteDomain(domainName string) (string, bool) {
+	canonical := strings.ToLower(strings.TrimSpace(domainName))
+	if !IsValidRouteDomain(canonical) {
+		return "", false
+	}
+	return canonical, true
+}
+
 func IsValidRouteDomain(domain string) bool {
 	// Reject empty
 	if domain == "" {

--- a/internal/testutils/mocks/runtime_gen.go
+++ b/internal/testutils/mocks/runtime_gen.go
@@ -72,9 +72,9 @@ func (mr *MockRuntimeMockRecorder) CreateContainer(ctx, config any) *gomock.Call
 }
 
 // CreateNetwork mocks base method.
-func (m *MockRuntime) CreateNetwork(ctx context.Context, name string, options map[string]string) error {
+func (m *MockRuntime) CreateNetwork(ctx context.Context, name string, config runtime.NetworkConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNetwork", ctx, name, options)
+	ret := m.ctrl.Call(m, "CreateNetwork", ctx, name, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/internal/testutils/mocks/runtime_gen.go
+++ b/internal/testutils/mocks/runtime_gen.go
@@ -72,9 +72,9 @@ func (mr *MockRuntimeMockRecorder) CreateContainer(ctx, config any) *gomock.Call
 }
 
 // CreateNetwork mocks base method.
-func (m *MockRuntime) CreateNetwork(ctx context.Context, name string, config runtime.NetworkConfig) error {
+func (m *MockRuntime) CreateNetwork(ctx context.Context, name string, options map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNetwork", ctx, name, config)
+	ret := m.ctrl.Call(m, "CreateNetwork", ctx, name, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/internal/usecase/backup/integration_test.go
+++ b/internal/usecase/backup/integration_test.go
@@ -47,7 +47,7 @@ func runPostgresBackupFlow(t *testing.T, ctx context.Context, runtime *docker.Ru
 	require.NoError(t, runtime.PullImage(pullCtx, image))
 	netCtx, cancelNet := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancelNet()
-	require.NoError(t, runtime.CreateNetwork(netCtx, networkName, map[string]string{"driver": "bridge"}))
+	require.NoError(t, runtime.CreateNetwork(netCtx, networkName, domain.NetworkConfig{Driver: "bridge"}))
 	t.Cleanup(func() {
 		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancelCleanup()
@@ -237,6 +237,9 @@ func (s *integrationContainerService) HealthCheck(context.Context) map[string]bo
 
 func (s *integrationContainerService) SyncContainers(context.Context) error {
 	return nil
+}
+
+func (s *integrationContainerService) UpdateAttachments(map[string][]string) {
 }
 
 func (s *integrationContainerService) AutoStart(context.Context, []domain.Route) error {

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -563,7 +563,7 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 	}
 	if _, exists := currentConfig.ExternalRoutes[route.Domain]; exists {
 		s.mu.Unlock()
-		return fmt.Errorf("route %q conflicts with external route", route.Domain)
+		return fmt.Errorf("%w: route %q conflicts with external route", domain.ErrRouteConflict, route.Domain)
 	}
 	previousCanonicalRoute, canonicalExisted := currentConfig.Routes[route.Domain]
 	legacyKey := legacyRouteStorageKey(route.Domain)

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -95,7 +95,16 @@ func (s *Service) Load(ctx context.Context) error {
 		return log.WrapErr(err, "failed to load routes")
 	}
 	newConfig.Routes = routes
-	newConfig.ExternalRoutes = loadStringMap(s.viper.Get("external_routes"))
+	externalRoutes, err := loadExternalRoutes(s.viper.Get("external_routes"))
+	if err != nil {
+		return log.WrapErr(err, "failed to load external routes")
+	}
+	for domainName := range externalRoutes {
+		if _, exists := routes[domainName]; exists {
+			return fmt.Errorf("external route %q conflicts with configured route", domainName)
+		}
+	}
+	newConfig.ExternalRoutes = externalRoutes
 	newConfig.NetworkGroups = loadStringArrayMap(s.viper.Get("network_groups"))
 	newConfig.Attachments = loadStringArrayMap(s.viper.Get("attachments"))
 
@@ -208,6 +217,33 @@ func loadStringMap(raw any) map[string]string {
 	return result
 }
 
+// loadExternalRoutes loads and canonicalizes external route mappings.
+func loadExternalRoutes(raw any) (map[string]string, error) {
+	result := make(map[string]string)
+	if raw == nil {
+		return result, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return result, nil
+	}
+	for k, v := range m {
+		vs, ok := v.(string)
+		if !ok {
+			continue
+		}
+		canonicalKey, ok := domain.CanonicalRouteDomain(k)
+		if !ok {
+			return nil, fmt.Errorf("invalid external route key %q: %w", k, domain.ErrRouteDomainInvalid)
+		}
+		if _, exists := result[canonicalKey]; exists {
+			return nil, fmt.Errorf("duplicate external route key %q canonicalizes to %q", k, canonicalKey)
+		}
+		result[canonicalKey] = vs
+	}
+	return result, nil
+}
+
 // loadStringArrayMap loads a map[string][]string from a viper value.
 func loadStringArrayMap(raw any) map[string][]string {
 	result := make(map[string][]string)
@@ -252,7 +288,11 @@ func loadCanonicalRoutes(raw any) (map[string]routeConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		result[key] = route
+		canonicalKey, _ := domain.CanonicalRouteDomain(key)
+		if _, exists := result[canonicalKey]; exists {
+			return nil, fmt.Errorf("duplicate route key %q canonicalizes to %q", key, canonicalKey)
+		}
+		result[canonicalKey] = route
 	}
 
 	for key, value := range routes {
@@ -261,7 +301,11 @@ func loadCanonicalRoutes(raw any) (map[string]routeConfig, error) {
 		}
 
 		domainName := strings.TrimPrefix(key, "http://")
-		if _, exists := result[domainName]; exists {
+		canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+		if !ok {
+			return nil, fmt.Errorf("invalid route key %q: %w", legacyRouteStorageKey(domainName), domain.ErrRouteDomainInvalid)
+		}
+		if _, exists := result[canonicalDomain]; exists {
 			continue
 		}
 
@@ -269,16 +313,18 @@ func loadCanonicalRoutes(raw any) (map[string]routeConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		result[domainName] = route
+		result[canonicalDomain] = route
 	}
 
 	return result, nil
 }
 
 func parseCanonicalRouteEntry(domainName string, raw any) (routeConfig, error) {
-	if !domain.IsValidRouteDomain(domainName) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
 		return routeConfig{}, fmt.Errorf("invalid route key %q: %w", domainName, domain.ErrRouteDomainInvalid)
 	}
+	domainName = canonicalDomain
 
 	switch value := raw.(type) {
 	case string:
@@ -294,9 +340,11 @@ func parseCanonicalRouteEntry(domainName string, raw any) (routeConfig, error) {
 }
 
 func parseLegacyRouteEntry(domainName string, raw any) (routeConfig, error) {
-	if !domain.IsValidRouteDomain(domainName) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
 		return routeConfig{}, fmt.Errorf("invalid route key %q: %w", legacyRouteStorageKey(domainName), domain.ErrRouteDomainInvalid)
 	}
+	domainName = canonicalDomain
 
 	value, ok := raw.(string)
 	if !ok {
@@ -348,6 +396,10 @@ func (s *Service) GetRoute(_ context.Context, domainName string) (*domain.Route,
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	domainName, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return nil, domain.ErrRouteNotFound
+	}
 	routeCfg, ok := s.config.Routes[domainName]
 	if !ok {
 		return nil, domain.ErrRouteNotFound
@@ -494,9 +546,11 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 	if route.Domain == "" {
 		return domain.ErrRouteDomainEmpty
 	}
-	if !domain.IsValidRouteDomain(route.Domain) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(route.Domain)
+	if !ok {
 		return domain.ErrRouteDomainInvalid
 	}
+	route.Domain = canonicalDomain
 	if route.Image == "" {
 		return domain.ErrRouteImageEmpty
 	}
@@ -506,6 +560,10 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 	currentConfig := s.config
 	if currentConfig.Routes == nil {
 		currentConfig.Routes = make(map[string]routeConfig)
+	}
+	if _, exists := currentConfig.ExternalRoutes[route.Domain]; exists {
+		s.mu.Unlock()
+		return fmt.Errorf("route %q conflicts with external route", route.Domain)
 	}
 	previousCanonicalRoute, canonicalExisted := currentConfig.Routes[route.Domain]
 	legacyKey := legacyRouteStorageKey(route.Domain)
@@ -550,9 +608,11 @@ func (s *Service) UpdateRoute(ctx context.Context, route domain.Route) error {
 	if route.Domain == "" {
 		return domain.ErrRouteDomainEmpty
 	}
-	if !domain.IsValidRouteDomain(route.Domain) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(route.Domain)
+	if !ok {
 		return domain.ErrRouteDomainInvalid
 	}
+	route.Domain = canonicalDomain
 	if route.Image == "" {
 		return domain.ErrRouteImageEmpty
 	}
@@ -601,14 +661,16 @@ func (s *Service) RemoveRoute(ctx context.Context, domainName string) error {
 	if domainName == "" {
 		return domain.ErrRouteDomainEmpty
 	}
-	if !domain.IsValidRouteDomain(domainName) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
 		return domain.ErrRouteDomainInvalid
 	}
+	domainName = canonicalDomain
 
 	// Store previous value for rollback
 	s.mu.Lock()
 	currentConfig := s.config
-	_, ok := currentConfig.Routes[domainName]
+	_, ok = currentConfig.Routes[domainName]
 	if !ok {
 		s.mu.Unlock()
 		return domain.ErrRouteNotFound
@@ -1455,7 +1517,7 @@ func (s *Service) GetExternalRoutes() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	result := make(map[string]string)
+	result := make(map[string]string, len(s.config.ExternalRoutes))
 	for k, v := range s.config.ExternalRoutes {
 		result[k] = v
 	}

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -518,6 +518,7 @@ func TestService_AddRoute_RejectsExternalRouteConflict(t *testing.T) {
 	err := svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Image: "app:latest"})
 
 	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrRouteConflict)
 	assert.Contains(t, err.Error(), "conflicts with external route")
 }
 

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -458,6 +458,91 @@ func TestService_GetRoute(t *testing.T) {
 	})
 }
 
+func TestLoadCanonicalRoutes_RejectsDuplicateCanonicalRouteKeys(t *testing.T) {
+	_, err := loadCanonicalRoutes(map[string]any{
+		"App.Example.com": "app:v1",
+		"app.example.com": "app:v2",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate route key")
+}
+
+func TestService_Load_RejectsExternalRouteConflictingWithRoute(t *testing.T) {
+	v := viper.New()
+	v.Set("routes", map[string]any{
+		"App.Example.com": "app:latest",
+	})
+	v.Set("external_routes", map[string]any{
+		"app.example.com": "203.0.113.10:5000",
+	})
+
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	err := svc.Load(testContext())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with configured route")
+}
+
+func TestLoadExternalRoutes_RejectsInvalidAndDuplicateKeys(t *testing.T) {
+	t.Run("invalid", func(t *testing.T) {
+		_, err := loadExternalRoutes(map[string]any{
+			"bad.example.com:8080": "203.0.113.10:5000",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid external route key")
+	})
+
+	t.Run("duplicate canonical", func(t *testing.T) {
+		_, err := loadExternalRoutes(map[string]any{
+			"Reg.Example.com": "203.0.113.10:5000",
+			"reg.example.com": "203.0.113.11:5000",
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate external route key")
+	})
+}
+
+func TestService_AddRoute_RejectsExternalRouteConflict(t *testing.T) {
+	v := viper.New()
+	v.Set("external_routes", map[string]any{
+		"app.example.com": "203.0.113.10:5000",
+	})
+
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
+
+	err := svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Image: "app:latest"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with external route")
+}
+
+func TestService_AddRoute_CanonicalizesDomainCaseAndRejectsInvalidAuthority(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "gordon.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte("[routes]\n"), 0600))
+	v := viper.New()
+	v.SetConfigFile(configFile)
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
+
+	require.NoError(t, svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Image: "app:latest", HTTPS: true}))
+	route, err := svc.GetRoute(ctx, "app.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "app.example.com", route.Domain)
+	_, err = svc.GetRoute(ctx, "APP.EXAMPLE.COM")
+	require.NoError(t, err)
+
+	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com:8080", Image: "app:latest"})
+	assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
+	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com.", Image: "app:latest"})
+	assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
+}
+
 func TestService_AddRoute(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Create temp config file for Save() to work
@@ -1556,7 +1641,7 @@ func TestService_AutoRouteAllowedDomains(t *testing.T) {
 func TestService_GetExternalRoutes(t *testing.T) {
 	v := viper.New()
 	v.Set("external_routes", map[string]interface{}{
-		"reg.example.com":   "localhost:5000",
+		"Reg.Example.com":   "localhost:5000",
 		"cache.example.com": "127.0.0.1:6379",
 	})
 

--- a/internal/usecase/container/autoroute.go
+++ b/internal/usecase/container/autoroute.go
@@ -174,6 +174,13 @@ func (h *AutoRouteHandler) processRoutes(ctx context.Context, domains []string, 
 			continue
 		}
 
+		canonicalDomain, ok := domain.CanonicalRouteDomain(routeDomain)
+		if !ok {
+			log.Warn().Str("domain", routeDomain).Msg("auto-route rejected invalid domain")
+			continue
+		}
+		routeDomain = canonicalDomain
+
 		created := h.createOrUpdateRoute(ctx, routeDomain, imageName, allowedDomains)
 
 		if created && labels.EnvFile != "" && h.extractor != nil && h.envDir != "" {
@@ -259,6 +266,38 @@ func (h *AutoRouteHandler) triggerDeploy(ctx context.Context, route domain.Route
 	}
 }
 
+func allowedAbsoluteEnvFileRoots() []string {
+	return []string{"/app", "/workspace", "/usr/src/app"}
+}
+
+func validateAutoRouteEnvFilePath(envFilePath string) (string, error) {
+	envFilePath = strings.TrimSpace(envFilePath)
+	if envFilePath == "" {
+		return "", fmt.Errorf("env file path cannot be empty")
+	}
+	if strings.Contains(envFilePath, "\x00") {
+		return "", fmt.Errorf("env file path contains NUL byte")
+	}
+
+	cleaned := filepath.Clean(envFilePath)
+	if cleaned == "." || cleaned == string(filepath.Separator) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("unsafe env file path: %s", envFilePath)
+	}
+	if filepath.IsAbs(cleaned) && !pathHasAllowedRoot(cleaned, allowedAbsoluteEnvFileRoots()) {
+		return "", fmt.Errorf("unsafe env file path: %s", envFilePath)
+	}
+	return cleaned, nil
+}
+
+func pathHasAllowedRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 // extractAndMergeEnvFile extracts an env file from the image and merges it with existing secrets.
 func (h *AutoRouteHandler) extractAndMergeEnvFile(ctx context.Context, imageRef, routeDomain, envFilePath string) error {
 	log := zerowrap.FromCtx(ctx)
@@ -269,8 +308,13 @@ func (h *AutoRouteHandler) extractAndMergeEnvFile(ctx context.Context, imageRef,
 		Str("env_file", envFilePath).
 		Msg("extracting env file from image")
 
+	safeEnvFilePath, err := validateAutoRouteEnvFilePath(envFilePath)
+	if err != nil {
+		return err
+	}
+
 	// Extract env file from image
-	envData, err := h.extractor.ExtractEnvFileFromImage(ctx, imageRef, envFilePath)
+	envData, err := h.extractor.ExtractEnvFileFromImage(ctx, imageRef, safeEnvFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to extract env file: %w", err)
 	}
@@ -291,13 +335,8 @@ func (h *AutoRouteHandler) extractAndMergeEnvFile(ctx context.Context, imageRef,
 		return nil
 	}
 
-	// Security check: reject imported env files containing secret references
-	// to prevent attacker-controlled images from persisting ${provider:path}
-	// syntax that would later resolve against host secret providers.
-	for key, value := range imageEnv {
-		if domain.ContainsSecretReference(value) {
-			return fmt.Errorf("env key %q contains secret reference: %w", key, domain.ErrEnvContainsSecretRef)
-		}
+	if err := rejectSecretReferences(imageEnv); err != nil {
+		return err
 	}
 
 	// Load existing env file for this domain
@@ -377,6 +416,18 @@ func domainToEnvFileName(domainName string) (string, error) {
 	}
 
 	return storageKey.FileName(), nil
+}
+
+func rejectSecretReferences(env map[string]string) error {
+	// Security check: reject imported env files containing secret references
+	// to prevent attacker-controlled images from persisting ${provider:path}
+	// syntax that would later resolve against host secret providers.
+	for key, value := range env {
+		if domain.ContainsSecretReference(value) {
+			return fmt.Errorf("env key %q contains secret reference: %w", key, domain.ErrEnvContainsSecretRef)
+		}
+	}
+	return nil
 }
 
 // writeEnvFile writes environment variables to a file.

--- a/internal/usecase/container/autoroute_test.go
+++ b/internal/usecase/container/autoroute_test.go
@@ -910,6 +910,53 @@ func (e *testEnvExtractor) ExtractEnvFileFromImage(_ context.Context, imageRef, 
 
 // collectDomains tests
 
+func TestValidateAutoRouteEnvFilePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{name: "relative path", path: ".env", want: ".env"},
+		{name: "absolute app path", path: "/app/.env", want: "/app/.env"},
+		{name: "absolute workspace path", path: "/workspace/.env", want: "/workspace/.env"},
+		{name: "cleans safe path", path: "/app/config/../.env", want: "/app/.env"},
+		{name: "absolute traversal escapes app root", path: "/app/../../etc/passwd", wantErr: true},
+		{name: "absolute non app path", path: "/etc/passwd", wantErr: true},
+		{name: "empty", path: "", wantErr: true},
+		{name: "root", path: "/", wantErr: true},
+		{name: "traversal", path: "../.env", wantErr: true},
+		{name: "proc", path: "/proc/self/environ", wantErr: true},
+		{name: "sys", path: "/sys/kernel", wantErr: true},
+		{name: "dev", path: "/dev/null", wantErr: true},
+		{name: "run", path: "/run/secrets", wantErr: true},
+		{name: "var run", path: "/var/run/docker.sock", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAutoRouteEnvFilePath(tt.path)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAutoRouteHandler_ExtractAndMergeEnvFile_UsesCleanSafeEnvFilePath(t *testing.T) {
+	ctx := zerowrap.WithCtx(context.Background(), zerowrap.Default())
+	extractor := &testEnvExtractor{data: []byte("FOO=bar\n")}
+	handler := NewAutoRouteHandler(ctx, inmocks.NewMockConfigService(t), inmocks.NewMockContainerService(t), mocks.NewMockBlobStorage(t), "registry.example.com").
+		WithEnvExtractor(extractor, t.TempDir())
+
+	err := handler.extractAndMergeEnvFile(ctx, "myapp:latest", "app.example.com", "/app/config/../.env")
+	require.NoError(t, err)
+	assert.Equal(t, "/app/.env", extractor.lastPath)
+}
+
 func TestAutoRouteHandler_ExtractAndMergeEnvFile_RejectsSecretReferences(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -5,10 +5,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"slices"
 	"strconv"
 	"strings"
@@ -43,7 +45,11 @@ type Config struct {
 	NetworkIsolation           bool
 	NetworkPrefix              string
 	NetworkGroups              map[string][]string
+	NetworkInternal            bool
 	Attachments                map[string][]string
+	AllowedRegistries          []string
+	RequireImageDigest         bool
+	SecurityProfile            string
 	ReadinessDelay             time.Duration // Delay after container starts before considering it ready
 	ReadinessMode              string        // Readiness strategy: auto, docker-health, delay
 	HealthTimeout              time.Duration // Max wait for health-based readiness
@@ -268,7 +274,7 @@ func (s *Service) buildContainerConfig(in containerConfigInput) *domain.Containe
 		}
 	}
 
-	return &domain.ContainerConfig{
+	containerConfig := &domain.ContainerConfig{
 		Image:       in.ImageRef,
 		Name:        containerName,
 		Ports:       ports,
@@ -282,6 +288,8 @@ func (s *Service) buildContainerConfig(in containerConfigInput) *domain.Containe
 		NanoCPUs:    cfg.DefaultNanoCPUs,
 		PidsLimit:   cfg.DefaultPidsLimit,
 	}
+	applySecurityProfile(containerConfig, cfg)
+	return containerConfig
 }
 
 // Deploy creates and starts a container for the given route.
@@ -561,7 +569,10 @@ func (s *Service) prepareDeployResources(ctx context.Context, route domain.Route
 		log.WrapErr(err, "failed to cleanup orphaned containers")
 	}
 
-	imageRef := s.buildImageRef(route.Image)
+	imageRef, err := s.buildValidatedImageRef(route.Image)
+	if err != nil {
+		return nil, err
+	}
 	actualImageRef, err := s.ensureImage(ctx, imageRef)
 	if err != nil {
 		return nil, err
@@ -1668,6 +1679,14 @@ func (s *Service) startLogCollection(ctx context.Context, containerID, domainNam
 	}
 }
 
+func (s *Service) buildValidatedImageRef(image string) (string, error) {
+	imageRef := s.buildImageRef(image)
+	if err := s.validateImageRef(imageRef); err != nil {
+		return "", err
+	}
+	return imageRef, nil
+}
+
 func (s *Service) buildImageRef(image string) string {
 	s.mu.RLock()
 	cfg := s.config
@@ -1743,6 +1762,108 @@ func hasExplicitRegistry(image string) bool {
 	return false
 }
 
+func (s *Service) validateImageRef(imageRef string) error {
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+
+	if !hasExplicitRegistry(imageRef) {
+		if cfg.RequireImageDigest && !isValidSha256DigestRef(imageRef) {
+			return fmt.Errorf("image %q rejected: digest reference required", imageRef)
+		}
+		return nil
+	}
+
+	registry := imageRegistry(imageRef)
+	if registry == "" {
+		return nil
+	}
+
+	if sameRegistry(registry, cfg.RegistryDomain) {
+		return nil
+	}
+	if isDangerousRegistryHost(imageRegistryHost(registry)) {
+		return fmt.Errorf("image %q rejected: registry %q is not allowed", imageRef, registry)
+	}
+	if len(cfg.AllowedRegistries) == 0 {
+		return fmt.Errorf("image %q rejected: registry %q is not in images.allowed_registries", imageRef, registry)
+	}
+	for _, allowed := range cfg.AllowedRegistries {
+		if sameRegistry(registry, allowed) {
+			if cfg.RequireImageDigest && !isValidSha256DigestRef(imageRef) {
+				return fmt.Errorf("image %q rejected: digest reference required", imageRef)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q rejected: registry %q is not in images.allowed_registries", imageRef, registry)
+}
+
+func imageRegistry(imageRef string) string {
+	slashIdx := strings.Index(imageRef, "/")
+	if slashIdx == -1 {
+		return ""
+	}
+	return normalizeRegistry(imageRef[:slashIdx])
+}
+
+func normalizeRegistry(registry string) string {
+	registry = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(registry), "."))
+	if strings.HasPrefix(registry, "[") {
+		if end := strings.Index(registry, "]"); end != -1 {
+			host := strings.Trim(registry[:end+1], "[]")
+			port := registry[end+1:]
+			return host + port
+		}
+	}
+	return registry
+}
+
+func imageRegistryHost(registry string) string {
+	if ip := net.ParseIP(registry); ip != nil {
+		return registry
+	}
+	if h, _, err := net.SplitHostPort(registry); err == nil {
+		return strings.Trim(h, "[]")
+	}
+	if strings.HasPrefix(registry, "[") && strings.Contains(registry, "]") {
+		return strings.TrimPrefix(strings.Split(registry, "]")[0], "[")
+	}
+	if colon := strings.LastIndex(registry, ":"); colon != -1 && isNumeric(registry[colon+1:]) {
+		return registry[:colon]
+	}
+	return registry
+}
+
+func sameRegistry(a, b string) bool {
+	return normalizeRegistry(a) == normalizeRegistry(b)
+}
+
+func isDangerousRegistryHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "localhost" || host == "metadata.google.internal" {
+		return true
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return true
+		}
+	}
+	return false
+}
+
+func applySecurityProfile(config *domain.ContainerConfig, cfg Config) {
+	if strings.EqualFold(cfg.SecurityProfile, "strict") {
+		config.ReadOnlyRootFS = true
+		config.CapDrop = []string{"ALL"}
+		config.CapAdd = []string{"NET_BIND_SERVICE"}
+	}
+}
+
 // isNumeric checks if a string contains only digits.
 func isNumeric(s string) bool {
 	for _, c := range s {
@@ -1767,7 +1888,16 @@ func normalizePullPolicy(policy string) string {
 }
 
 func isDigestRef(imageRef string) bool {
-	return strings.Contains(imageRef, "@sha256:")
+	return isValidSha256DigestRef(imageRef)
+}
+
+func isValidSha256DigestRef(imageRef string) bool {
+	_, digest, ok := strings.Cut(imageRef, "@sha256:")
+	if !ok || len(digest) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(digest)
+	return err == nil
 }
 
 func (s *Service) pullRefForDeploy(ctx context.Context, imageRef string) (string, bool) {
@@ -2101,7 +2231,10 @@ func (s *Service) createNetworkIfNeeded(ctx context.Context, networkName string)
 	}
 
 	if !exists {
-		if err := s.runtime.CreateNetwork(ctx, networkName, map[string]string{"driver": "bridge"}); err != nil {
+		s.mu.RLock()
+		internal := s.config.NetworkInternal
+		s.mu.RUnlock()
+		if err := s.runtime.CreateNetwork(ctx, networkName, domain.NetworkConfig{Driver: "bridge", Internal: internal}); err != nil {
 			return log.WrapErr(err, "failed to create network")
 		}
 		log.Info().Msg("created network for app isolation")
@@ -2415,32 +2548,18 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	log.Info().Str(zerowrap.FieldService, serviceImage).Msg("deploying attached service")
 
 	// Ensure image (canonical ref is returned; internal pulls may use the local registry).
-	imageRef := s.buildImageRef(serviceImage)
+	imageRef, err := s.buildValidatedImageRef(serviceImage)
+	if err != nil {
+		return err
+	}
 	actualImageRef, err := s.ensureImage(ctx, imageRef)
 	if err != nil {
 		return err
 	}
 
-	// Get image metadata
-	exposedPorts, err := s.runtime.GetImageExposedPorts(ctx, actualImageRef)
-	if err != nil {
-		log.WrapErr(err, "failed to get exposed ports for attachment, using defaults")
-		exposedPorts = []int{}
-	}
-
-	// Setup volumes (attachments need persistent data)
-	volumes, err := s.setupVolumes(ctx, containerName, actualImageRef)
-	if err != nil {
-		log.WrapErr(err, "failed to setup volumes for attachment")
-		volumes = make(map[string]string)
-	}
-
-	// Load environment (attachment-specific env file)
-	envVars, err := s.loadEnvironment(ctx, nil, containerName, actualImageRef)
-	if err != nil {
-		log.WrapErr(err, "failed to load environment for attachment")
-		envVars = []string{}
-	}
+	exposedPorts := s.attachmentExposedPorts(ctx, actualImageRef)
+	volumes := s.attachmentVolumes(ctx, containerName, actualImageRef)
+	envVars := s.attachmentEnv(ctx, containerName, actualImageRef)
 	envHash := hashEnvironment(envVars)
 
 	s.mu.RLock()
@@ -2468,6 +2587,7 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 		NanoCPUs:    cfg.DefaultNanoCPUs,
 		PidsLimit:   cfg.DefaultPidsLimit,
 	}
+	applySecurityProfile(config, cfg)
 
 	container, err := s.runtime.CreateContainer(ctx, config)
 	if err != nil {
@@ -2502,8 +2622,42 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	return nil
 }
 
+func (s *Service) attachmentExposedPorts(ctx context.Context, imageRef string) []int {
+	log := zerowrap.FromCtx(ctx)
+	exposedPorts, err := s.runtime.GetImageExposedPorts(ctx, imageRef)
+	if err != nil {
+		log.WrapErr(err, "failed to get exposed ports for attachment, using defaults")
+		return []int{}
+	}
+	return exposedPorts
+}
+
+func (s *Service) attachmentVolumes(ctx context.Context, containerName, imageRef string) map[string]string {
+	log := zerowrap.FromCtx(ctx)
+	volumes, err := s.setupVolumes(ctx, containerName, imageRef)
+	if err != nil {
+		log.WrapErr(err, "failed to setup volumes for attachment")
+		return make(map[string]string)
+	}
+	return volumes
+}
+
+func (s *Service) attachmentEnv(ctx context.Context, containerName, imageRef string) []string {
+	log := zerowrap.FromCtx(ctx)
+	envVars, err := s.loadEnvironment(ctx, nil, containerName, imageRef)
+	if err != nil {
+		log.WrapErr(err, "failed to load environment for attachment")
+		return []string{}
+	}
+	return envVars
+}
+
 func (s *Service) attachmentEnvDrifted(ctx context.Context, existing *domain.Container, containerName, serviceImage string) (bool, error) {
-	currentEnv, err := s.loadEnvironment(ctx, nil, containerName, s.buildImageRef(serviceImage))
+	imageRef, err := s.buildValidatedImageRef(serviceImage)
+	if err != nil {
+		return false, err
+	}
+	currentEnv, err := s.loadEnvironment(ctx, nil, containerName, imageRef)
 	if err != nil {
 		return false, err
 	}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1763,26 +1763,33 @@ func hasExplicitRegistry(image string) bool {
 }
 
 func (s *Service) validateImageRef(imageRef string) error {
+	if !hasExplicitRegistry(imageRef) {
+		return nil
+	}
+	return s.validateExternalImageRef(imageRef, imageRegistry(imageRef))
+}
+
+func (s *Service) validateImagePullRef(imageRef string) error {
+	return s.validateExternalImageRef(imageRef, imageRegistryForPolicy(imageRef))
+}
+
+func (s *Service) validateExternalImageRef(imageRef, registry string) error {
 	s.mu.RLock()
 	cfg := s.config
 	s.mu.RUnlock()
 
-	if !hasExplicitRegistry(imageRef) {
-		if cfg.RequireImageDigest && !isValidSha256DigestRef(imageRef) {
-			return fmt.Errorf("image %q rejected: digest reference required", imageRef)
-		}
-		return nil
-	}
-
-	registry := imageRegistry(imageRef)
 	if registry == "" {
-		return nil
+		return fmt.Errorf("image %q rejected: invalid image reference", imageRef)
 	}
 
 	if sameRegistry(registry, cfg.RegistryDomain) {
 		return nil
 	}
-	if isDangerousRegistryHost(imageRegistryHost(registry)) {
+	dangerous, err := isDangerousRegistryHost(imageRegistryHost(registry))
+	if err != nil {
+		return fmt.Errorf("image %q rejected: registry %q could not be verified: %w", imageRef, registry, err)
+	}
+	if dangerous {
 		return fmt.Errorf("image %q rejected: registry %q is not allowed", imageRef, registry)
 	}
 	if len(cfg.AllowedRegistries) == 0 {
@@ -1805,6 +1812,13 @@ func imageRegistry(imageRef string) string {
 		return ""
 	}
 	return normalizeRegistry(imageRef[:slashIdx])
+}
+
+func imageRegistryForPolicy(imageRef string) string {
+	if hasExplicitRegistry(imageRef) {
+		return imageRegistry(imageRef)
+	}
+	return "docker.io"
 }
 
 func normalizeRegistry(registry string) string {
@@ -1839,21 +1853,28 @@ func sameRegistry(a, b string) bool {
 	return normalizeRegistry(a) == normalizeRegistry(b)
 }
 
-func isDangerousRegistryHost(host string) bool {
+func isDangerousRegistryHost(host string) (bool, error) {
 	host = strings.ToLower(strings.TrimSuffix(host, "."))
 	if host == "localhost" || host == "metadata.google.internal" {
-		return true
+		return true, nil
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return isDangerousRegistryIP(ip), nil
 	}
 	ips, err := net.LookupIP(host)
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, ip := range ips {
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
-			return true
+		if isDangerousRegistryIP(ip) {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+func isDangerousRegistryIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 func applySecurityProfile(config *domain.ContainerConfig, cfg Config) {
@@ -1924,6 +1945,9 @@ func (s *Service) ensureImage(ctx context.Context, imageRef string) (string, err
 
 	// Determine if this is an internal deploy and what reference to use for pulls.
 	pullRef, isInternal := s.pullRefForDeploy(ctx, imageRef)
+	if err := s.validateImagePullRef(imageRef); err != nil {
+		return "", err
+	}
 	if pullRef != imageRef {
 		log.Info().
 			Str("original_ref", imageRef).

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1823,6 +1823,7 @@ func imageRegistryForPolicy(imageRef string) string {
 
 func normalizeRegistry(registry string) string {
 	registry = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(registry), "."))
+	registry = strings.TrimSuffix(registry, "/")
 	if strings.HasPrefix(registry, "[") {
 		if end := strings.Index(registry, "]"); end != -1 {
 			host := strings.Trim(registry[:end+1], "[]")

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -569,7 +569,7 @@ func (s *Service) prepareDeployResources(ctx context.Context, route domain.Route
 		log.WrapErr(err, "failed to cleanup orphaned containers")
 	}
 
-	imageRef, err := s.buildValidatedImageRef(route.Image)
+	imageRef, err := s.buildValidatedImageRef(ctx, route.Image)
 	if err != nil {
 		return nil, err
 	}
@@ -1679,9 +1679,9 @@ func (s *Service) startLogCollection(ctx context.Context, containerID, domainNam
 	}
 }
 
-func (s *Service) buildValidatedImageRef(image string) (string, error) {
+func (s *Service) buildValidatedImageRef(ctx context.Context, image string) (string, error) {
 	imageRef := s.buildImageRef(image)
-	if err := s.validateImageRef(imageRef); err != nil {
+	if err := s.validateImageRef(ctx, imageRef); err != nil {
 		return "", err
 	}
 	return imageRef, nil
@@ -1762,11 +1762,11 @@ func hasExplicitRegistry(image string) bool {
 	return false
 }
 
-func (s *Service) validateImageRef(imageRef string) error {
+func (s *Service) validateImageRef(ctx context.Context, imageRef string) error {
 	if !hasExplicitRegistry(imageRef) {
 		return nil
 	}
-	return s.validateExternalImageRef(context.Background(), imageRef, imageRegistry(imageRef))
+	return s.validateExternalImageRef(ctx, imageRef, imageRegistry(imageRef))
 }
 
 func (s *Service) validateImagePullRef(ctx context.Context, imageRef string) error {
@@ -1821,6 +1821,11 @@ func imageRegistryForPolicy(imageRef string) string {
 	return "docker.io"
 }
 
+// normalizeRegistry normalizes a registry string for comparison purposes only.
+// This function is used by sameRegistry to determine if two registry strings
+// refer to the same registry. The output intentionally strips IPv6 brackets
+// (e.g., "[fd00::1]:5000" -> "fd00::1:5000") which is acceptable for equality
+// checks but the result MUST NOT be used to construct or emit valid registry URLs.
 func normalizeRegistry(registry string) string {
 	registry = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(registry), "."))
 	registry = strings.TrimSuffix(registry, "/")
@@ -2573,7 +2578,7 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	log.Info().Str(zerowrap.FieldService, serviceImage).Msg("deploying attached service")
 
 	// Ensure image (canonical ref is returned; internal pulls may use the local registry).
-	imageRef, err := s.buildValidatedImageRef(serviceImage)
+	imageRef, err := s.buildValidatedImageRef(ctx, serviceImage)
 	if err != nil {
 		return err
 	}
@@ -2680,7 +2685,7 @@ func (s *Service) attachmentEnv(ctx context.Context, containerName, imageRef str
 }
 
 func (s *Service) attachmentEnvDrifted(ctx context.Context, existing *domain.Container, containerName, serviceImage string) (bool, error) {
-	imageRef, err := s.buildValidatedImageRef(serviceImage)
+	imageRef, err := s.buildValidatedImageRef(ctx, serviceImage)
 	if err != nil {
 		return false, err
 	}

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -2784,6 +2784,10 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 // Utility functions
 
 func normalizeImageRef(image string) string {
+	if isDigestRef(image) {
+		return image
+	}
+
 	// Extract repository from image reference, handling port numbers correctly.
 	// Examples:
 	//   nginx:latest -> docker.io/library/nginx

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1766,14 +1766,14 @@ func (s *Service) validateImageRef(imageRef string) error {
 	if !hasExplicitRegistry(imageRef) {
 		return nil
 	}
-	return s.validateExternalImageRef(imageRef, imageRegistry(imageRef))
+	return s.validateExternalImageRef(context.Background(), imageRef, imageRegistry(imageRef))
 }
 
-func (s *Service) validateImagePullRef(imageRef string) error {
-	return s.validateExternalImageRef(imageRef, imageRegistryForPolicy(imageRef))
+func (s *Service) validateImagePullRef(ctx context.Context, imageRef string) error {
+	return s.validateExternalImageRef(ctx, imageRef, imageRegistryForPolicy(imageRef))
 }
 
-func (s *Service) validateExternalImageRef(imageRef, registry string) error {
+func (s *Service) validateExternalImageRef(ctx context.Context, imageRef, registry string) error {
 	s.mu.RLock()
 	cfg := s.config
 	s.mu.RUnlock()
@@ -1785,7 +1785,7 @@ func (s *Service) validateExternalImageRef(imageRef, registry string) error {
 	if sameRegistry(registry, cfg.RegistryDomain) {
 		return nil
 	}
-	dangerous, err := isDangerousRegistryHost(imageRegistryHost(registry))
+	dangerous, err := isDangerousRegistryHost(ctx, imageRegistryHost(registry))
 	if err != nil {
 		return fmt.Errorf("image %q rejected: registry %q could not be verified: %w", imageRef, registry, err)
 	}
@@ -1853,7 +1853,7 @@ func sameRegistry(a, b string) bool {
 	return normalizeRegistry(a) == normalizeRegistry(b)
 }
 
-func isDangerousRegistryHost(host string) (bool, error) {
+func isDangerousRegistryHost(ctx context.Context, host string) (bool, error) {
 	host = strings.ToLower(strings.TrimSuffix(host, "."))
 	if host == "localhost" || host == "metadata.google.internal" {
 		return true, nil
@@ -1861,12 +1861,12 @@ func isDangerousRegistryHost(host string) (bool, error) {
 	if ip := net.ParseIP(host); ip != nil {
 		return isDangerousRegistryIP(ip), nil
 	}
-	ips, err := net.LookupIP(host)
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return false, err
 	}
-	for _, ip := range ips {
-		if isDangerousRegistryIP(ip) {
+	for _, addr := range addrs {
+		if isDangerousRegistryIP(addr.IP) {
 			return true, nil
 		}
 	}
@@ -1945,7 +1945,7 @@ func (s *Service) ensureImage(ctx context.Context, imageRef string) (string, err
 
 	// Determine if this is an internal deploy and what reference to use for pulls.
 	pullRef, isInternal := s.pullRefForDeploy(ctx, imageRef)
-	if err := s.validateImagePullRef(imageRef); err != nil {
+	if err := s.validateImagePullRef(ctx, imageRef); err != nil {
 		return "", err
 	}
 	if pullRef != imageRef {
@@ -2582,8 +2582,14 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	}
 
 	exposedPorts := s.attachmentExposedPorts(ctx, actualImageRef)
-	volumes := s.attachmentVolumes(ctx, containerName, actualImageRef)
-	envVars := s.attachmentEnv(ctx, containerName, actualImageRef)
+	volumes, err := s.attachmentVolumes(ctx, containerName, actualImageRef)
+	if err != nil {
+		return err
+	}
+	envVars, err := s.attachmentEnv(ctx, containerName, actualImageRef)
+	if err != nil {
+		return err
+	}
 	envHash := hashEnvironment(envVars)
 
 	s.mu.RLock()
@@ -2656,24 +2662,20 @@ func (s *Service) attachmentExposedPorts(ctx context.Context, imageRef string) [
 	return exposedPorts
 }
 
-func (s *Service) attachmentVolumes(ctx context.Context, containerName, imageRef string) map[string]string {
-	log := zerowrap.FromCtx(ctx)
+func (s *Service) attachmentVolumes(ctx context.Context, containerName, imageRef string) (map[string]string, error) {
 	volumes, err := s.setupVolumes(ctx, containerName, imageRef)
 	if err != nil {
-		log.WrapErr(err, "failed to setup volumes for attachment")
-		return make(map[string]string)
+		return nil, fmt.Errorf("failed to setup volumes for attachment %s with image %s: %w", containerName, imageRef, err)
 	}
-	return volumes
+	return volumes, nil
 }
 
-func (s *Service) attachmentEnv(ctx context.Context, containerName, imageRef string) []string {
-	log := zerowrap.FromCtx(ctx)
+func (s *Service) attachmentEnv(ctx context.Context, containerName, imageRef string) ([]string, error) {
 	envVars, err := s.loadEnvironment(ctx, nil, containerName, imageRef)
 	if err != nil {
-		log.WrapErr(err, "failed to load environment for attachment")
-		return []string{}
+		return nil, fmt.Errorf("failed to load environment for attachment %s with image %s: %w", containerName, imageRef, err)
 	}
-	return envVars
+	return envVars, nil
 }
 
 func (s *Service) attachmentEnvDrifted(ctx context.Context, existing *domain.Container, containerName, serviceImage string) (bool, error) {

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -4235,7 +4235,7 @@ func TestService_BuildValidatedImageRef_RejectsExternalRegistryWhenAllowlistEmpt
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "images.allowed_registries")
 
-	err = svc.validateImagePullRef("nginx:latest")
+	err = svc.validateImagePullRef(context.Background(), "nginx:latest")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "docker.io")
 }
@@ -4251,7 +4251,7 @@ func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegis
 	_, err := svc.buildValidatedImageRef("docker.io/library/nginx:latest")
 	require.Error(t, err)
 
-	err = svc.validateImagePullRef("nginx:latest")
+	err = svc.validateImagePullRef(context.Background(), "nginx:latest")
 	require.Error(t, err)
 
 	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -49,6 +49,7 @@ func dockerLogFrames(stream byte, lines ...string) io.ReadCloser {
 // suitable for unit tests that don't want to wait for real timeouts.
 func testMinDelayConfig() Config {
 	return Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -326,6 +327,7 @@ func TestService_Deploy_Success(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		NetworkIsolation:     false,
 		VolumeAutoCreate:     false,
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
@@ -408,6 +410,7 @@ func TestService_Deploy_ReadinessRecoveryWindow_AllowsTransientFlap(t *testing.T
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		NetworkIsolation:     false,
 		VolumeAutoCreate:     false,
 		ReadinessDelay:       time.Millisecond,
@@ -472,7 +475,7 @@ func TestService_Deploy_ImagePullFailure(t *testing.T) {
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
-	config := Config{}
+	config := Config{AllowedRegistries: []string{"docker.io"}}
 	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
 	ctx := testContext()
 
@@ -514,7 +517,7 @@ func TestService_Deploy_DoesNotMisclassifyUnauthorizedEnvLoadFailure(t *testing.
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
-	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{AllowedRegistries: []string{"docker.io"}}, nil)
 	ctx := testContext()
 
 	route := domain.Route{
@@ -555,6 +558,7 @@ func TestService_Deploy_ReadinessFailureReturnsDeployFailureWithLogs(t *testing.
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessMode:        "docker-health",
 		HealthTimeout:        10 * time.Millisecond,
 		ReadinessDelay:       time.Millisecond,
@@ -613,6 +617,7 @@ func TestService_Deploy_StrictHealthModeWithoutHealthcheckReturnsHint(t *testing
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessMode:        "docker-health",
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
@@ -659,6 +664,7 @@ func TestService_PullImage_UsesServiceTokenForExternalPull(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		RegistryAuthEnabled:  true,
 		ServiceTokenUsername: "gordon-service",
 		ServiceToken:         "service-token",
@@ -678,6 +684,7 @@ func TestService_PullImage_RequiresServiceTokenForExternalPull(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 
 	config := Config{
+		AllowedRegistries:   []string{"docker.io"},
 		RegistryAuthEnabled: true,
 	}
 
@@ -694,6 +701,7 @@ func TestService_PullImage_InternalRetriesOnConnectionRefused(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 
 	config := Config{
+		AllowedRegistries:        []string{"docker.io"},
 		RegistryAuthEnabled:      true,
 		InternalRegistryUsername: "internal",
 		InternalRegistryPassword: "secret",
@@ -721,6 +729,7 @@ func TestService_Deploy_ReplacesExistingContainer(t *testing.T) {
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -963,6 +972,7 @@ func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		NetworkIsolation:     true,
 		NetworkPrefix:        "gordon",
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
@@ -1020,6 +1030,7 @@ func TestService_Deploy_WithVolumeAutoCreate(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		VolumeAutoCreate:     true,
 		VolumePrefix:         "gordon",
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
@@ -1135,8 +1146,9 @@ func TestService_Remove_WithNetworkCleanup(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
-		NetworkIsolation: true,
-		NetworkPrefix:    "gordon",
+		AllowedRegistries: []string{"docker.io"},
+		NetworkIsolation:  true,
+		NetworkPrefix:     "gordon",
 	}
 	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
 	ctx := testContext()
@@ -1932,6 +1944,7 @@ func TestService_Deploy_InternalDeployForcesPull(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:        []string{"docker.io"},
 		RegistryAuthEnabled:      true,
 		RegistryDomain:           "registry.example.com",
 		RegistryPort:             5000,
@@ -2011,6 +2024,7 @@ func TestService_AutoStart_StartsNewContainers(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2059,6 +2073,7 @@ func TestService_AutoStart_SkipsExistingContainers(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2106,7 +2121,7 @@ func TestService_AutoStart_HandlesDeployErrors(t *testing.T) {
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
-	config := Config{}
+	config := Config{AllowedRegistries: []string{"docker.io"}}
 	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
 	ctx := testContext()
 
@@ -2188,6 +2203,7 @@ func TestService_Deploy_OrphanCleanupSkipsTrackedContainer(t *testing.T) {
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2282,6 +2298,7 @@ func TestService_Deploy_OrphanCleanupRemovesTrueOrphans(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond, // Minimal delay for tests
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2732,6 +2749,7 @@ func TestService_Deploy_ContextCancellation(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2890,6 +2908,7 @@ func TestService_Deploy_SkipsRedundantDeploy(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -2949,6 +2968,7 @@ func TestService_Deploy_SkipsRedundantDeploy_WhenTrackedImageIDMissing(t *testin
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3455,6 +3475,7 @@ func TestService_Deploy_RollbackOnPostSwitchCrash(t *testing.T) {
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3548,6 +3569,7 @@ func TestService_Deploy_StabilizationSuccess(t *testing.T) {
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3635,6 +3657,7 @@ func TestService_Deploy_ZeroDowntime_OldNeverStoppedBeforeNewReady(t *testing.T)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3729,6 +3752,7 @@ func TestService_Deploy_ZeroDowntime_ReadinessFailure_OldUntouched(t *testing.T)
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3818,6 +3842,7 @@ func TestService_Deploy_ZeroDowntime_NoExisting_FirstDeploy(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		ReadinessDelay:       time.Millisecond,
 		DrainDelay:           time.Millisecond,
 		DrainDelayConfigured: true,
@@ -3893,6 +3918,7 @@ func TestService_Deploy_PropagatesImageLabelsToContainerConfig(t *testing.T) {
 	eventBus := mocks.NewMockEventPublisher(t)
 
 	config := Config{
+		AllowedRegistries:    []string{"docker.io"},
 		NetworkIsolation:     false,
 		VolumeAutoCreate:     false,
 		ReadinessDelay:       time.Millisecond,
@@ -4208,6 +4234,10 @@ func TestService_BuildValidatedImageRef_RejectsExternalRegistryWhenAllowlistEmpt
 	_, err := svc.buildValidatedImageRef("ghcr.io/acme/app:latest")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "images.allowed_registries")
+
+	err = svc.validateImagePullRef("nginx:latest")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker.io")
 }
 
 func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegistries(t *testing.T) {
@@ -4219,6 +4249,9 @@ func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegis
 	}, nil)
 
 	_, err := svc.buildValidatedImageRef("docker.io/library/nginx:latest")
+	require.Error(t, err)
+
+	err = svc.validateImagePullRef("nginx:latest")
 	require.Error(t, err)
 
 	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -4236,12 +4269,12 @@ func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegis
 }
 
 func TestService_BuildValidatedImageRef_AllowedRegistryMatchesPort(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, Config{AllowedRegistries: []string{"registry.example.com:5000"}}, nil)
+	svc := NewService(nil, nil, nil, nil, Config{AllowedRegistries: []string{"docker.io:5000"}}, nil)
 
-	_, err := svc.buildValidatedImageRef("registry.example.com:5000/app:latest")
+	_, err := svc.buildValidatedImageRef("docker.io:5000/app:latest")
 	require.NoError(t, err)
 
-	_, err = svc.buildValidatedImageRef("registry.example.com:5001/app:latest")
+	_, err = svc.buildValidatedImageRef("docker.io:5001/app:latest")
 	require.Error(t, err)
 }
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -989,7 +989,7 @@ func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 
 	// Network isolation - should check and create network
 	runtime.EXPECT().NetworkExists(mock.Anything, "gordon-test-example-com").Return(false, nil)
-	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-test-example-com", map[string]string{"driver": "bridge"}).Return(nil)
+	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-test-example-com", domain.NetworkConfig{Driver: "bridge"}).Return(nil)
 
 	container := &domain.Container{ID: "container-123", Status: "created"}
 	runtime.EXPECT().CreateContainer(mock.Anything, mock.MatchedBy(func(cfg *domain.ContainerConfig) bool {
@@ -4167,4 +4167,110 @@ func TestDeployAttachedService_SetsAliasOnContainerConfig(t *testing.T) {
 	svc.mu.RUnlock()
 	require.Len(t, attachIDs, 1)
 	assert.Equal(t, "pg-container-1", attachIDs[0])
+}
+
+func TestService_BuildValidatedImageRef_RegistryPolicy(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{
+		RegistryAuthEnabled: true,
+		RegistryDomain:      "registry.example.com",
+		AllowedRegistries:   []string{"docker.io"},
+	}, nil)
+
+	ref, err := svc.buildValidatedImageRef("myapp:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com/myapp:latest", ref)
+
+	ref, err = svc.buildValidatedImageRef("registry.example.com/myapp:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com/myapp:latest", ref)
+
+	ref, err = svc.buildValidatedImageRef("docker.io/library/nginx:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/nginx:latest", ref)
+
+	for _, image := range []string{
+		"ghcr.io/acme/app:latest",
+		"localhost:5000/app:latest",
+		"127.0.0.1:5000/app:latest",
+		"10.0.0.2:5000/app:latest",
+		"169.254.169.254/app:latest",
+	} {
+		t.Run(image, func(t *testing.T) {
+			_, err := svc.buildValidatedImageRef(image)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestService_BuildValidatedImageRef_RejectsExternalRegistryWhenAllowlistEmpty(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{}, nil)
+
+	_, err := svc.buildValidatedImageRef("ghcr.io/acme/app:latest")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "images.allowed_registries")
+}
+
+func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegistries(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{
+		RegistryAuthEnabled: true,
+		RegistryDomain:      "registry.example.com",
+		RequireImageDigest:  true,
+		AllowedRegistries:   []string{"docker.io"},
+	}, nil)
+
+	_, err := svc.buildValidatedImageRef("docker.io/library/nginx:latest")
+	require.Error(t, err)
+
+	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+
+	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:not-a-digest")
+	require.Error(t, err)
+
+	ref, err := svc.buildValidatedImageRef("myapp:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com/myapp:latest", ref)
+
+	_, err = svc.buildValidatedImageRef("registry.example.com/myapp:latest")
+	require.NoError(t, err)
+}
+
+func TestService_BuildValidatedImageRef_AllowedRegistryMatchesPort(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{AllowedRegistries: []string{"registry.example.com:5000"}}, nil)
+
+	_, err := svc.buildValidatedImageRef("registry.example.com:5000/app:latest")
+	require.NoError(t, err)
+
+	_, err = svc.buildValidatedImageRef("registry.example.com:5001/app:latest")
+	require.Error(t, err)
+}
+
+func TestService_CreateNetworkIfNeeded_UsesInternalOptionWhenConfigured(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{NetworkInternal: true}, nil)
+
+	runtime.EXPECT().NetworkExists(mock.Anything, "gordon-app").Return(false, nil)
+	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-app", domain.NetworkConfig{Driver: "bridge", Internal: true}).Return(nil)
+
+	require.NoError(t, svc.createNetworkIfNeeded(testContext(), "gordon-app"))
+}
+
+func TestService_BuildContainerConfig_StrictSecurityProfile(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{SecurityProfile: "strict"}, nil)
+
+	cfg := svc.buildContainerConfig(containerConfigInput{Domain: "app.example.com", Image: "app:latest", ImageRef: "app:latest"})
+
+	assert.True(t, cfg.ReadOnlyRootFS)
+	assert.Equal(t, []string{"ALL"}, cfg.CapDrop)
+	assert.Equal(t, []string{"NET_BIND_SERVICE"}, cfg.CapAdd)
+}
+
+func TestService_BuildContainerConfig_CompatSecurityProfileDefault(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{}, nil)
+
+	cfg := svc.buildContainerConfig(containerConfigInput{Domain: "app.example.com", Image: "app:latest", ImageRef: "app:latest"})
+
+	assert.False(t, cfg.ReadOnlyRootFS)
+	assert.Nil(t, cfg.CapDrop)
+	assert.Nil(t, cfg.CapAdd)
 }

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -4202,15 +4202,15 @@ func TestService_BuildValidatedImageRef_RegistryPolicy(t *testing.T) {
 		AllowedRegistries:   []string{"docker.io"},
 	}, nil)
 
-	ref, err := svc.buildValidatedImageRef("myapp:latest")
+	ref, err := svc.buildValidatedImageRef(context.Background(), "myapp:latest")
 	require.NoError(t, err)
 	assert.Equal(t, "registry.example.com/myapp:latest", ref)
 
-	ref, err = svc.buildValidatedImageRef("registry.example.com/myapp:latest")
+	ref, err = svc.buildValidatedImageRef(context.Background(), "registry.example.com/myapp:latest")
 	require.NoError(t, err)
 	assert.Equal(t, "registry.example.com/myapp:latest", ref)
 
-	ref, err = svc.buildValidatedImageRef("docker.io/library/nginx:latest")
+	ref, err = svc.buildValidatedImageRef(context.Background(), "docker.io/library/nginx:latest")
 	require.NoError(t, err)
 	assert.Equal(t, "docker.io/library/nginx:latest", ref)
 
@@ -4222,7 +4222,7 @@ func TestService_BuildValidatedImageRef_RegistryPolicy(t *testing.T) {
 		"169.254.169.254/app:latest",
 	} {
 		t.Run(image, func(t *testing.T) {
-			_, err := svc.buildValidatedImageRef(image)
+			_, err := svc.buildValidatedImageRef(context.Background(), image)
 			require.Error(t, err)
 		})
 	}
@@ -4231,7 +4231,7 @@ func TestService_BuildValidatedImageRef_RegistryPolicy(t *testing.T) {
 func TestService_BuildValidatedImageRef_RejectsExternalRegistryWhenAllowlistEmpty(t *testing.T) {
 	svc := NewService(nil, nil, nil, nil, Config{}, nil)
 
-	_, err := svc.buildValidatedImageRef("ghcr.io/acme/app:latest")
+	_, err := svc.buildValidatedImageRef(context.Background(), "ghcr.io/acme/app:latest")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "images.allowed_registries")
 
@@ -4248,33 +4248,33 @@ func TestService_BuildValidatedImageRef_RequireDigestOnlyForExternalAllowedRegis
 		AllowedRegistries:   []string{"docker.io"},
 	}, nil)
 
-	_, err := svc.buildValidatedImageRef("docker.io/library/nginx:latest")
+	_, err := svc.buildValidatedImageRef(context.Background(), "docker.io/library/nginx:latest")
 	require.Error(t, err)
 
 	err = svc.validateImagePullRef(context.Background(), "nginx:latest")
 	require.Error(t, err)
 
-	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	_, err = svc.buildValidatedImageRef(context.Background(), "docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	require.NoError(t, err)
 
-	_, err = svc.buildValidatedImageRef("docker.io/library/nginx@sha256:not-a-digest")
+	_, err = svc.buildValidatedImageRef(context.Background(), "docker.io/library/nginx@sha256:not-a-digest")
 	require.Error(t, err)
 
-	ref, err := svc.buildValidatedImageRef("myapp:latest")
+	ref, err := svc.buildValidatedImageRef(context.Background(), "myapp:latest")
 	require.NoError(t, err)
 	assert.Equal(t, "registry.example.com/myapp:latest", ref)
 
-	_, err = svc.buildValidatedImageRef("registry.example.com/myapp:latest")
+	_, err = svc.buildValidatedImageRef(context.Background(), "registry.example.com/myapp:latest")
 	require.NoError(t, err)
 }
 
 func TestService_BuildValidatedImageRef_AllowedRegistryMatchesPort(t *testing.T) {
 	svc := NewService(nil, nil, nil, nil, Config{AllowedRegistries: []string{"docker.io:5000"}}, nil)
 
-	_, err := svc.buildValidatedImageRef("docker.io:5000/app:latest")
+	_, err := svc.buildValidatedImageRef(context.Background(), "docker.io:5000/app:latest")
 	require.NoError(t, err)
 
-	_, err = svc.buildValidatedImageRef("docker.io:5001/app:latest")
+	_, err = svc.buildValidatedImageRef(context.Background(), "docker.io:5001/app:latest")
 	require.Error(t, err)
 }
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1675,6 +1675,16 @@ func TestNormalizeImageRef(t *testing.T) {
 			input:    "registry.example.com:5000/image:v1.0",
 			expected: "registry.example.com:5000/image",
 		},
+		{
+			name:     "digest ref preserves digest",
+			input:    "registry.example.com/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expected: "registry.example.com/image@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:     "docker hub digest ref preserves digest",
+			input:    "nginx@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			expected: "nginx@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -3,6 +3,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -65,6 +66,12 @@ func NewService(
 
 // GetTarget returns the proxy target for a given domain.
 func (s *Service) GetTarget(ctx context.Context, domainName string) (target *domain.ProxyTarget, retErr error) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return nil, domain.ErrNoTargetAvailable
+	}
+	domainName = canonicalDomain
+
 	ctx, span := proxyTracer.Start(ctx, "proxy.get_target",
 		trace.WithAttributes(attribute.String("domain", domainName)))
 	defer func() {
@@ -181,6 +188,9 @@ func (s *Service) resolveExternalRoute(_ context.Context, domainName, targetAddr
 	if err != nil {
 		return nil, log.WrapErrWithFields(err, "invalid port in external route", map[string]any{"target": targetAddr})
 	}
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("invalid port in external route %q: port must be between 1 and 65535", targetAddr)
+	}
 
 	// SECURITY: Resolve DNS and validate that the target is not an internal/blocked
 	// network. We use the resolved IP as the proxy target to prevent DNS rebinding
@@ -225,29 +235,44 @@ func (s *Service) resolveExternalRoute(_ context.Context, domainName, targetAddr
 
 // RegisterTarget registers a new proxy target for a domain.
 func (s *Service) RegisterTarget(_ context.Context, domainName string, target *domain.ProxyTarget) error {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return domain.ErrRouteDomainInvalid
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.targets[domainName] = target
+	s.targets[canonicalDomain] = target
 	return nil
 }
 
 // UnregisterTarget removes a proxy target for a domain.
 func (s *Service) UnregisterTarget(_ context.Context, domainName string) error {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return domain.ErrRouteDomainInvalid
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.targets, domainName)
+	delete(s.targets, canonicalDomain)
 	return nil
 }
 
 // InvalidateTarget removes a cached proxy target, forcing re-lookup on next request.
 // This is used during zero-downtime deployments to switch traffic to a new container.
 func (s *Service) InvalidateTarget(_ context.Context, domainName string) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	delete(s.targets, domainName)
+	delete(s.targets, canonicalDomain)
 }
 
 // WaitForNoInFlight waits until no requests are currently proxied to the
@@ -303,9 +328,31 @@ func (s *Service) UpdateConfig(config Config) {
 
 // IsRegistryDomain returns true if the host matches the configured registry domain.
 func (s *Service) IsRegistryDomain(host string) bool {
+	canonicalHost, ok := domain.CanonicalRouteDomain(host)
+	if !ok {
+		return false
+	}
+
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.config.RegistryDomain != "" && host == s.config.RegistryDomain
+	registryDomain, ok := domain.CanonicalRouteDomain(s.config.RegistryDomain)
+	s.mu.RUnlock()
+	return ok && canonicalHost == registryDomain
+}
+
+// IsKnownHost returns true if host is configured as registry, route, or external route.
+func (s *Service) IsKnownHost(ctx context.Context, host string) bool {
+	canonicalHost, ok := domain.CanonicalRouteDomain(host)
+	if !ok {
+		return false
+	}
+	if s.IsRegistryDomain(canonicalHost) {
+		return true
+	}
+	if _, err := s.configSvc.GetRoute(ctx, canonicalHost); err == nil {
+		return true
+	}
+	_, ok = s.configSvc.GetExternalRoutes()[canonicalHost]
+	return ok
 }
 
 // TrackInFlight records an in-flight request for a container.

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -47,6 +47,28 @@ func TestService_GetTarget_FromCache(t *testing.T) {
 	assert.Equal(t, cachedTarget, result)
 }
 
+func TestService_GetTarget_CanonicalizesHostForLookup(t *testing.T) {
+	runtime := outmocks.NewMockContainerRuntime(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+	svc := NewService(runtime, containerSvc, configSvc, Config{})
+	ctx := testContext()
+
+	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
+	containerSvc.EXPECT().Get(mock.Anything, "app.example.com").Return(nil, false)
+
+	result, err := svc.GetTarget(ctx, "App.Example.com")
+	assert.ErrorIs(t, err, domain.ErrNoTargetAvailable)
+	assert.Nil(t, result)
+}
+
+func TestService_GetTarget_RejectsInvalidHostAuthority(t *testing.T) {
+	svc := NewService(outmocks.NewMockContainerRuntime(t), inmocks.NewMockContainerService(t), inmocks.NewMockConfigService(t), Config{})
+	result, err := svc.GetTarget(testContext(), "app.example.com:8080")
+	assert.ErrorIs(t, err, domain.ErrNoTargetAvailable)
+	assert.Nil(t, result)
+}
+
 func TestService_GetTarget_ContainerNotFound(t *testing.T) {
 	runtime := outmocks.NewMockContainerRuntime(t)
 	containerSvc := inmocks.NewMockContainerService(t)
@@ -169,22 +191,34 @@ func TestService_GetTarget_ExternalRoute_InvalidTarget(t *testing.T) {
 }
 
 func TestService_GetTarget_ExternalRoute_InvalidPort(t *testing.T) {
-	runtime := outmocks.NewMockContainerRuntime(t)
-	containerSvc := inmocks.NewMockContainerService(t)
-	configSvc := inmocks.NewMockConfigService(t)
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{name: "not a number", target: "localhost:abc"},
+		{name: "zero", target: "localhost:0"},
+		{name: "too high", target: "localhost:65536"},
+	}
 
-	svc := NewService(runtime, containerSvc, configSvc, Config{})
-	ctx := testContext()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := outmocks.NewMockContainerRuntime(t)
+			containerSvc := inmocks.NewMockContainerService(t)
+			configSvc := inmocks.NewMockConfigService(t)
 
-	// Mock external routes with invalid port
-	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{
-		"invalid.example.com": "localhost:abc",
-	})
+			svc := NewService(runtime, containerSvc, configSvc, Config{})
+			ctx := testContext()
 
-	result, err := svc.GetTarget(ctx, "invalid.example.com")
+			configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{
+				"invalid.example.com": tt.target,
+			})
 
-	assert.Error(t, err)
-	assert.Nil(t, result)
+			result, err := svc.GetTarget(ctx, "invalid.example.com")
+
+			assert.Error(t, err)
+			assert.Nil(t, result)
+		})
+	}
 }
 
 func TestService_RegisterTarget(t *testing.T) {
@@ -202,11 +236,11 @@ func TestService_RegisterTarget(t *testing.T) {
 		Scheme:      "http",
 	}
 
-	err := svc.RegisterTarget(ctx, "app.example.com", target)
+	err := svc.RegisterTarget(ctx, "App.Example.com", target)
 
 	assert.NoError(t, err)
 
-	// Verify target is cached
+	// Verify target is cached under the canonical domain.
 	svc.mu.RLock()
 	cached := svc.targets["app.example.com"]
 	svc.mu.RUnlock()
@@ -228,7 +262,7 @@ func TestService_UnregisterTarget(t *testing.T) {
 		Port: 8080,
 	}
 
-	err := svc.UnregisterTarget(ctx, "app.example.com")
+	err := svc.UnregisterTarget(ctx, "App.Example.com")
 
 	assert.NoError(t, err)
 
@@ -313,8 +347,8 @@ func TestService_InvalidateTarget(t *testing.T) {
 		ContainerID: "old-container",
 	}
 
-	// Invalidate the target
-	svc.InvalidateTarget(ctx, "app.example.com")
+	// Invalidate the target using mixed-case input.
+	svc.InvalidateTarget(ctx, "App.Example.com")
 
 	// Verify target is removed from cache
 	svc.mu.RLock()

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -304,7 +304,7 @@ func (s *Service) StartUpload(ctx context.Context, name string) (string, error) 
 }
 
 // AppendBlobChunk appends data to an in-progress blob upload.
-func (s *Service) AppendBlobChunk(ctx context.Context, name, uuid string, data io.Reader) (int64, error) {
+func (s *Service) AppendBlobChunk(ctx context.Context, name, uuid string, data io.Reader, contentLength, maxBlobSize int64) (int64, error) {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldUseCase: "AppendBlobChunk",
@@ -313,7 +313,7 @@ func (s *Service) AppendBlobChunk(ctx context.Context, name, uuid string, data i
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	length, err := s.blobStorage.AppendBlobChunk(name, uuid, data)
+	length, err := s.blobStorage.AppendBlobChunk(name, uuid, data, contentLength, maxBlobSize)
 	if err != nil {
 		return 0, log.WrapErr(err, "failed to append blob chunk")
 	}

--- a/internal/usecase/registry/service_test.go
+++ b/internal/usecase/registry/service_test.go
@@ -306,6 +306,38 @@ func TestService_StartUpload_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to start blob upload")
 }
 
+func TestService_AppendBlobChunk_PassesMaxBlobSize(t *testing.T) {
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(blobStorage, manifestStorage, eventBus)
+	ctx := testContext()
+
+	blobStorage.EXPECT().AppendBlobChunk("myapp", "upload-id", mock.Anything, int64(4), int64(10)).Return(int64(4), nil)
+
+	length, err := svc.AppendBlobChunk(ctx, "myapp", "upload-id", strings.NewReader("data"), 4, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), length)
+}
+
+func TestService_AppendBlobChunk_MaxBlobSizeExceeded(t *testing.T) {
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(blobStorage, manifestStorage, eventBus)
+	ctx := testContext()
+
+	blobStorage.EXPECT().AppendBlobChunk("myapp", "upload-id", mock.Anything, int64(11), int64(10)).Return(int64(0), domain.ErrBlobSizeExceeded)
+
+	_, err := svc.AppendBlobChunk(ctx, "myapp", "upload-id", strings.NewReader("too large"), 11, 10)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrBlobSizeExceeded)
+}
+
 func TestService_FinishUpload_Success(t *testing.T) {
 	blobStorage := mocks.NewMockBlobStorage(t)
 	manifestStorage := mocks.NewMockManifestStorage(t)

--- a/internal/usecase/volumes/service.go
+++ b/internal/usecase/volumes/service.go
@@ -54,7 +54,7 @@ func (s *Service) PruneVolumes(ctx context.Context, dryRun bool) (*domain.Volume
 	var removed []*domain.VolumeInfo
 
 	for _, vol := range vols {
-		if vol.InUse {
+		if !isGordonManagedVolume(vol) || vol.InUse {
 			continue
 		}
 
@@ -71,4 +71,11 @@ func (s *Service) PruneVolumes(ctx context.Context, dryRun bool) (*domain.Volume
 	}
 
 	return report, removed, nil
+}
+
+func isGordonManagedVolume(vol *domain.VolumeInfo) bool {
+	if vol == nil || vol.Labels == nil {
+		return false
+	}
+	return vol.Labels[domain.LabelManaged] == "true"
 }

--- a/internal/usecase/volumes/service_test.go
+++ b/internal/usecase/volumes/service_test.go
@@ -31,8 +31,8 @@ func TestService_PruneVolumes_RemovesOrphaned(t *testing.T) {
 	runtime := outmocks.NewMockContainerRuntime(t)
 
 	vols := []*domain.VolumeInfo{
-		{Name: "vol-in-use", InUse: true, Containers: []string{"web"}},
-		{Name: "vol-orphaned", InUse: false, Size: 1024},
+		{Name: "vol-in-use", InUse: true, Containers: []string{"web"}, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "vol-orphaned", InUse: false, Size: 1024, Labels: map[string]string{domain.LabelManaged: "true"}},
 	}
 	runtime.EXPECT().ListVolumes(context.Background()).Return(vols, nil)
 	runtime.EXPECT().RemoveVolume(context.Background(), "vol-orphaned", false).Return(nil)
@@ -50,7 +50,7 @@ func TestService_PruneVolumes_DryRunDoesNotRemove(t *testing.T) {
 	runtime := outmocks.NewMockContainerRuntime(t)
 
 	vols := []*domain.VolumeInfo{
-		{Name: "vol-orphaned", InUse: false, Size: 2048},
+		{Name: "vol-orphaned", InUse: false, Size: 2048, Labels: map[string]string{domain.LabelManaged: "true"}},
 	}
 	runtime.EXPECT().ListVolumes(context.Background()).Return(vols, nil)
 
@@ -60,6 +60,47 @@ func TestService_PruneVolumes_DryRunDoesNotRemove(t *testing.T) {
 	assert.Equal(t, 1, report.VolumesRemoved)
 	assert.Equal(t, int64(2048), report.SpaceReclaimed)
 	assert.Len(t, removed, 1)
+}
+
+func TestService_PruneVolumes_OnlyRemovesUnusedGordonManagedVolumes(t *testing.T) {
+	runtime := outmocks.NewMockContainerRuntime(t)
+
+	vols := []*domain.VolumeInfo{
+		{Name: "gordon-used", InUse: true, Size: 100, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "gordon-unused", InUse: false, Size: 200, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "other-unused", InUse: false, Size: 300},
+		{Name: "other-labelled-false", InUse: false, Size: 400, Labels: map[string]string{domain.LabelManaged: "false"}},
+		{Name: "other-used", InUse: true, Size: 500},
+	}
+	runtime.EXPECT().ListVolumes(context.Background()).Return(vols, nil)
+	runtime.EXPECT().RemoveVolume(context.Background(), "gordon-unused", false).Return(nil)
+
+	svc := NewService(runtime)
+	report, removed, err := svc.PruneVolumes(context.Background(), false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.VolumesRemoved)
+	assert.Equal(t, int64(200), report.SpaceReclaimed)
+	require.Len(t, removed, 1)
+	assert.Equal(t, "gordon-unused", removed[0].Name)
+}
+
+func TestService_PruneVolumes_DryRunReportsOnlyUnusedGordonManagedVolumes(t *testing.T) {
+	runtime := outmocks.NewMockContainerRuntime(t)
+
+	vols := []*domain.VolumeInfo{
+		{Name: "gordon-used", InUse: true, Size: 100, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "gordon-unused", InUse: false, Size: 200, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "other-unused", InUse: false, Size: 300},
+	}
+	runtime.EXPECT().ListVolumes(context.Background()).Return(vols, nil)
+
+	svc := NewService(runtime)
+	report, removed, err := svc.PruneVolumes(context.Background(), true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, report.VolumesRemoved)
+	assert.Equal(t, int64(200), report.SpaceReclaimed)
+	require.Len(t, removed, 1)
+	assert.Equal(t, "gordon-unused", removed[0].Name)
 }
 
 func TestService_PruneVolumes_AllInUse(t *testing.T) {
@@ -91,8 +132,8 @@ func TestService_PruneVolumes_SkipsFailedRemoval(t *testing.T) {
 	runtime := outmocks.NewMockContainerRuntime(t)
 
 	vols := []*domain.VolumeInfo{
-		{Name: "vol-fail", InUse: false, Size: 1024},
-		{Name: "vol-ok", InUse: false, Size: 2048},
+		{Name: "vol-fail", InUse: false, Size: 1024, Labels: map[string]string{domain.LabelManaged: "true"}},
+		{Name: "vol-ok", InUse: false, Size: 2048, Labels: map[string]string{domain.LabelManaged: "true"}},
 	}
 	runtime.EXPECT().ListVolumes(context.Background()).Return(vols, nil)
 	runtime.EXPECT().RemoveVolume(context.Background(), "vol-fail", false).Return(fmt.Errorf("volume in use"))

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -25,13 +25,6 @@ type NetworkInfo struct {
 	Labels     map[string]string
 }
 
-// NetworkConfig holds options for creating a network.
-type NetworkConfig struct {
-	Driver   string
-	Internal bool
-	Labels   map[string]string
-}
-
 // ContainerConfig holds configuration for creating a container
 type ContainerConfig struct {
 	Image       string
@@ -117,7 +110,7 @@ type Runtime interface {
 	InspectImageEnv(ctx context.Context, imageRef string) ([]string, error)
 
 	// Network management
-	CreateNetwork(ctx context.Context, name string, config NetworkConfig) error
+	CreateNetwork(ctx context.Context, name string, options map[string]string) error
 	RemoveNetwork(ctx context.Context, name string) error
 	ListNetworks(ctx context.Context) ([]*NetworkInfo, error)
 	NetworkExists(ctx context.Context, name string) (bool, error)

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -25,6 +25,13 @@ type NetworkInfo struct {
 	Labels     map[string]string
 }
 
+// NetworkConfig holds options for creating a network.
+type NetworkConfig struct {
+	Driver   string
+	Internal bool
+	Labels   map[string]string
+}
+
 // ContainerConfig holds configuration for creating a container
 type ContainerConfig struct {
 	Image       string
@@ -110,7 +117,7 @@ type Runtime interface {
 	InspectImageEnv(ctx context.Context, imageRef string) ([]string, error)
 
 	// Network management
-	CreateNetwork(ctx context.Context, name string, options map[string]string) error
+	CreateNetwork(ctx context.Context, name string, config NetworkConfig) error
 	RemoveNetwork(ctx context.Context, name string) error
 	ListNetworks(ctx context.Context) ([]*NetworkInfo, error)
 	NetworkExists(ctx context.Context, name string) (bool, error)


### PR DESCRIPTION
## Summary

Implements the full security hardening audit fix set across registry uploads, admin log/config exposure, auto-route/env handling, domain canonicalization, volume pruning, backup storage, secrets migration, image pull policy, Docker runtime hardening, and install/supply-chain defaults.

Key changes:
- Limit cumulative registry blob uploads and cancel failed oversized uploads.
- Add `admin:logs:read` and `admin:volumes:*` scopes; redact sensitive log output.
- Harden auto-route env-file extraction and canonicalize route/host domains.
- Restrict volume pruning to Gordon-managed unused volumes.
- Make backup filenames/temp files collision-safe.
- Secure unsafe secret file reads and remove plaintext `.env` after successful pass migration.
- Redact sensitive `/admin/config` details by default.
- Add external registry allowlist/digest policy, internal network option, and strict/compat runtime profiles.
- Harden install script and setup action checksum/extraction behavior.
- Add `gordon.toml.example`, `.dockerignore`, gitleaks config, and security hardening docs.

## Verification

- `rtk go test ./...` — passed (`2682` tests)
- `rtk golangci-lint run ./...` — passed
- `rtk go mod verify` — passed
- `gitleaks detect` on clean `git archive HEAD` — passed, no leaks
- `docker build -t gordon-security-hardening-test .` — passed
- `bash -n install.sh` — passed
- setup action YAML parse — passed
- `GOFLAGS=-mod=readonly rtk govulncheck ./...` — only reports known Docker/Moby no-fix advisories:
  - `GO-2026-4887`
  - `GO-2026-4883`

## Reviews

- Phase-by-phase Go/security reviews completed.
- Final full-branch Go and security reviews completed.
- Follow-up targeted review findings were fixed and approved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container security profiles (compat/strict), image registry allowlist & digest enforcement, network isolation toggle, cumulative blob upload size cap, new admin scopes for logs & volumes, safer HTTPS redirects by validating known hosts

* **Bug Fixes**
  * Host/domain canonicalization for routing and redirects, stricter env-file path validation, secret redaction in logs and deploy failures, volume pruning limited to managed volumes, upload size enforcement and cleanup

* **Documentation**
  * New security hardening guide, expanded CLI/config docs, example configuration added

* **Configuration**
  * Updated base images and default port (8088), added repository security configs and Docker ignore, installer checksum/verification improvements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->