### PR TITLE
Fix backup extraction with basename tar entries

### DIFF
--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -49,6 +50,11 @@ type pipeReadCloser struct {
 	once     sync.Once
 }
 
+type removeOnCloseFile struct {
+	*os.File
+	path string
+}
+
 func (p *pipeReadCloser) Read(b []byte) (int, error) {
 	return p.pr.Read(b)
 }
@@ -69,6 +75,15 @@ func (p *pipeReadCloser) Close() error {
 		}
 	})
 	return closeErr
+}
+
+func (f *removeOnCloseFile) Close() error {
+	closeErr := f.File.Close()
+	removeErr := os.Remove(f.path)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
 }
 
 // NewRuntime creates a new Docker runtime instance.
@@ -1506,6 +1521,8 @@ func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser,
 	tr := tar.NewReader(reader)
 	targetName := normalizedTarPath(targetPath)
 	targetBase := filepath.Base(targetName)
+	var fallback *removeOnCloseFile
+	fallbackMatches := 0
 
 	for {
 		header, err := tr.Next()
@@ -1513,32 +1530,77 @@ func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser,
 			break
 		}
 		if err != nil {
+			cleanupFallback(fallback)
+			_ = reader.Close()
 			return nil, err
 		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
 
-		if header.Typeflag == tar.TypeReg && tarHeaderMatchesTarget(header.Name, targetName, targetBase) {
-			size := header.Size
-			pr, pw := io.Pipe()
-			go func() {
-				defer reader.Close()
-				_, copyErr := io.CopyN(pw, tr, size)
-				if copyErr != nil {
-					_ = pw.CloseWithError(copyErr)
-					return
+		headerName := normalizedTarPath(header.Name)
+		if headerName == targetName {
+			cleanupFallback(fallback)
+			return streamCurrentTarFile(reader, tr, header.Size), nil
+		}
+		if headerName == targetBase {
+			fallbackMatches++
+			if fallbackMatches == 1 {
+				fallback, err = bufferCurrentTarFile(tr, header.Size)
+				if err != nil {
+					_ = reader.Close()
+					return nil, err
 				}
-				_ = pw.Close()
-			}()
-			return &pipeReadCloser{pr: pr, pw: pw, original: reader}, nil
+			}
 		}
 	}
 
 	_ = reader.Close()
+	if fallbackMatches == 1 {
+		if _, err := fallback.Seek(0, io.SeekStart); err != nil {
+			cleanupFallback(fallback)
+			return nil, err
+		}
+		return fallback, nil
+	}
+	cleanupFallback(fallback)
+	if fallbackMatches > 1 {
+		return nil, fmt.Errorf("ambiguous basename matches in container archive for: %s", targetPath)
+	}
 	return nil, fmt.Errorf("file not found in container: %s", targetPath)
 }
 
-func tarHeaderMatchesTarget(headerName, targetName, targetBase string) bool {
-	headerName = normalizedTarPath(headerName)
-	return headerName == targetName || headerName == targetBase
+func streamCurrentTarFile(reader io.ReadCloser, tr *tar.Reader, size int64) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		defer reader.Close()
+		_, copyErr := io.CopyN(pw, tr, size)
+		if copyErr != nil {
+			_ = pw.CloseWithError(copyErr)
+			return
+		}
+		_ = pw.Close()
+	}()
+	return &pipeReadCloser{pr: pr, pw: pw, original: reader}
+}
+
+func bufferCurrentTarFile(tr *tar.Reader, size int64) (*removeOnCloseFile, error) {
+	file, err := os.CreateTemp("", "gordon-copy-from-container-*")
+	if err != nil {
+		return nil, err
+	}
+	fallback := &removeOnCloseFile{File: file, path: file.Name()}
+	if _, err := io.CopyN(fallback, tr, size); err != nil {
+		cleanupFallback(fallback)
+		return nil, err
+	}
+	return fallback, nil
+}
+
+func cleanupFallback(fallback *removeOnCloseFile) {
+	if fallback != nil {
+		_ = fallback.Close()
+	}
 }
 
 func normalizedTarPath(path string) string {

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -1505,6 +1505,7 @@ func (r *Runtime) CopyFromContainer(ctx context.Context, containerID, srcPath st
 func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser, error) {
 	tr := tar.NewReader(reader)
 	targetName := normalizedTarPath(targetPath)
+	targetBase := filepath.Base(targetName)
 
 	for {
 		header, err := tr.Next()
@@ -1515,7 +1516,7 @@ func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser,
 			return nil, err
 		}
 
-		if header.Typeflag == tar.TypeReg && normalizedTarPath(header.Name) == targetName {
+		if header.Typeflag == tar.TypeReg && tarHeaderMatchesTarget(header.Name, targetName, targetBase) {
 			size := header.Size
 			pr, pw := io.Pipe()
 			go func() {
@@ -1533,6 +1534,11 @@ func extractFileFromTar(reader io.ReadCloser, targetPath string) (io.ReadCloser,
 
 	_ = reader.Close()
 	return nil, fmt.Errorf("file not found in container: %s", targetPath)
+}
+
+func tarHeaderMatchesTarget(headerName, targetName, targetBase string) bool {
+	headerName = normalizedTarPath(headerName)
+	return headerName == targetName || headerName == targetBase
 }
 
 func normalizedTarPath(path string) string {

--- a/internal/adapters/out/docker/runtime_exec_test.go
+++ b/internal/adapters/out/docker/runtime_exec_test.go
@@ -82,6 +82,35 @@ func TestExtractFileFromTarMatchesBasenameForCopiedFile(t *testing.T) {
 	assert.Equal(t, "backup data", string(data))
 }
 
+func TestExtractFileFromTarPrefersExactPathOverBasename(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, writeTarFile(tw, "gordon-backup-test.bak", "wrong"))
+	require.NoError(t, writeTarFile(tw, "tmp/gordon-backup-test.bak", "right"))
+	require.NoError(t, tw.Close())
+
+	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/tmp/gordon-backup-test.bak")
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "right", string(data))
+}
+
+func TestExtractFileFromTarRejectsAmbiguousBasenameFallback(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, writeTarFile(tw, "gordon-backup-test.bak", "first"))
+	require.NoError(t, writeTarFile(tw, "gordon-backup-test.bak", "second"))
+	require.NoError(t, tw.Close())
+
+	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/tmp/gordon-backup-test.bak")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Nil(t, rc)
+}
+
 func TestExtractFileFromTarDoesNotMatchBasenameInNestedDirectory(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)

--- a/internal/adapters/out/docker/runtime_exec_test.go
+++ b/internal/adapters/out/docker/runtime_exec_test.go
@@ -54,12 +54,8 @@ func frameDockerStream(streamID byte, payload []byte) []byte {
 func TestExtractFileFromTarMatchesFullCleanPath(t *testing.T) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "other/.env", Typeflag: tar.TypeReg, Size: int64(len("wrong"))}))
-	_, err := tw.Write([]byte("wrong"))
-	require.NoError(t, err)
-	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "app/.env", Typeflag: tar.TypeReg, Size: int64(len("right"))}))
-	_, err = tw.Write([]byte("right"))
-	require.NoError(t, err)
+	require.NoError(t, writeTarFile(tw, "other/.env", "wrong"))
+	require.NoError(t, writeTarFile(tw, "app/.env", "right"))
 	require.NoError(t, tw.Close())
 
 	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/app/.env")
@@ -69,6 +65,41 @@ func TestExtractFileFromTarMatchesFullCleanPath(t *testing.T) {
 	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, "right", string(data))
+}
+
+func TestExtractFileFromTarMatchesBasenameForCopiedFile(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, writeTarFile(tw, "gordon-backup-test.bak", "backup data"))
+	require.NoError(t, tw.Close())
+
+	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/tmp/gordon-backup-test.bak")
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "backup data", string(data))
+}
+
+func TestExtractFileFromTarDoesNotMatchBasenameInNestedDirectory(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, writeTarFile(tw, "other/gordon-backup-test.bak", "wrong"))
+	require.NoError(t, tw.Close())
+
+	rc, err := extractFileFromTar(io.NopCloser(bytes.NewReader(buf.Bytes())), "/tmp/gordon-backup-test.bak")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+	assert.Nil(t, rc)
+}
+
+func writeTarFile(tw *tar.Writer, name, content string) error {
+	if err := tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeReg, Size: int64(len(content))}); err != nil {
+		return err
+	}
+	_, err := tw.Write([]byte(content))
+	return err
 }
 
 func TestReadExtractedEnvFileRejectsOversizedContent(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow copied single-file tar archives to match the requested file basename as well as the normalized full path
- keep nested basename entries from matching accidentally
- add regression coverage for Podman-style `CopyFromContainer` basename headers

Fixes #189

## Verification
- `go test ./internal/adapters/out/docker/...`
- `golangci-lint run ./...`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file extraction from Docker container archives: exact path matches are preferred, a safe basename fallback is used when appropriate, and ambiguous basename matches are rejected to avoid incorrect file returns.

* **Tests**
  * Added and expanded tests covering full-path vs basename matching, ambiguous basename cases, and related extraction behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->