### PR TITLE
Preserve route host for managed proxy targets

### DIFF
--- a/internal/adapters/in/http/proxy/forwarder.go
+++ b/internal/adapters/in/http/proxy/forwarder.go
@@ -90,14 +90,19 @@ func (h *Handler) forwardToTarget(w http.ResponseWriter, r *http.Request, target
 		return
 	}
 
-	originalHost := target.OriginalHost
 	releaseInFlight := h.proxySvc.TrackInFlight(target.ContainerID)
 	defer releaseInFlight()
 
 	transport := h.transportForTarget(target)
 
-	proxy := newReverseProxy(targetURL, originalHost, transport, r, h.trustedNets,
-		func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
+	proxy := newReverseProxy(reverseProxyOptions{
+		targetURL:     targetURL,
+		hostHeader:    targetHostHeader(target, targetURL),
+		forwardedHost: target.RouteHost,
+		transport:     transport,
+		incomingReq:   r,
+		trustedNets:   h.trustedNets,
+		errorHandler: func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(proxyErr, &maxBytesErr) {
 				log.Warn().Err(proxyErr).Str("target", targetURL.String()).Msg("proxy error: request body too large")
@@ -107,8 +112,8 @@ func (h *Handler) forwardToTarget(w http.ResponseWriter, r *http.Request, target
 			log.Error().Err(proxyErr).Str("target", targetURL.String()).Msg("proxy error: connection failed")
 			proxyError(w, "Service Unavailable", http.StatusServiceUnavailable)
 		},
-		modifyResponse(maxResponseSize),
-	)
+		modifyResponse: modifyResponse(maxResponseSize),
+	})
 
 	if target.Protocol == "h2c" {
 		log.Debug().
@@ -176,39 +181,57 @@ func (h *Handler) forwardToRegistry(w http.ResponseWriter, r *http.Request, regi
 	proxy.ServeHTTP(w, r)
 }
 
+type reverseProxyOptions struct {
+	targetURL      *url.URL
+	hostHeader     string
+	forwardedHost  string
+	transport      http.RoundTripper
+	incomingReq    *http.Request
+	trustedNets    []*net.IPNet
+	errorHandler   func(http.ResponseWriter, *http.Request, error)
+	modifyResponse func(*http.Response) error
+}
+
+func targetHostHeader(target *domain.ProxyTarget, targetURL *url.URL) string {
+	if target.RouteHost != "" {
+		return target.RouteHost
+	}
+	if target.OriginalHost != "" {
+		return net.JoinHostPort(target.OriginalHost, targetURL.Port())
+	}
+	return targetURL.Host
+}
+
 // newReverseProxy creates a reverse proxy using Rewrite instead of Director to prevent
 // hop-by-hop header attacks. A malicious client could send "Connection: Authorization"
 // to strip the Authorization header when using the default Director. Rewrite processes
 // headers after hop-by-hop removal, ensuring headers like Authorization are preserved.
 //
-// originalHost, when non-empty, overrides the Host header sent to the backend.
-// This is used for DNS-pinned targets where the proxy dials an IP but needs to
-// send the original hostname for virtual-hosted upstreams.
-//
 // incomingReq and trustedNets are used to preserve X-Forwarded-Proto when the
 // request originates from a trusted upstream proxy.
-func newReverseProxy(targetURL *url.URL, originalHost string, transport http.RoundTripper, incomingReq *http.Request, trustedNets []*net.IPNet, errorHandler func(http.ResponseWriter, *http.Request, error), modifyResp func(*http.Response) error) *httputil.ReverseProxy {
+func newReverseProxy(opts reverseProxyOptions) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			existingProto := pr.In.Header.Get("X-Forwarded-Proto")
-			pr.SetURL(targetURL)
+			pr.SetURL(opts.targetURL)
 			pr.SetXForwarded()
-			if originalHost != "" {
-				pr.Out.Host = net.JoinHostPort(originalHost, targetURL.Port())
-			} else {
-				pr.Out.Host = targetURL.Host
+			if opts.hostHeader != "" {
+				pr.Out.Host = opts.hostHeader
+			}
+			if opts.forwardedHost != "" {
+				pr.Out.Header.Set("X-Forwarded-Host", opts.forwardedHost)
 			}
 			// Preserve X-Forwarded-Proto from trusted upstream proxies.
 			// SetXForwarded() unconditionally sets it based on the incoming scheme
 			// (HTTP between proxies), but when a trusted proxy already sent the
 			// real client proto, we must honor it.
-			if existingProto != "" && gordonhttp.IsTrustedSource(incomingReq, trustedNets) {
+			if existingProto != "" && gordonhttp.IsTrustedSource(opts.incomingReq, opts.trustedNets) {
 				pr.Out.Header.Set("X-Forwarded-Proto", existingProto)
 			}
 		},
-		Transport:      transport,
-		ErrorHandler:   errorHandler,
-		ModifyResponse: modifyResp,
+		Transport:      opts.transport,
+		ErrorHandler:   opts.errorHandler,
+		ModifyResponse: opts.modifyResponse,
 	}
 }
 

--- a/internal/adapters/in/http/proxy/forwarder_test.go
+++ b/internal/adapters/in/http/proxy/forwarder_test.go
@@ -145,7 +145,44 @@ func TestForwardToTarget_OriginalHostPreserved(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, receivedHost, "upstream.example.com")
+	assert.Equal(t, net.JoinHostPort("upstream.example.com", strconv.Itoa(backendPort)), receivedHost)
+}
+
+func TestForwardToTarget_RouteHostPreservedForManagedTarget(t *testing.T) {
+	var receivedHost string
+	var receivedForwardedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		receivedForwardedHost = r.Header.Get("X-Forwarded-Host")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	proxySvc := inmocks.NewMockProxyService(t)
+
+	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+	proxySvc.EXPECT().IsRegistryDomain("app.example.com").Return(false)
+	proxySvc.EXPECT().GetTarget(mock.Anything, "app.example.com").Return(&domain.ProxyTarget{
+		Host:        "127.0.0.1",
+		Port:        backendPort,
+		ContainerID: "c-1",
+		Scheme:      "http",
+		RouteHost:   "app.example.com",
+	}, nil)
+	proxySvc.EXPECT().TrackInFlight("c-1").Return(func() {})
+
+	handler := NewHandler(proxySvc, nil, zerowrap.Default())
+
+	req := httptest.NewRequest(http.MethodGet, "http://app.example.com/", nil)
+	req.Host = "App.Example.com:443"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "app.example.com", receivedHost)
+	assert.Equal(t, "app.example.com", receivedForwardedHost)
 }
 
 func TestForwardToTarget_BackendDown_Returns503(t *testing.T) {
@@ -280,12 +317,15 @@ func TestNewReverseProxy_XForwardedProto(t *testing.T) {
 				incomingReq.Header.Set("X-Forwarded-Proto", tt.incomingProto)
 			}
 
-			proxy := newReverseProxy(backendURL, "", http.DefaultTransport, incomingReq, tt.nets,
-				func(w http.ResponseWriter, _ *http.Request, err error) {
+			proxy := newReverseProxy(reverseProxyOptions{
+				targetURL:   backendURL,
+				transport:   http.DefaultTransport,
+				incomingReq: incomingReq,
+				trustedNets: tt.nets,
+				errorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
 					http.Error(w, err.Error(), http.StatusBadGateway)
 				},
-				nil,
-			)
+			})
 
 			rec := httptest.NewRecorder()
 			proxy.ServeHTTP(rec, incomingReq)

--- a/internal/domain/route.go
+++ b/internal/domain/route.go
@@ -15,7 +15,8 @@ type ProxyTarget struct {
 	ContainerID  string
 	Scheme       string // "http" or "https"
 	Protocol     string // "" (default HTTP/1.1) or "h2c" (cleartext HTTP/2)
-	OriginalHost string // Original hostname before DNS resolution (for Host header)
+	OriginalHost string // Original hostname before DNS resolution (for external-route Host header)
+	RouteHost    string // Canonical matched route domain for managed-route Host header
 }
 
 // RouteMatch represents the result of matching a request to a route.

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -134,6 +134,7 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 			ContainerID: container.ID,
 			Scheme:      "http",
 			Protocol:    meta.Protocol,
+			RouteHost:   domainName,
 		}
 	} else {
 		// Gordon is on the host - use host port mapping
@@ -166,6 +167,7 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 			ContainerID: container.ID,
 			Scheme:      "http",
 			Protocol:    meta.Protocol,
+			RouteHost:   domainName,
 		}
 	}
 

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -644,6 +644,7 @@ func TestService_GetTarget_HostMode_UsesProxyPortLabel(t *testing.T) {
 	assert.Equal(t, "localhost", result.Host)
 	assert.Equal(t, 32000, result.Port)
 	assert.Equal(t, "c-gitea", result.ContainerID)
+	assert.Equal(t, "git.example.com", result.RouteHost)
 }
 
 func TestService_GetTarget_HostMode_UsesDeprecatedPortLabel(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve the canonical matched route host when proxying managed container routes
- Set managed-route `X-Forwarded-Host` to the canonical route host instead of the raw/internal target
- Add regression coverage for managed route host preservation and keep external route host behavior covered

Fixes #179

## Test Plan
- [x] go test ./internal/adapters/in/http/proxy ./internal/usecase/proxy -count=1
- [x] go test ./...
- [x] golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Host header preservation when forwarding requests through the proxy, with enhanced support for distinguishing between managed and external route host configurations.
  * Refined X-Forwarded-Host header generation in proxy forwarding operations to ensure proper header propagation and consistency.

* **Tests**
  * Expanded test coverage to validate Host header preservation behavior across managed routes and various backend connectivity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->