### PR TITLE
Add global DNS config for ACME DNS-01

### DIFF
--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -24,6 +24,14 @@ proxy_allowed_ips = []                       # IPs or CIDR ranges allowed to rea
 registry_listen_address = ""                 # Bind address for registry (empty = all interfaces, "127.0.0.1" = loopback only)
 
 # =============================================================================
+# DNS
+# =============================================================================
+[dns]
+resolvers = ["1.1.1.1:53", "8.8.8.8:53"] # Recursive resolvers for public DNS visibility checks
+propagation_timeout = "5m"                 # Max wait for DNS-01 TXT propagation
+polling_interval = "5s"                    # Interval between DNS-01 propagation checks
+
+# =============================================================================
 # AUTHENTICATION (required - Gordon won't start without credentials configured)
 # =============================================================================
 [auth]
@@ -204,6 +212,9 @@ keep_last = 3                                # Keep N newest tags per repository
 | `server.registry_allowed_ips` | `[]` | IPs or CIDR ranges allowed to access the registry (empty = allow all) |
 | `server.proxy_allowed_ips` | `[]` | IPs or CIDR ranges allowed to reach the proxy (empty = allow all) |
 | `server.registry_listen_address` | `""` | Bind address for registry (empty = all interfaces) |
+| `dns.resolvers` | `["1.1.1.1:53", "8.8.8.8:53"]` | Recursive resolvers used for public DNS visibility checks, including ACME DNS-01 propagation |
+| `dns.propagation_timeout` | `"5m"` | Maximum time to wait for DNS-01 TXT records to become visible through configured recursive resolvers |
+| `dns.polling_interval` | `"5s"` | Interval between DNS-01 propagation checks |
 | `tls.acme.enabled` | `false` | Enable public ACME certificates (requires `server.tls_port > 0`) |
 | `tls.acme.email` | `""` | ACME account email when enabled |
 | `tls.acme.challenge` | `"auto"` | ACME challenge mode: `auto`, `http-01`, or `cloudflare-dns-01` |

--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -92,6 +92,11 @@ Gordon can obtain public certificates through Let's Encrypt-compatible ACME when
 [server]
 tls_port = 8443
 
+[dns]
+resolvers = ["1.1.1.1:53", "8.8.8.8:53"]
+propagation_timeout = "5m"
+polling_interval = "5s"
+
 [tls.acme]
 enabled = true
 email = "admin@example.com"
@@ -113,6 +118,12 @@ If the initial ACME reconcile fails (e.g. due to a transient network error or mi
 For Cloudflare Full/Strict, Cloudflare terminates browser TLS at the edge and connects to Gordon over HTTPS. A public ACME certificate served by Gordon is the preferred origin certificate because Cloudflare Strict can validate it without custom origin trust. Cloudflare Flexible mode (HTTPS at the edge, HTTP to Gordon) is not end-to-end HTTPS.
 
 Static certificates have priority, then public ACME certificates, then Gordon's internal CA fallback. Gordon uses the `go-acme/lego` ACME client, including its DNS-provider support for Cloudflare DNS-01.
+
+DNS-01 uses the Cloudflare API to create TXT records, then checks public DNS visibility through `[dns].resolvers`. These resolvers are recursive resolvers (for example Cloudflare DNS or Google DNS), not the authoritative DNS provider. A domain can be hosted at Cloudflare while Gordon verifies propagation through Google DNS.
+
+The defaults avoid relying on host-local DNS. This matters on hosts using Tailscale MagicDNS, split-horizon corporate DNS, or Pi-hole, where `/etc/resolv.conf` may not reflect public DNS visibility as Let's Encrypt sees it.
+
+Because Gordon's ACME challenge mode is global, `cloudflare-dns-01` requires a Cloudflare token that can read zones and edit DNS records for every zone used by configured HTTPS routes. If that is not desirable, use `http-01` until Gordon supports per-route or per-zone challenge policy.
 
 #### Direct HTTP Onboarding
 

--- a/internal/adapters/out/acmelego/issuer.go
+++ b/internal/adapters/out/acmelego/issuer.go
@@ -92,13 +92,16 @@ func NewIssuer(cfg Config) (*Issuer, error) {
 			return nil, fmt.Errorf("acmelego: %w", domain.ErrCloudflareTokenMissing)
 		}
 		if len(cfg.DNSResolvers) == 0 {
-			return nil, fmt.Errorf("acmelego: DNSResolvers must contain at least one resolver")
+			return nil, fmt.Errorf("acmelego: %w: DNSResolvers must contain at least one resolver", domain.ErrDNSConfigInvalid)
 		}
 		if cfg.DNSPropagationTimeout <= 0 {
-			return nil, fmt.Errorf("acmelego: DNSPropagationTimeout must be positive")
+			return nil, fmt.Errorf("acmelego: %w: DNSPropagationTimeout must be positive", domain.ErrDNSConfigInvalid)
 		}
 		if cfg.DNSPollingInterval <= 0 {
-			return nil, fmt.Errorf("acmelego: DNSPollingInterval must be positive")
+			return nil, fmt.Errorf("acmelego: %w: DNSPollingInterval must be positive", domain.ErrDNSConfigInvalid)
+		}
+		if cfg.DNSPollingInterval >= cfg.DNSPropagationTimeout {
+			return nil, fmt.Errorf("acmelego: %w: DNSPollingInterval must be less than DNSPropagationTimeout", domain.ErrDNSConfigInvalid)
 		}
 	default:
 		return nil, fmt.Errorf("acmelego: %w: %s", domain.ErrACMEChallengeInvalid, cfg.Challenge)

--- a/internal/adapters/out/acmelego/issuer.go
+++ b/internal/adapters/out/acmelego/issuer.go
@@ -7,7 +7,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -91,9 +93,11 @@ func NewIssuer(cfg Config) (*Issuer, error) {
 		if cfg.Token == "" {
 			return nil, fmt.Errorf("acmelego: %w", domain.ErrCloudflareTokenMissing)
 		}
-		if len(cfg.DNSResolvers) == 0 {
-			return nil, fmt.Errorf("acmelego: %w: DNSResolvers must contain at least one resolver", domain.ErrDNSConfigInvalid)
+		resolvers, err := normalizeDNSResolvers(cfg.DNSResolvers)
+		if err != nil {
+			return nil, err
 		}
+		cfg.DNSResolvers = resolvers
 		if cfg.DNSPropagationTimeout <= 0 {
 			return nil, fmt.Errorf("acmelego: %w: DNSPropagationTimeout must be positive", domain.ErrDNSConfigInvalid)
 		}
@@ -108,6 +112,34 @@ func NewIssuer(cfg Config) (*Issuer, error) {
 	}
 
 	return &Issuer{cfg: cfg}, nil
+}
+
+func normalizeDNSResolvers(resolvers []string) ([]string, error) {
+	if len(resolvers) == 0 {
+		return nil, fmt.Errorf("acmelego: %w: DNSResolvers must contain at least one resolver", domain.ErrDNSConfigInvalid)
+	}
+
+	normalized := make([]string, len(resolvers))
+	for i, resolver := range resolvers {
+		trimmed := strings.TrimSpace(resolver)
+		if trimmed == "" {
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+		}
+		host, port, err := net.SplitHostPort(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+		}
+		if host == "" {
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+		}
+		normalized[i] = trimmed
+	}
+
+	return normalized, nil
 }
 
 // compile-time interface check

--- a/internal/adapters/out/acmelego/issuer.go
+++ b/internal/adapters/out/acmelego/issuer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-acme/lego/v4/acme"
 	"github.com/go-acme/lego/v4/certcrypto"
 	"github.com/go-acme/lego/v4/certificate"
+	"github.com/go-acme/lego/v4/challenge/dns01"
 	"github.com/go-acme/lego/v4/lego"
 	"github.com/go-acme/lego/v4/providers/dns/cloudflare"
 	"github.com/go-acme/lego/v4/registration"
@@ -33,6 +34,15 @@ type Config struct {
 
 	// Token is the Cloudflare API token (required for DNS-01 challenge).
 	Token string
+
+	// DNSResolvers are recursive resolvers used for DNS-01 propagation checks.
+	DNSResolvers []string
+
+	// DNSPropagationTimeout is the maximum wait for DNS-01 TXT propagation.
+	DNSPropagationTimeout time.Duration
+
+	// DNSPollingInterval is the interval between DNS-01 propagation checks.
+	DNSPollingInterval time.Duration
 
 	// Store persists ACME accounts and certificates.
 	Store out.CertificateStore
@@ -80,6 +90,15 @@ func NewIssuer(cfg Config) (*Issuer, error) {
 	case domain.ACMEChallengeCloudflareDNS01:
 		if cfg.Token == "" {
 			return nil, fmt.Errorf("acmelego: %w", domain.ErrCloudflareTokenMissing)
+		}
+		if len(cfg.DNSResolvers) == 0 {
+			return nil, fmt.Errorf("acmelego: DNSResolvers must contain at least one resolver")
+		}
+		if cfg.DNSPropagationTimeout <= 0 {
+			return nil, fmt.Errorf("acmelego: DNSPropagationTimeout must be positive")
+		}
+		if cfg.DNSPollingInterval <= 0 {
+			return nil, fmt.Errorf("acmelego: DNSPollingInterval must be positive")
 		}
 	default:
 		return nil, fmt.Errorf("acmelego: %w: %s", domain.ErrACMEChallengeInvalid, cfg.Challenge)
@@ -208,13 +227,11 @@ func (i *Issuer) buildClient(ctx context.Context) (*AccountUser, *lego.Client, e
 			return nil, nil, fmt.Errorf("set http-01 provider: %w", err)
 		}
 	case domain.ACMEChallengeCloudflareDNS01:
-		cfCfg := cloudflare.NewDefaultConfig()
-		cfCfg.AuthToken = i.cfg.Token
-		cfProvider, err := cloudflare.NewDNSProviderConfig(cfCfg)
+		cfProvider, err := cloudflare.NewDNSProviderConfig(newCloudflareDNSProviderConfig(i.cfg))
 		if err != nil {
 			return nil, nil, fmt.Errorf("create cloudflare dns provider: %w", err)
 		}
-		if err := client.Challenge.SetDNS01Provider(cfProvider); err != nil {
+		if err := client.Challenge.SetDNS01Provider(cfProvider, dns01.AddRecursiveNameservers(i.cfg.DNSResolvers)); err != nil {
 			return nil, nil, fmt.Errorf("set dns-01 provider: %w", err)
 		}
 	}
@@ -310,6 +327,15 @@ func (i *Issuer) newLegoConfig(user *AccountUser) *lego.Config {
 		legoCfg.HTTPClient = i.cfg.HTTPClient
 	}
 	return legoCfg
+}
+
+// newCloudflareDNSProviderConfig creates a cloudflare DNS provider config from the issuer config.
+func newCloudflareDNSProviderConfig(cfg Config) *cloudflare.Config {
+	cfCfg := cloudflare.NewDefaultConfig()
+	cfCfg.AuthToken = cfg.Token
+	cfCfg.PropagationTimeout = cfg.DNSPropagationTimeout
+	cfCfg.PollingInterval = cfg.DNSPollingInterval
+	return cfCfg
 }
 
 // resourceToStored converts a lego certificate.Resource to out.StoredCertificate.

--- a/internal/adapters/out/acmelego/issuer.go
+++ b/internal/adapters/out/acmelego/issuer.go
@@ -123,18 +123,18 @@ func normalizeDNSResolvers(resolvers []string) ([]string, error) {
 	for i, resolver := range resolvers {
 		trimmed := strings.TrimSpace(resolver)
 		if trimmed == "" {
-			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry at index %d value %q", domain.ErrDNSConfigInvalid, i, trimmed)
 		}
 		host, port, err := net.SplitHostPort(trimmed)
 		if err != nil {
-			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry at index %d value %q: %v", domain.ErrDNSConfigInvalid, i, trimmed, err)
 		}
 		if host == "" {
-			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry at index %d value %q: host must not be empty", domain.ErrDNSConfigInvalid, i, trimmed)
 		}
 		portNumber, err := strconv.Atoi(port)
 		if err != nil || portNumber < 1 || portNumber > 65535 {
-			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry", domain.ErrDNSConfigInvalid)
+			return nil, fmt.Errorf("acmelego: %w: invalid DNSResolvers entry at index %d value %q: port must be a number between 1 and 65535", domain.ErrDNSConfigInvalid, i, trimmed)
 		}
 		normalized[i] = trimmed
 	}

--- a/internal/adapters/out/acmelego/issuer_test.go
+++ b/internal/adapters/out/acmelego/issuer_test.go
@@ -69,6 +69,31 @@ func TestNewIssuerValidatesCloudflareToken(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrCloudflareTokenMissing)
 }
 
+func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
+	_, err := NewIssuer(Config{
+		Email:                 "test@example.com",
+		Challenge:             domain.ACMEChallengeCloudflareDNS01,
+		Token:                 "token",
+		Store:                 outmocks.NewMockCertificateStore(t),
+		DNSResolvers:          nil,
+		DNSPropagationTimeout: 5 * time.Minute,
+		DNSPollingInterval:    5 * time.Second,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DNSResolvers")
+
+	_, err = NewIssuer(Config{
+		Email:                 "test@example.com",
+		Challenge:             domain.ACMEChallengeCloudflareDNS01,
+		Token:                 "token",
+		Store:                 outmocks.NewMockCertificateStore(t),
+		DNSResolvers:          []string{"1.1.1.1:53"},
+		DNSPropagationTimeout: 5 * time.Minute,
+		DNSPollingInterval:    5 * time.Second,
+	})
+	require.NoError(t, err)
+}
+
 func TestNewIssuerRejectsNonHTTPSURL(t *testing.T) {
 	_, err := NewIssuer(Config{
 		Email:             "test@example.com",
@@ -100,6 +125,20 @@ func TestNewIssuerValidWithDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, issuer)
 	assert.Equal(t, domain.ACMEChallengeHTTP01, issuer.cfg.Challenge)
+}
+
+func TestCloudflareDNSProviderConfigUsesDNSSettings(t *testing.T) {
+	cfg := Config{
+		Token:                 "token",
+		DNSPropagationTimeout: 7 * time.Minute,
+		DNSPollingInterval:    11 * time.Second,
+	}
+
+	cfCfg := newCloudflareDNSProviderConfig(cfg)
+
+	assert.Equal(t, "token", cfCfg.AuthToken)
+	assert.Equal(t, 7*time.Minute, cfCfg.PropagationTimeout)
+	assert.Equal(t, 11*time.Second, cfCfg.PollingInterval)
 }
 
 func TestPrivateKeyRoundTrip(t *testing.T) {

--- a/internal/adapters/out/acmelego/issuer_test.go
+++ b/internal/adapters/out/acmelego/issuer_test.go
@@ -95,6 +95,8 @@ func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
 	assert.Contains(t, err.Error(), "invalid DNSResolvers entry")
+	assert.Contains(t, err.Error(), "index 0")
+	assert.Contains(t, err.Error(), "1.1.1.1:abc")
 
 	_, err = NewIssuer(Config{
 		Email:                 "test@example.com",
@@ -120,6 +122,30 @@ func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1.1.1.1:53", "8.8.8.8:53"}, issuer.cfg.DNSResolvers)
+}
+
+func TestNormalizeDNSResolversErrorsIncludeEntryContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver string
+		want     string
+	}{
+		{name: "empty after trimming", resolver: " \t ", want: "value \"\""},
+		{name: "missing port", resolver: "1.1.1.1", want: "value \"1.1.1.1\""},
+		{name: "empty host", resolver: ":53", want: "value \":53\""},
+		{name: "invalid port", resolver: "1.1.1.1:abc", want: "value \"1.1.1.1:abc\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := normalizeDNSResolvers([]string{"8.8.8.8:53", tt.resolver})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
+			assert.Contains(t, err.Error(), "invalid DNSResolvers entry")
+			assert.Contains(t, err.Error(), "index 1")
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
 }
 
 func TestNewIssuerRejectsNonHTTPSURL(t *testing.T) {

--- a/internal/adapters/out/acmelego/issuer_test.go
+++ b/internal/adapters/out/acmelego/issuer_test.go
@@ -88,6 +88,19 @@ func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
 		Challenge:             domain.ACMEChallengeCloudflareDNS01,
 		Token:                 "token",
 		Store:                 outmocks.NewMockCertificateStore(t),
+		DNSResolvers:          []string{"1.1.1.1:abc"},
+		DNSPropagationTimeout: 5 * time.Minute,
+		DNSPollingInterval:    5 * time.Second,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
+	assert.Contains(t, err.Error(), "invalid DNSResolvers entry")
+
+	_, err = NewIssuer(Config{
+		Email:                 "test@example.com",
+		Challenge:             domain.ACMEChallengeCloudflareDNS01,
+		Token:                 "token",
+		Store:                 outmocks.NewMockCertificateStore(t),
 		DNSResolvers:          []string{"1.1.1.1:53"},
 		DNSPropagationTimeout: 5 * time.Second,
 		DNSPollingInterval:    5 * time.Second,
@@ -96,16 +109,17 @@ func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
 	assert.Contains(t, err.Error(), "DNSPollingInterval")
 
-	_, err = NewIssuer(Config{
+	issuer, err := NewIssuer(Config{
 		Email:                 "test@example.com",
 		Challenge:             domain.ACMEChallengeCloudflareDNS01,
 		Token:                 "token",
 		Store:                 outmocks.NewMockCertificateStore(t),
-		DNSResolvers:          []string{"1.1.1.1:53"},
+		DNSResolvers:          []string{" 1.1.1.1:53 ", "\t8.8.8.8:53\n"},
 		DNSPropagationTimeout: 5 * time.Minute,
 		DNSPollingInterval:    5 * time.Second,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, []string{"1.1.1.1:53", "8.8.8.8:53"}, issuer.cfg.DNSResolvers)
 }
 
 func TestNewIssuerRejectsNonHTTPSURL(t *testing.T) {

--- a/internal/adapters/out/acmelego/issuer_test.go
+++ b/internal/adapters/out/acmelego/issuer_test.go
@@ -80,7 +80,21 @@ func TestNewIssuerValidatesCloudflareDNSConfig(t *testing.T) {
 		DNSPollingInterval:    5 * time.Second,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
 	assert.Contains(t, err.Error(), "DNSResolvers")
+
+	_, err = NewIssuer(Config{
+		Email:                 "test@example.com",
+		Challenge:             domain.ACMEChallengeCloudflareDNS01,
+		Token:                 "token",
+		Store:                 outmocks.NewMockCertificateStore(t),
+		DNSResolvers:          []string{"1.1.1.1:53"},
+		DNSPropagationTimeout: 5 * time.Second,
+		DNSPollingInterval:    5 * time.Second,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
+	assert.Contains(t, err.Error(), "DNSPollingInterval")
 
 	_, err = NewIssuer(Config{
 		Email:                 "test@example.com",

--- a/internal/app/acme_config_test.go
+++ b/internal/app/acme_config_test.go
@@ -15,4 +15,7 @@ func TestLoadConfig_ACMEDefaults(t *testing.T) {
 	assert.Equal(t, "", v.GetString("tls.acme.email"))
 	assert.Equal(t, "auto", v.GetString("tls.acme.challenge"))
 	assert.Equal(t, 1, v.GetInt("tls.acme.obtain_batch_size"))
+	assert.Equal(t, []string{"1.1.1.1:53", "8.8.8.8:53"}, v.GetStringSlice("dns.resolvers"))
+	assert.Equal(t, "5m", v.GetString("dns.propagation_timeout"))
+	assert.Equal(t, "5s", v.GetString("dns.polling_interval"))
 }

--- a/internal/app/dns_config_test.go
+++ b/internal/app/dns_config_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDNSConfigFromConfig(t *testing.T) {
+	cfg := Config{}
+	cfg.DNS.Resolvers = []string{"9.9.9.9:53", "1.1.1.1:53"}
+	cfg.DNS.PropagationTimeout = "10m"
+	cfg.DNS.PollingInterval = "10s"
+
+	dnsCfg, err := buildDNSConfig(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"9.9.9.9:53", "1.1.1.1:53"}, dnsCfg.Resolvers)
+	assert.Equal(t, 10*time.Minute, dnsCfg.PropagationTimeout)
+	assert.Equal(t, 10*time.Second, dnsCfg.PollingInterval)
+}
+
+func TestBuildDNSConfigRejectsInvalidDuration(t *testing.T) {
+	cfg := Config{}
+	cfg.DNS.PropagationTimeout = "not-a-duration"
+
+	_, err := buildDNSConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dns.propagation_timeout")
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -553,6 +553,11 @@ func (si *serviceInit) initPublicTLS() error {
 	ctx := si.ctx
 	log := si.log
 
+	dnsCfg, err := buildDNSConfig(si.cfg)
+	if err != nil {
+		return log.WrapErr(err, "invalid DNS configuration")
+	}
+
 	publicTLSCfg := publictls.Config{
 		Enabled:         si.cfg.TLS.ACME.Enabled,
 		Email:           si.cfg.TLS.ACME.Email,
@@ -561,6 +566,7 @@ func (si *serviceInit) initPublicTLS() error {
 		TLSPort:         si.cfg.Server.TLSPort,
 		DataDir:         resolveDataDir(si.cfg.Server.DataDir),
 		ObtainBatchSize: si.cfg.TLS.ACME.ObtainBatchSize,
+		DNS:             dnsCfg,
 	}
 
 	tokenResolver := secrets.NewPublicTLSResolver(secrets.PublicTLSResolverConfig{})
@@ -583,11 +589,14 @@ func (si *serviceInit) initPublicTLS() error {
 	}
 
 	issuer, err := acmelego.NewIssuer(acmelego.Config{
-		Email:             si.cfg.TLS.ACME.Email,
-		Challenge:         effective.Mode,
-		Token:             effective.Token,
-		Store:             store,
-		HTTPChallengeSink: challenges,
+		Email:                 si.cfg.TLS.ACME.Email,
+		Challenge:             effective.Mode,
+		Token:                 effective.Token,
+		Store:                 store,
+		HTTPChallengeSink:     challenges,
+		DNSResolvers:          publicTLSCfg.DNS.Resolvers,
+		DNSPropagationTimeout: publicTLSCfg.DNS.PropagationTimeout,
+		DNSPollingInterval:    publicTLSCfg.DNS.PollingInterval,
 	})
 	if err != nil {
 		return log.WrapErr(err, "create ACME issuer")

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -204,6 +204,12 @@ type Config struct {
 			ObtainBatchSize int    `mapstructure:"obtain_batch_size"`
 		} `mapstructure:"acme"`
 	} `mapstructure:"tls"`
+
+	DNS struct {
+		Resolvers          []string `mapstructure:"resolvers"`
+		PropagationTimeout string   `mapstructure:"propagation_timeout"`
+		PollingInterval    string   `mapstructure:"polling_interval"`
+	} `mapstructure:"dns"`
 }
 
 // services holds all the services used by the application.
@@ -1748,6 +1754,44 @@ func buildProxyConfig(cfg Config, log zerowrap.Logger) (*proxyConfigResult, erro
 	}, nil
 }
 
+// buildDNSConfig parses the raw dns config section into a publictls.DNSConfig.
+func buildDNSConfig(cfg Config) (publictls.DNSConfig, error) {
+	defaults := publictls.DefaultDNSConfig()
+
+	resolvers := cfg.DNS.Resolvers
+	if len(resolvers) == 0 {
+		resolvers = defaults.Resolvers
+	}
+
+	propagationTimeout := defaults.PropagationTimeout
+	if cfg.DNS.PropagationTimeout != "" {
+		parsed, err := time.ParseDuration(cfg.DNS.PropagationTimeout)
+		if err != nil {
+			return publictls.DNSConfig{}, fmt.Errorf("invalid dns.propagation_timeout: %w", err)
+		}
+		propagationTimeout = parsed
+	}
+
+	pollingInterval := defaults.PollingInterval
+	if cfg.DNS.PollingInterval != "" {
+		parsed, err := time.ParseDuration(cfg.DNS.PollingInterval)
+		if err != nil {
+			return publictls.DNSConfig{}, fmt.Errorf("invalid dns.polling_interval: %w", err)
+		}
+		pollingInterval = parsed
+	}
+
+	dnsCfg := publictls.DNSConfig{
+		Resolvers:          append([]string(nil), resolvers...),
+		PropagationTimeout: propagationTimeout,
+		PollingInterval:    pollingInterval,
+	}
+	if err := dnsCfg.Validate(); err != nil {
+		return publictls.DNSConfig{}, err
+	}
+	return dnsCfg, nil
+}
+
 // createContainerService creates the container service with configuration.
 func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc *services, log zerowrap.Logger) (*container.Service, error) {
 	// Parse and validate container resource limits from config
@@ -3269,6 +3313,9 @@ func loadConfig(v *viper.Viper, configPath string) error {
 	v.SetDefault("tls.acme.email", "")
 	v.SetDefault("tls.acme.challenge", "auto")
 	v.SetDefault("tls.acme.obtain_batch_size", 1)
+	v.SetDefault("dns.resolvers", publictls.DefaultDNSResolvers)
+	v.SetDefault("dns.propagation_timeout", "5m")
+	v.SetDefault("dns.polling_interval", "5s")
 	v.SetDefault("server.force_https_redirect", false)
 	v.SetDefault("server.data_dir", DefaultDataDir())
 	v.SetDefault("server.runtime", "auto")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -96,6 +96,7 @@ var (
 	ErrACMEDisabled              = errors.New("acme disabled")
 	ErrACMEEmailRequired         = errors.New("acme email required")
 	ErrACMEChallengeInvalid      = errors.New("acme challenge invalid")
+	ErrDNSConfigInvalid          = errors.New("dns configuration invalid")
 	ErrCloudflareTokenMissing    = errors.New("cloudflare api token missing")
 	ErrCertificateStoreRequired  = errors.New("certificate store required")
 	ErrCertificateIssuerRequired = errors.New("certificate issuer required")

--- a/internal/usecase/publictls/config.go
+++ b/internal/usecase/publictls/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	TLSPort         int
 	DataDir         string
 	ObtainBatchSize int
+	DNS             DNSConfig
 }
 
 // EffectiveChallenge represents the resolved ACME challenge configuration.

--- a/internal/usecase/publictls/dns_config.go
+++ b/internal/usecase/publictls/dns_config.go
@@ -1,0 +1,59 @@
+package publictls
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultDNSPropagationTimeout = 5 * time.Minute
+	DefaultDNSPollingInterval    = 5 * time.Second
+)
+
+var DefaultDNSResolvers = []string{"1.1.1.1:53", "8.8.8.8:53"}
+
+// DNSConfig controls public DNS visibility checks used by ACME DNS-01.
+// These are recursive resolvers, not authoritative DNS providers.
+type DNSConfig struct {
+	Resolvers          []string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+}
+
+// DefaultDNSConfig returns Gordon's default public DNS check configuration.
+func DefaultDNSConfig() DNSConfig {
+	resolvers := append([]string(nil), DefaultDNSResolvers...)
+	return DNSConfig{
+		Resolvers:          resolvers,
+		PropagationTimeout: DefaultDNSPropagationTimeout,
+		PollingInterval:    DefaultDNSPollingInterval,
+	}
+}
+
+// Validate checks DNSConfig for ACME DNS-01 usage.
+func (c DNSConfig) Validate() error {
+	if len(c.Resolvers) == 0 {
+		return fmt.Errorf("dns.resolvers must contain at least one resolver")
+	}
+	for i, resolver := range c.Resolvers {
+		resolver = strings.TrimSpace(resolver)
+		if resolver == "" {
+			return fmt.Errorf("invalid dns.resolvers[%d]: empty resolver", i)
+		}
+		if _, _, err := net.SplitHostPort(resolver); err != nil {
+			return fmt.Errorf("invalid dns.resolvers[%d]: %q: expected host:port: %w", i, resolver, err)
+		}
+	}
+	if c.PropagationTimeout <= 0 {
+		return fmt.Errorf("dns.propagation_timeout must be positive")
+	}
+	if c.PollingInterval <= 0 {
+		return fmt.Errorf("dns.polling_interval must be positive")
+	}
+	if c.PollingInterval >= c.PropagationTimeout {
+		return fmt.Errorf("dns.polling_interval must be less than dns.propagation_timeout")
+	}
+	return nil
+}

--- a/internal/usecase/publictls/dns_config.go
+++ b/internal/usecase/publictls/dns_config.go
@@ -3,6 +3,7 @@ package publictls
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,19 +33,28 @@ func DefaultDNSConfig() DNSConfig {
 	}
 }
 
-// Validate checks DNSConfig for ACME DNS-01 usage.
-func (c DNSConfig) Validate() error {
+// Validate checks DNSConfig for ACME DNS-01 usage and normalizes resolver whitespace.
+func (c *DNSConfig) Validate() error {
 	if len(c.Resolvers) == 0 {
 		return fmt.Errorf("dns.resolvers must contain at least one resolver")
 	}
 	for i, resolver := range c.Resolvers {
-		resolver = strings.TrimSpace(resolver)
-		if resolver == "" {
+		trimmed := strings.TrimSpace(resolver)
+		if trimmed == "" {
 			return fmt.Errorf("invalid dns.resolvers[%d]: empty resolver", i)
 		}
-		if _, _, err := net.SplitHostPort(resolver); err != nil {
-			return fmt.Errorf("invalid dns.resolvers[%d]: %q: expected host:port: %w", i, resolver, err)
+		host, port, err := net.SplitHostPort(trimmed)
+		if err != nil {
+			return fmt.Errorf("invalid dns.resolvers[%d]: %q: expected host:port: %w", i, trimmed, err)
 		}
+		if host == "" {
+			return fmt.Errorf("invalid dns.resolvers[%d]: %q: host must not be empty", i, trimmed)
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return fmt.Errorf("invalid dns.resolvers[%d]: %q: port must be a number between 1 and 65535", i, trimmed)
+		}
+		c.Resolvers[i] = trimmed
 	}
 	if c.PropagationTimeout <= 0 {
 		return fmt.Errorf("dns.propagation_timeout must be positive")

--- a/internal/usecase/publictls/dns_config.go
+++ b/internal/usecase/publictls/dns_config.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 const (
@@ -36,34 +38,34 @@ func DefaultDNSConfig() DNSConfig {
 // Validate checks DNSConfig for ACME DNS-01 usage and normalizes resolver whitespace.
 func (c *DNSConfig) Validate() error {
 	if len(c.Resolvers) == 0 {
-		return fmt.Errorf("dns.resolvers must contain at least one resolver")
+		return fmt.Errorf("%w: dns.resolvers must contain at least one resolver", domain.ErrDNSConfigInvalid)
 	}
 	for i, resolver := range c.Resolvers {
 		trimmed := strings.TrimSpace(resolver)
 		if trimmed == "" {
-			return fmt.Errorf("invalid dns.resolvers[%d]: empty resolver", i)
+			return fmt.Errorf("%w: invalid dns.resolvers[%d]: empty resolver", domain.ErrDNSConfigInvalid, i)
 		}
 		host, port, err := net.SplitHostPort(trimmed)
 		if err != nil {
-			return fmt.Errorf("invalid dns.resolvers[%d]: %q: expected host:port: %w", i, trimmed, err)
+			return fmt.Errorf("%w: invalid dns.resolvers[%d]: %q: expected host:port: %v", domain.ErrDNSConfigInvalid, i, trimmed, err)
 		}
 		if host == "" {
-			return fmt.Errorf("invalid dns.resolvers[%d]: %q: host must not be empty", i, trimmed)
+			return fmt.Errorf("%w: invalid dns.resolvers[%d]: %q: host must not be empty", domain.ErrDNSConfigInvalid, i, trimmed)
 		}
 		portNumber, err := strconv.Atoi(port)
 		if err != nil || portNumber < 1 || portNumber > 65535 {
-			return fmt.Errorf("invalid dns.resolvers[%d]: %q: port must be a number between 1 and 65535", i, trimmed)
+			return fmt.Errorf("%w: invalid dns.resolvers[%d]: %q: port must be a number between 1 and 65535", domain.ErrDNSConfigInvalid, i, trimmed)
 		}
 		c.Resolvers[i] = trimmed
 	}
 	if c.PropagationTimeout <= 0 {
-		return fmt.Errorf("dns.propagation_timeout must be positive")
+		return fmt.Errorf("%w: dns.propagation_timeout must be positive", domain.ErrDNSConfigInvalid)
 	}
 	if c.PollingInterval <= 0 {
-		return fmt.Errorf("dns.polling_interval must be positive")
+		return fmt.Errorf("%w: dns.polling_interval must be positive", domain.ErrDNSConfigInvalid)
 	}
 	if c.PollingInterval >= c.PropagationTimeout {
-		return fmt.Errorf("dns.polling_interval must be less than dns.propagation_timeout")
+		return fmt.Errorf("%w: dns.polling_interval must be less than dns.propagation_timeout", domain.ErrDNSConfigInvalid)
 	}
 	return nil
 }

--- a/internal/usecase/publictls/dns_config_test.go
+++ b/internal/usecase/publictls/dns_config_test.go
@@ -16,6 +16,17 @@ func TestDefaultDNSConfig(t *testing.T) {
 	assert.Equal(t, 5*time.Second, cfg.PollingInterval)
 }
 
+func TestDNSConfigValidateNormalizesResolvers(t *testing.T) {
+	cfg := DNSConfig{
+		Resolvers:          []string{" 1.1.1.1:53 ", "\t8.8.8.8:53\n"},
+		PropagationTimeout: 5 * time.Minute,
+		PollingInterval:    5 * time.Second,
+	}
+
+	require.NoError(t, cfg.Validate())
+	assert.Equal(t, []string{"1.1.1.1:53", "8.8.8.8:53"}, cfg.Resolvers)
+}
+
 func TestDNSConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -43,6 +54,24 @@ func TestDNSConfigValidate(t *testing.T) {
 			name: "resolver missing port",
 			cfg: DNSConfig{
 				Resolvers:          []string{"1.1.1.1"},
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "invalid dns.resolvers[0]",
+		},
+		{
+			name: "whitespace-only resolver",
+			cfg: DNSConfig{
+				Resolvers:          []string{"   "},
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "invalid dns.resolvers[0]",
+		},
+		{
+			name: "malformed resolver port",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1:abc"},
 				PropagationTimeout: 5 * time.Minute,
 				PollingInterval:    5 * time.Second,
 			},

--- a/internal/usecase/publictls/dns_config_test.go
+++ b/internal/usecase/publictls/dns_config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestDefaultDNSConfig(t *testing.T) {
@@ -114,6 +116,7 @@ func TestDNSConfigValidate(t *testing.T) {
 				return
 			}
 			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrDNSConfigInvalid)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}

--- a/internal/usecase/publictls/dns_config_test.go
+++ b/internal/usecase/publictls/dns_config_test.go
@@ -1,0 +1,91 @@
+package publictls
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultDNSConfig(t *testing.T) {
+	cfg := DefaultDNSConfig()
+
+	assert.Equal(t, []string{"1.1.1.1:53", "8.8.8.8:53"}, cfg.Resolvers)
+	assert.Equal(t, 5*time.Minute, cfg.PropagationTimeout)
+	assert.Equal(t, 5*time.Second, cfg.PollingInterval)
+}
+
+func TestDNSConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     DNSConfig
+		wantErr string
+	}{
+		{
+			name: "valid",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1:53", "8.8.8.8:53"},
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    5 * time.Second,
+			},
+		},
+		{
+			name: "empty resolvers",
+			cfg: DNSConfig{
+				Resolvers:          nil,
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "dns.resolvers must contain at least one resolver",
+		},
+		{
+			name: "resolver missing port",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1"},
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "invalid dns.resolvers[0]",
+		},
+		{
+			name: "zero timeout",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1:53"},
+				PropagationTimeout: 0,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "dns.propagation_timeout must be positive",
+		},
+		{
+			name: "zero polling interval",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1:53"},
+				PropagationTimeout: 5 * time.Minute,
+				PollingInterval:    0,
+			},
+			wantErr: "dns.polling_interval must be positive",
+		},
+		{
+			name: "polling interval equals timeout",
+			cfg: DNSConfig{
+				Resolvers:          []string{"1.1.1.1:53"},
+				PropagationTimeout: 5 * time.Second,
+				PollingInterval:    5 * time.Second,
+			},
+			wantErr: "dns.polling_interval must be less than dns.propagation_timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add global `[dns]` config with recursive resolver defaults and propagation timing validation.
- Wire DNS settings into ACME DNS-01 via Cloudflare provider timeout/polling and lego recursive nameservers.
- Document DNS-01 resolver behavior, Tailscale/split-DNS rationale, and global Cloudflare token caveat.

## Test Plan
- [x] `rtk go test ./internal/app ./internal/usecase/publictls ./internal/adapters/out/acmelego`
- [x] `rtk go test ./...`
- [x] `rtk golangci-lint run ./...`
- [x] `rtk git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a DNS configuration block to specify recursive resolvers and DNS‑01 propagation checks (resolvers, propagation_timeout, polling_interval) with sensible defaults.

* **Documentation**
  * Updated config reference and server docs describing the new DNS settings, defaults, DNS‑01 visibility behavior, and operational guidance.

* **Behavior**
  * DNS settings are parsed and validated at startup; invalid DNS config prevents public TLS/ACME initialization.

* **Tests**
  * Added tests covering defaults, parsing/validation, and ACME/DNS issuer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->