### PR TITLE
Set restart policy for managed containers

### DIFF
--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -43,6 +43,8 @@ type Runtime struct {
 	client *client.Client
 }
 
+var _ out.ContainerRuntime = (*Runtime)(nil)
+
 type pipeReadCloser struct {
 	pr       *io.PipeReader
 	pw       *io.PipeWriter
@@ -358,6 +360,42 @@ func (r *Runtime) RenameContainer(ctx context.Context, containerID, newName stri
 	}
 
 	log.Info().Msg("container renamed")
+	return nil
+}
+
+// EnsureContainerRestartPolicy updates a container restart policy when it does not match.
+func (r *Runtime) EnsureContainerRestartPolicy(ctx context.Context, containerID, policy string) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:    "adapter",
+		zerowrap.FieldAdapter:  "docker",
+		zerowrap.FieldAction:   "EnsureContainerRestartPolicy",
+		zerowrap.FieldEntityID: containerID,
+		"restart_policy":       policy,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	inspect, err := r.client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return log.WrapErr(err, "failed to inspect container")
+	}
+	if inspect.HostConfig == nil {
+		return fmt.Errorf("container inspect response missing host config: %s", containerID)
+	}
+	if string(inspect.HostConfig.RestartPolicy.Name) == policy {
+		return nil
+	}
+
+	updateConfig := container.UpdateConfig{
+		Resources:     inspect.HostConfig.Resources,
+		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyMode(policy)},
+	}
+	resp, err := r.client.ContainerUpdate(ctx, containerID, updateConfig)
+	if err != nil {
+		return log.WrapErr(err, "failed to update container restart policy")
+	}
+	for _, warning := range resp.Warnings {
+		log.Warn().Str("warning", warning).Msg("container restart policy update warning")
+	}
 	return nil
 }
 

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -193,6 +193,9 @@ func (r *Runtime) CreateContainer(ctx context.Context, config *domain.ContainerC
 		CapAdd:         capAdd,
 		ReadonlyRootfs: config.ReadOnlyRootFS,
 	}
+	if config.RestartPolicy != "" {
+		hostConfig.RestartPolicy = container.RestartPolicy{Name: container.RestartPolicyMode(config.RestartPolicy)}
+	}
 
 	// Create network configuration for container
 	var networkConfig *network.NetworkingConfig

--- a/internal/adapters/out/docker/runtime_create_test.go
+++ b/internal/adapters/out/docker/runtime_create_test.go
@@ -1,0 +1,62 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestRuntime_CreateContainerAppliesRestartPolicy(t *testing.T) {
+	var createBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.41/containers/create":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&createBody))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"abc123","Warnings":null}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.41/containers/abc123/json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"Id":"abc123",
+				"Name":"/gordon-app.example.com",
+				"Image":"sha256:image",
+				"Created":"2026-05-05T00:00:00Z",
+				"Config":{"Image":"nginx:latest","Labels":{}},
+				"State":{"Status":"created","ExitCode":0},
+				"NetworkSettings":{"Ports":{}}
+			}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+
+	runtime := NewRuntimeWithClient(cli)
+	created, err := runtime.CreateContainer(context.Background(), &domain.ContainerConfig{
+		Image:         "nginx:latest",
+		Name:          "gordon-app.example.com",
+		RestartPolicy: domain.RestartPolicyAlways,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", created.ID)
+
+	require.NotNil(t, createBody)
+	hostConfig, ok := createBody["HostConfig"].(map[string]any)
+	require.True(t, ok)
+	restartPolicy, ok := hostConfig["RestartPolicy"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, domain.RestartPolicyAlways, restartPolicy["Name"])
+}

--- a/internal/adapters/out/docker/runtime_restart_policy_test.go
+++ b/internal/adapters/out/docker/runtime_restart_policy_test.go
@@ -1,0 +1,129 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestRuntime_EnsureContainerRestartPolicy_SkipsWhenAlreadySet(t *testing.T) {
+	var updateCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.41/containers/abc123/json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"Id": "abc123",
+				"HostConfig": {
+					"RestartPolicy": {
+						"Name": "always"
+					}
+				}
+			}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.41/containers/abc123/update":
+			updateCalled = true
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	runtime := newRuntimeForRestartPolicyHTTPServer(t, server)
+	err := runtime.EnsureContainerRestartPolicy(context.Background(), "abc123", domain.RestartPolicyAlways)
+	require.NoError(t, err)
+	assert.False(t, updateCalled, "update should not be called when restart policy is already set")
+}
+
+func TestRuntime_EnsureContainerRestartPolicy_UpdatesAndPreservesResources(t *testing.T) {
+	var updateBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.41/containers/abc123/json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"Id": "abc123",
+				"HostConfig": {
+					"RestartPolicy": {
+						"Name": ""
+					},
+					"Memory": 268435456,
+					"NanoCpus": 500000000,
+					"PidsLimit": 128,
+					"Ulimits": [
+						{
+							"Name": "nofile",
+							"Soft": 65536,
+							"Hard": 65536
+						}
+					]
+				}
+			}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.41/containers/abc123/update":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&updateBody))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Warnings":null}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	runtime := newRuntimeForRestartPolicyHTTPServer(t, server)
+	err := runtime.EnsureContainerRestartPolicy(context.Background(), "abc123", domain.RestartPolicyAlways)
+	require.NoError(t, err)
+	require.NotNil(t, updateBody)
+	assert.Equal(t, domain.RestartPolicyAlways, updateBody["RestartPolicy"].(map[string]any)["Name"])
+	assert.Equal(t, float64(268435456), updateBody["Memory"])
+	assert.Equal(t, float64(500000000), updateBody["NanoCpus"])
+	assert.Equal(t, float64(128), updateBody["PidsLimit"])
+	ulimits, ok := updateBody["Ulimits"].([]any)
+	require.True(t, ok, "Ulimits should be an array")
+	require.Greater(t, len(ulimits), 0)
+	firstUlimit, ok := ulimits[0].(map[string]any)
+	require.True(t, ok, "first Ulimit should be a map")
+	assert.Equal(t, "nofile", firstUlimit["Name"])
+	assert.Equal(t, float64(65536), firstUlimit["Soft"])
+	assert.Equal(t, float64(65536), firstUlimit["Hard"])
+}
+
+func TestRuntime_EnsureContainerRestartPolicy_ReturnsErrorWhenHostConfigMissing(t *testing.T) {
+	var updateCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.41/containers/abc123/json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"Id": "abc123"
+			}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.41/containers/abc123/update":
+			updateCalled = true
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	runtime := newRuntimeForRestartPolicyHTTPServer(t, server)
+	err := runtime.EnsureContainerRestartPolicy(context.Background(), "abc123", domain.RestartPolicyAlways)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing host config")
+	assert.False(t, updateCalled, "update should not be called when host config is missing")
+}
+
+func newRuntimeForRestartPolicyHTTPServer(t *testing.T, server *httptest.Server) *Runtime {
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+	return NewRuntimeWithClient(cli)
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2015,6 +2015,10 @@ func setupConfigHotReload(ctx context.Context, configSvc configWatcher, coordina
 
 // syncAndAutoStart syncs existing containers and auto-starts if configured.
 func syncAndAutoStart(ctx context.Context, svc *services, log zerowrap.Logger) {
+	if err := svc.containerSvc.EnsureManagedContainerRestartPolicies(ctx); err != nil {
+		log.Warn().Err(err).Msg("failed to migrate managed container restart policies")
+	}
+
 	if err := svc.containerSvc.SyncContainers(ctx); err != nil {
 		log.Warn().Err(err).Msg("failed to sync existing containers")
 	}

--- a/internal/boundaries/out/mocks/mock_container_runtime.go
+++ b/internal/boundaries/out/mocks/mock_container_runtime.go
@@ -428,6 +428,69 @@ func (_c *MockContainerRuntime_DisconnectContainerFromNetwork_Call) RunAndReturn
 	return _c
 }
 
+// EnsureContainerRestartPolicy provides a mock function for the type MockContainerRuntime
+func (_mock *MockContainerRuntime) EnsureContainerRestartPolicy(ctx context.Context, containerID string, policy string) error {
+	ret := _mock.Called(ctx, containerID, policy)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureContainerRestartPolicy")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, containerID, policy)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockContainerRuntime_EnsureContainerRestartPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnsureContainerRestartPolicy'
+type MockContainerRuntime_EnsureContainerRestartPolicy_Call struct {
+	*mock.Call
+}
+
+// EnsureContainerRestartPolicy is a helper method to define mock.On call
+//   - ctx context.Context
+//   - containerID string
+//   - policy string
+func (_e *MockContainerRuntime_Expecter) EnsureContainerRestartPolicy(ctx interface{}, containerID interface{}, policy interface{}) *MockContainerRuntime_EnsureContainerRestartPolicy_Call {
+	return &MockContainerRuntime_EnsureContainerRestartPolicy_Call{Call: _e.mock.On("EnsureContainerRestartPolicy", ctx, containerID, policy)}
+}
+
+func (_c *MockContainerRuntime_EnsureContainerRestartPolicy_Call) Run(run func(ctx context.Context, containerID string, policy string)) *MockContainerRuntime_EnsureContainerRestartPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerRuntime_EnsureContainerRestartPolicy_Call) Return(err error) *MockContainerRuntime_EnsureContainerRestartPolicy_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockContainerRuntime_EnsureContainerRestartPolicy_Call) RunAndReturn(run func(ctx context.Context, containerID string, policy string) error) *MockContainerRuntime_EnsureContainerRestartPolicy_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExecInContainer provides a mock function for the type MockContainerRuntime
 func (_mock *MockContainerRuntime) ExecInContainer(ctx context.Context, containerID string, cmd []string) (*out.ExecResult, error) {
 	ret := _mock.Called(ctx, containerID, cmd)

--- a/internal/boundaries/out/runtime.go
+++ b/internal/boundaries/out/runtime.go
@@ -20,6 +20,7 @@ type ContainerRuntime interface {
 	RestartContainer(ctx context.Context, containerID string) error
 	RemoveContainer(ctx context.Context, containerID string, force bool) error
 	RenameContainer(ctx context.Context, containerID, newName string) error
+	EnsureContainerRestartPolicy(ctx context.Context, containerID, policy string) error
 
 	// Container inspection
 	ListContainers(ctx context.Context, all bool) ([]*domain.Container, error)

--- a/internal/domain/container.go
+++ b/internal/domain/container.go
@@ -63,6 +63,7 @@ type ContainerConfig struct {
 	WorkingDir      string
 	Cmd             []string
 	AutoRemove      bool
+	RestartPolicy   string
 	Volumes         map[string]string // map[containerPath]volumeName
 	ReadOnlyVolumes map[string]string // containerPath -> volumeName (mounted read-only)
 	NetworkMode     string            // Network to join
@@ -87,4 +88,8 @@ const (
 	ContainerStatusExited  ContainerStatus = "exited"
 	ContainerStatusPaused  ContainerStatus = "paused"
 	ContainerStatusUnknown ContainerStatus = "unknown"
+)
+
+const (
+	RestartPolicyAlways = "always"
 )

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -275,18 +275,19 @@ func (s *Service) buildContainerConfig(in containerConfigInput) *domain.Containe
 	}
 
 	containerConfig := &domain.ContainerConfig{
-		Image:       in.ImageRef,
-		Name:        containerName,
-		Ports:       ports,
-		Env:         in.EnvVars,
-		Volumes:     in.Volumes,
-		NetworkMode: in.NetworkName,
-		Hostname:    in.Domain,
-		Labels:      labels,
-		AutoRemove:  false,
-		MemoryLimit: cfg.DefaultMemoryLimit,
-		NanoCPUs:    cfg.DefaultNanoCPUs,
-		PidsLimit:   cfg.DefaultPidsLimit,
+		Image:         in.ImageRef,
+		Name:          containerName,
+		Ports:         ports,
+		Env:           in.EnvVars,
+		Volumes:       in.Volumes,
+		NetworkMode:   in.NetworkName,
+		Hostname:      in.Domain,
+		Labels:        labels,
+		AutoRemove:    false,
+		RestartPolicy: domain.RestartPolicyAlways,
+		MemoryLimit:   cfg.DefaultMemoryLimit,
+		NanoCPUs:      cfg.DefaultNanoCPUs,
+		PidsLimit:     cfg.DefaultPidsLimit,
 	}
 	applySecurityProfile(containerConfig, cfg)
 	return containerConfig
@@ -2619,9 +2620,10 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 			domain.LabelEnvHash:    envHash,
 			domain.LabelImage:      serviceImage,
 		},
-		MemoryLimit: cfg.DefaultMemoryLimit,
-		NanoCPUs:    cfg.DefaultNanoCPUs,
-		PidsLimit:   cfg.DefaultPidsLimit,
+		MemoryLimit:   cfg.DefaultMemoryLimit,
+		NanoCPUs:      cfg.DefaultNanoCPUs,
+		PidsLimit:     cfg.DefaultPidsLimit,
+		RestartPolicy: domain.RestartPolicyAlways,
 	}
 	applySecurityProfile(config, cfg)
 

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -275,19 +275,18 @@ func (s *Service) buildContainerConfig(in containerConfigInput) *domain.Containe
 	}
 
 	containerConfig := &domain.ContainerConfig{
-		Image:         in.ImageRef,
-		Name:          containerName,
-		Ports:         ports,
-		Env:           in.EnvVars,
-		Volumes:       in.Volumes,
-		NetworkMode:   in.NetworkName,
-		Hostname:      in.Domain,
-		Labels:        labels,
-		AutoRemove:    false,
-		RestartPolicy: domain.RestartPolicyAlways,
-		MemoryLimit:   cfg.DefaultMemoryLimit,
-		NanoCPUs:      cfg.DefaultNanoCPUs,
-		PidsLimit:     cfg.DefaultPidsLimit,
+		Image:       in.ImageRef,
+		Name:        containerName,
+		Ports:       ports,
+		Env:         in.EnvVars,
+		Volumes:     in.Volumes,
+		NetworkMode: in.NetworkName,
+		Hostname:    in.Domain,
+		Labels:      labels,
+		AutoRemove:  false,
+		MemoryLimit: cfg.DefaultMemoryLimit,
+		NanoCPUs:    cfg.DefaultNanoCPUs,
+		PidsLimit:   cfg.DefaultPidsLimit,
 	}
 	applySecurityProfile(containerConfig, cfg)
 	return containerConfig
@@ -654,6 +653,10 @@ func (s *Service) createStartedContainer(ctx context.Context, route domain.Route
 			s.cleanupFailedContainer(ctx, newContainer.ID)
 			return nil, deployErr
 		}
+	}
+	if err := s.runtime.EnsureContainerRestartPolicy(ctx, newContainer.ID, domain.RestartPolicyAlways); err != nil {
+		s.cleanupFailedContainer(ctx, newContainer.ID)
+		return nil, log.WrapErr(err, "failed to set container restart policy")
 	}
 
 	inspected, err := s.runtime.InspectContainer(ctx, newContainer.ID)
@@ -1418,13 +1421,13 @@ func (s *Service) EnsureManagedContainerRestartPolicies(ctx context.Context) err
 		return log.WrapErr(err, "failed to list containers for restart policy migration")
 	}
 
-	s.ensureManagedContainerRestartPolicies(ctx, allContainers)
-	return nil
+	return s.ensureManagedContainerRestartPolicies(ctx, allContainers)
 }
 
-func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context, allContainers []*domain.Container) {
+func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context, allContainers []*domain.Container) error {
 	log := zerowrap.FromCtx(ctx)
 
+	var errs []error
 	for _, c := range allContainers {
 		if c.Labels == nil || c.Labels[domain.LabelManaged] != "true" {
 			continue
@@ -1434,8 +1437,10 @@ func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context, all
 				Str(zerowrap.FieldEntityID, c.ID).
 				Str("container_name", c.Name).
 				Msg("failed to ensure managed container restart policy")
+			errs = append(errs, fmt.Errorf("container %s: %w", c.ID, err))
 		}
 	}
+	return errors.Join(errs...)
 }
 
 // SyncContainers synchronizes containers with runtime state.
@@ -2616,54 +2621,10 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 
 	log.Info().Str(zerowrap.FieldService, serviceImage).Msg("deploying attached service")
 
-	// Ensure image (canonical ref is returned; internal pulls may use the local registry).
-	imageRef, err := s.buildValidatedImageRef(ctx, serviceImage)
+	config, err := s.buildAttachmentContainerConfig(ctx, ownerDomain, serviceName, serviceImage, containerName, networkName)
 	if err != nil {
 		return err
 	}
-	actualImageRef, err := s.ensureImage(ctx, imageRef)
-	if err != nil {
-		return err
-	}
-
-	exposedPorts := s.attachmentExposedPorts(ctx, actualImageRef)
-	volumes, err := s.attachmentVolumes(ctx, containerName, actualImageRef)
-	if err != nil {
-		return err
-	}
-	envVars, err := s.attachmentEnv(ctx, containerName, actualImageRef)
-	if err != nil {
-		return err
-	}
-	envHash := hashEnvironment(envVars)
-
-	s.mu.RLock()
-	cfg := s.config
-	s.mu.RUnlock()
-
-	// Create container with attachment labels (use actual ref, track original in labels)
-	config := &domain.ContainerConfig{
-		Image:       actualImageRef,
-		Name:        containerName,
-		Hostname:    serviceName, // Internal DNS: postgres, redis, etc.
-		Aliases:     []string{serviceName},
-		Ports:       exposedPorts,
-		Env:         envVars,
-		Volumes:     volumes,
-		NetworkMode: networkName, // Same network as main app
-		Labels: map[string]string{
-			domain.LabelManaged:    "true",
-			domain.LabelAttachment: "true",
-			domain.LabelAttachedTo: ownerDomain,
-			domain.LabelEnvHash:    envHash,
-			domain.LabelImage:      serviceImage,
-		},
-		MemoryLimit:   cfg.DefaultMemoryLimit,
-		NanoCPUs:      cfg.DefaultNanoCPUs,
-		PidsLimit:     cfg.DefaultPidsLimit,
-		RestartPolicy: domain.RestartPolicyAlways,
-	}
-	applySecurityProfile(config, cfg)
 
 	container, err := s.runtime.CreateContainer(ctx, config)
 	if err != nil {
@@ -2685,6 +2646,9 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 		s.runtime.RemoveContainer(ctx, container.ID, true)
 		return fmt.Errorf("attachment %q not ready: %w", serviceName, err)
 	}
+	if err := s.ensureAttachmentRestartPolicy(ctx, container.ID); err != nil {
+		return err
+	}
 
 	// Track attachment
 	s.mu.Lock()
@@ -2695,6 +2659,66 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	s.startLogCollection(ctx, container.ID, containerName)
 
 	log.Info().Str(zerowrap.FieldEntityID, container.ID).Msg("attachment deployed successfully")
+	return nil
+}
+
+func (s *Service) buildAttachmentContainerConfig(ctx context.Context, ownerDomain, serviceName, serviceImage, containerName, networkName string) (*domain.ContainerConfig, error) {
+	imageRef, err := s.buildValidatedImageRef(ctx, serviceImage)
+	if err != nil {
+		return nil, err
+	}
+	actualImageRef, err := s.ensureImage(ctx, imageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	exposedPorts := s.attachmentExposedPorts(ctx, actualImageRef)
+	volumes, err := s.attachmentVolumes(ctx, containerName, actualImageRef)
+	if err != nil {
+		return nil, err
+	}
+	envVars, err := s.attachmentEnv(ctx, containerName, actualImageRef)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	cfg := s.config
+	s.mu.RUnlock()
+
+	config := &domain.ContainerConfig{
+		Image:       actualImageRef,
+		Name:        containerName,
+		Hostname:    serviceName,
+		Aliases:     []string{serviceName},
+		Ports:       exposedPorts,
+		Env:         envVars,
+		Volumes:     volumes,
+		NetworkMode: networkName,
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: ownerDomain,
+			domain.LabelEnvHash:    hashEnvironment(envVars),
+			domain.LabelImage:      serviceImage,
+		},
+		MemoryLimit: cfg.DefaultMemoryLimit,
+		NanoCPUs:    cfg.DefaultNanoCPUs,
+		PidsLimit:   cfg.DefaultPidsLimit,
+	}
+	applySecurityProfile(config, cfg)
+	return config, nil
+}
+
+func (s *Service) ensureAttachmentRestartPolicy(ctx context.Context, containerID string) error {
+	log := zerowrap.FromCtx(ctx)
+	if err := s.runtime.EnsureContainerRestartPolicy(ctx, containerID, domain.RestartPolicyAlways); err != nil {
+		if stopErr := s.runtime.StopContainer(ctx, containerID); stopErr != nil {
+			log.Warn().Err(stopErr).Str(zerowrap.FieldEntityID, containerID).Msg("failed to stop attachment after restart policy update failure")
+		}
+		s.runtime.RemoveContainer(ctx, containerID, true)
+		return log.WrapErr(err, "failed to set attachment restart policy")
+	}
 	return nil
 }
 

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1405,6 +1405,27 @@ func (s *Service) HealthCheck(ctx context.Context) map[string]bool {
 	return health
 }
 
+func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context) {
+	log := zerowrap.FromCtx(ctx)
+	allContainers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to list containers for restart policy migration")
+		return
+	}
+
+	for _, c := range allContainers {
+		if c.Labels == nil || c.Labels[domain.LabelManaged] != "true" {
+			continue
+		}
+		if err := s.runtime.EnsureContainerRestartPolicy(ctx, c.ID, domain.RestartPolicyAlways); err != nil {
+			log.Warn().Err(err).
+				Str(zerowrap.FieldEntityID, c.ID).
+				Str("container_name", c.Name).
+				Msg("failed to ensure managed container restart policy")
+		}
+	}
+}
+
 // SyncContainers synchronizes containers with runtime state.
 func (s *Service) SyncContainers(ctx context.Context) error {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
@@ -1412,6 +1433,8 @@ func (s *Service) SyncContainers(ctx context.Context) error {
 		zerowrap.FieldUseCase: "SyncContainers",
 	})
 	log := zerowrap.FromCtx(ctx)
+
+	s.ensureManagedContainerRestartPolicies(ctx)
 
 	// List containers without holding lock to avoid blocking during Docker API call
 	allContainers, err := s.runtime.ListContainers(ctx, false)

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1405,6 +1405,23 @@ func (s *Service) HealthCheck(ctx context.Context) map[string]bool {
 	return health
 }
 
+// EnsureManagedContainerRestartPolicies updates restart policy for all managed containers.
+func (s *Service) EnsureManagedContainerRestartPolicies(ctx context.Context) error {
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "EnsureManagedContainerRestartPolicies",
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	allContainers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		return log.WrapErr(err, "failed to list containers for restart policy migration")
+	}
+
+	s.ensureManagedContainerRestartPolicies(ctx, allContainers)
+	return nil
+}
+
 func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context, allContainers []*domain.Container) {
 	log := zerowrap.FromCtx(ctx)
 
@@ -1436,8 +1453,6 @@ func (s *Service) SyncContainers(ctx context.Context) error {
 	if err != nil {
 		return log.WrapErr(err, "failed to list containers")
 	}
-
-	s.ensureManagedContainerRestartPolicies(ctx, allContainers)
 
 	managed := make(map[string]*domain.Container)
 	attachments := make(map[string][]string)

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1405,13 +1405,8 @@ func (s *Service) HealthCheck(ctx context.Context) map[string]bool {
 	return health
 }
 
-func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context) {
+func (s *Service) ensureManagedContainerRestartPolicies(ctx context.Context, allContainers []*domain.Container) {
 	log := zerowrap.FromCtx(ctx)
-	allContainers, err := s.runtime.ListContainers(ctx, true)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to list containers for restart policy migration")
-		return
-	}
 
 	for _, c := range allContainers {
 		if c.Labels == nil || c.Labels[domain.LabelManaged] != "true" {
@@ -1434,17 +1429,22 @@ func (s *Service) SyncContainers(ctx context.Context) error {
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	s.ensureManagedContainerRestartPolicies(ctx)
-
-	// List containers without holding lock to avoid blocking during Docker API call
-	allContainers, err := s.runtime.ListContainers(ctx, false)
+	// List containers without holding lock to avoid blocking during Docker API call.
+	// Use all=true so the same runtime snapshot can migrate stopped containers and
+	// rebuild the running-container maps without a second Docker list call.
+	allContainers, err := s.runtime.ListContainers(ctx, true)
 	if err != nil {
 		return log.WrapErr(err, "failed to list containers")
 	}
 
+	s.ensureManagedContainerRestartPolicies(ctx, allContainers)
+
 	managed := make(map[string]*domain.Container)
 	attachments := make(map[string][]string)
 	for _, c := range allContainers {
+		if c.Status != "" && c.Status != string(domain.ContainerStatusRunning) {
+			continue
+		}
 		if c.Labels == nil || c.Labels[domain.LabelManaged] != "true" {
 			continue
 		}

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -255,9 +255,9 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	ctx := testContext()
 	metrics, reader := setupMetricsTest(t)
 	svc.SetMetrics(metrics)
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
 
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-1",
 			Labels: map[string]string{
@@ -281,8 +281,7 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	assert.Equal(t, 0, points[0].Attributes.Len())
 
 	// No runtime change: metric should remain stable.
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-1",
 			Labels: map[string]string{
@@ -306,8 +305,7 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	assert.Equal(t, 0, points[0].Attributes.Len())
 
 	// One container removed in runtime: metric should decrement by one.
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-1",
 			Labels: map[string]string{
@@ -1250,20 +1248,31 @@ func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachmen
 	ctx := testContext()
 
 	routeContainer := &domain.Container{
-		ID:   "route-1",
-		Name: "gordon-app.example.com",
+		ID:     "route-1",
+		Name:   "gordon-app.example.com",
+		Status: string(domain.ContainerStatusRunning),
 		Labels: map[string]string{
 			domain.LabelManaged: "true",
 			domain.LabelDomain:  "app.example.com",
 		},
 	}
 	attachmentContainer := &domain.Container{
-		ID:   "attachment-1",
-		Name: "gordon-app-example-com-postgres",
+		ID:     "attachment-1",
+		Name:   "gordon-app-example-com-postgres",
+		Status: string(domain.ContainerStatusRunning),
 		Labels: map[string]string{
 			domain.LabelManaged:    "true",
 			domain.LabelAttachment: "true",
 			domain.LabelAttachedTo: "app.example.com",
+		},
+	}
+	stoppedContainer := &domain.Container{
+		ID:     "stopped-1",
+		Name:   "gordon-stopped.example.com",
+		Status: string(domain.ContainerStatusExited),
+		Labels: map[string]string{
+			domain.LabelManaged: "true",
+			domain.LabelDomain:  "stopped.example.com",
 		},
 	}
 	unmanagedContainer := &domain.Container{
@@ -1274,15 +1283,12 @@ func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachmen
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		routeContainer,
 		attachmentContainer,
+		stoppedContainer,
 		unmanagedContainer,
 	}, nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "attachment-1", domain.RestartPolicyAlways).Return(nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
-		routeContainer,
-		attachmentContainer,
-	}, nil).Once()
-
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "stopped-1", domain.RestartPolicyAlways).Return(nil).Once()
 	err := svc.SyncContainers(ctx)
 
 	require.NoError(t, err)
@@ -1295,7 +1301,8 @@ func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachmen
 	svc.mu.RUnlock()
 	assert.Equal(t, []string{"attachment-1"}, attachmentIDs)
 	assert.NotContains(t, svc.containers, "other-1")
-	runtime.AssertNumberOfCalls(t, "EnsureContainerRestartPolicy", 2)
+	assert.NotContains(t, svc.containers, "stopped.example.com")
+	runtime.AssertNumberOfCalls(t, "EnsureContainerRestartPolicy", 3)
 }
 
 func TestService_SyncContainers_RestartPolicyMigrationErrorIsNonFatal(t *testing.T) {
@@ -1317,8 +1324,6 @@ func TestService_SyncContainers_RestartPolicyMigrationErrorIsNonFatal(t *testing
 
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{routeContainer}, nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(errors.New("update failed")).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{routeContainer}, nil).Once()
-
 	err := svc.SyncContainers(ctx)
 
 	require.NoError(t, err)
@@ -1335,8 +1340,8 @@ func TestService_SyncContainers(t *testing.T) {
 	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
 	ctx := testContext()
 
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID:   "container-1",
 			Name: "gordon-app1.example.com",
@@ -1462,8 +1467,7 @@ func TestService_Restart_ReconcilesStaleContainerID(t *testing.T) {
 	runtime.EXPECT().RestartContainer(mock.Anything, "stale-container-id").
 		Return(errors.New("no container with name or ID \"stale-container-id\" found")).
 		Once()
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID:   "fresh-container-id",
 			Name: "gordon-test.example.com",
@@ -1473,6 +1477,7 @@ func TestService_Restart_ReconcilesStaleContainerID(t *testing.T) {
 			},
 		},
 	}, nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "fresh-container-id", domain.RestartPolicyAlways).Return(nil).Once()
 	runtime.EXPECT().RestartContainer(mock.Anything, "fresh-container-id").Return(nil).Once()
 
 	err := svc.Restart(ctx, "test.example.com", false)
@@ -1498,7 +1503,6 @@ func TestService_Restart_ReconcilesStaleContainerID_NotFoundAfterSync(t *testing
 		Return(errors.New("no such container")).
 		Once()
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil).Once()
 
 	err := svc.Restart(ctx, "test.example.com", false)
 
@@ -1520,8 +1524,7 @@ func TestService_Restart_WithAttachments(t *testing.T) {
 		Status: "running",
 	}
 	svc.attachments["test.example.com"] = []string{"container-attach-1", "container-attach-2"}
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-123",
 			Labels: map[string]string{
@@ -1546,6 +1549,7 @@ func TestService_Restart_WithAttachments(t *testing.T) {
 			},
 		},
 	}, nil).Maybe()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
 
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-attach-1").Return(nil)
@@ -1576,7 +1580,6 @@ func TestService_Restart_WithAttachments_ErrorsWhenConfiguredButNotDeployed(t *t
 	}
 	// No attachment containers tracked — s.attachments is empty
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil).Maybe()
 
 	err := svc.Restart(testContext(), "test.example.com", true)
 
@@ -1606,8 +1609,7 @@ func TestService_Restart_WithAttachments_ErrorsWhenPartiallyDeployed(t *testing.
 	}
 	// Only 1 of 2 attachments deployed
 	svc.attachments["test.example.com"] = []string{"attach-postgres"}
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-123",
 			Labels: map[string]string{
@@ -1624,6 +1626,7 @@ func TestService_Restart_WithAttachments_ErrorsWhenPartiallyDeployed(t *testing.
 			},
 		},
 	}, nil).Maybe()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
 
 	err := svc.Restart(testContext(), "test.example.com", true)
 
@@ -1653,8 +1656,7 @@ func TestService_Restart_WithAttachments_SucceedsWhenAllDeployed(t *testing.T) {
 		Status: "running",
 	}
 	svc.attachments["test.example.com"] = []string{"attach-456"}
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-123",
 			Labels: map[string]string{
@@ -1671,6 +1673,7 @@ func TestService_Restart_WithAttachments_SucceedsWhenAllDeployed(t *testing.T) {
 			},
 		},
 	}, nil).Maybe()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
 
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
 	runtime.EXPECT().RestartContainer(mock.Anything, "attach-456").Return(nil)
@@ -3198,8 +3201,7 @@ func TestSyncContainersRebuildsAttachmentMap(t *testing.T) {
 	ctx := testContext()
 
 	// ListContainers returns one main container and one attachment container
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
-	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "main-container-1",
 			Labels: map[string]string{
@@ -3216,6 +3218,8 @@ func TestSyncContainersRebuildsAttachmentMap(t *testing.T) {
 			},
 		},
 	}, nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "main-container-1", domain.RestartPolicyAlways).Return(nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "attachment-container-1", domain.RestartPolicyAlways).Return(nil).Once()
 
 	require.NoError(t, svc.SyncContainers(ctx))
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -4181,6 +4181,7 @@ func TestDeployAttachedService_SetsAliasOnContainerConfig(t *testing.T) {
 			assert.Equal(t, []string{"postgres"}, cfg.Aliases, "attachment container must have network aliases for DNS resolution")
 			assert.Equal(t, "postgres", cfg.Hostname)
 			assert.Equal(t, networkName, cfg.NetworkMode)
+			assert.Equal(t, domain.RestartPolicyAlways, cfg.RestartPolicy)
 		}).
 		Return(&domain.Container{ID: "pg-container-1", Name: containerName}, nil)
 
@@ -4316,4 +4317,12 @@ func TestService_BuildContainerConfig_CompatSecurityProfileDefault(t *testing.T)
 	assert.False(t, cfg.ReadOnlyRootFS)
 	assert.Nil(t, cfg.CapDrop)
 	assert.Nil(t, cfg.CapAdd)
+}
+
+func TestService_BuildContainerConfig_SetsRestartPolicyAlways(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, Config{}, nil)
+
+	cfg := svc.buildContainerConfig(containerConfigInput{Domain: "app.example.com", Image: "app:latest", ImageRef: "app:latest"})
+
+	assert.Equal(t, domain.RestartPolicyAlways, cfg.RestartPolicy)
 }

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1239,7 +1239,7 @@ func TestService_HealthCheck(t *testing.T) {
 	assert.False(t, result["unhealthy.example.com"])
 }
 
-func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachments(t *testing.T) {
+func TestService_EnsureManagedContainerRestartPolicies_EnsuresRoutesAttachmentsAndStoppedContainers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
@@ -1289,23 +1289,13 @@ func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachmen
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "attachment-1", domain.RestartPolicyAlways).Return(nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "stopped-1", domain.RestartPolicyAlways).Return(nil).Once()
-	err := svc.SyncContainers(ctx)
+	err := svc.EnsureManagedContainerRestartPolicies(ctx)
 
 	require.NoError(t, err)
-	tracked, exists := svc.Get(ctx, "app.example.com")
-	require.True(t, exists)
-	assert.Equal(t, "route-1", tracked.ID)
-
-	svc.mu.RLock()
-	attachmentIDs := append([]string{}, svc.attachments["app.example.com"]...)
-	svc.mu.RUnlock()
-	assert.Equal(t, []string{"attachment-1"}, attachmentIDs)
-	assert.NotContains(t, svc.containers, "other-1")
-	assert.NotContains(t, svc.containers, "stopped.example.com")
 	runtime.AssertNumberOfCalls(t, "EnsureContainerRestartPolicy", 3)
 }
 
-func TestService_SyncContainers_RestartPolicyMigrationErrorIsNonFatal(t *testing.T) {
+func TestService_EnsureManagedContainerRestartPolicies_ErrorIsNonFatal(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
@@ -1324,12 +1314,9 @@ func TestService_SyncContainers_RestartPolicyMigrationErrorIsNonFatal(t *testing
 
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{routeContainer}, nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(errors.New("update failed")).Once()
-	err := svc.SyncContainers(ctx)
+	err := svc.EnsureManagedContainerRestartPolicies(ctx)
 
 	require.NoError(t, err)
-	tracked, exists := svc.Get(ctx, "app.example.com")
-	require.True(t, exists)
-	assert.Equal(t, "route-1", tracked.ID)
 }
 
 func TestService_SyncContainers(t *testing.T) {
@@ -1477,7 +1464,6 @@ func TestService_Restart_ReconcilesStaleContainerID(t *testing.T) {
 			},
 		},
 	}, nil).Once()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "fresh-container-id", domain.RestartPolicyAlways).Return(nil).Once()
 	runtime.EXPECT().RestartContainer(mock.Anything, "fresh-container-id").Return(nil).Once()
 
 	err := svc.Restart(ctx, "test.example.com", false)
@@ -3218,8 +3204,6 @@ func TestSyncContainersRebuildsAttachmentMap(t *testing.T) {
 			},
 		},
 	}, nil).Once()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "main-container-1", domain.RestartPolicyAlways).Return(nil).Once()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "attachment-container-1", domain.RestartPolicyAlways).Return(nil).Once()
 
 	require.NoError(t, svc.SyncContainers(ctx))
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -57,6 +57,11 @@ func testMinDelayConfig() Config {
 	}
 }
 
+func allowRestartPolicyEnsure(t *testing.T, runtime *mocks.MockContainerRuntime) {
+	t.Helper()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
+}
+
 func setupMetricsTest(t *testing.T) (*telemetry.Metrics, *sdkmetric.ManualReader) {
 	t.Helper()
 
@@ -255,8 +260,6 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	ctx := testContext()
 	metrics, reader := setupMetricsTest(t)
 	svc.SetMetrics(metrics)
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
-
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID: "container-1",
@@ -379,6 +382,8 @@ func TestService_Deploy_Success(t *testing.T) {
 	// Wait for ready: IsContainerRunning (first check returns true) + verify after delay
 	runtime.EXPECT().IsContainerRunning(mock.Anything, "container-123").Return(true, nil).Times(2)
 
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "container-123", domain.RestartPolicyAlways).Return(nil).Once()
+
 	// Re-inspect after start
 	runningContainer := &domain.Container{
 		ID:     "container-123",
@@ -407,6 +412,7 @@ func TestService_Deploy_Success(t *testing.T) {
 
 func TestService_Deploy_ReadinessRecoveryWindow_AllowsTransientFlap(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -473,6 +479,7 @@ func TestService_Deploy_ReadinessRecoveryWindow_AllowsTransientFlap(t *testing.T
 
 func TestService_Deploy_ImagePullFailure(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -515,6 +522,7 @@ func TestIsPullFailure_ErrImagePullFailed(t *testing.T) {
 
 func TestService_Deploy_DoesNotMisclassifyUnauthorizedEnvLoadFailure(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -555,6 +563,7 @@ func TestService_CaptureRecentContainerLogs_SkipsCanceledContext(t *testing.T) {
 
 func TestService_Deploy_ReadinessFailureReturnsDeployFailureWithLogs(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -614,6 +623,7 @@ func TestService_Deploy_ReadinessFailureReturnsDeployFailureWithLogs(t *testing.
 
 func TestService_Deploy_StrictHealthModeWithoutHealthcheckReturnsHint(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -725,6 +735,7 @@ func TestService_PullImage_InternalRetriesOnConnectionRefused(t *testing.T) {
 
 func TestService_Deploy_ReplacesExistingContainer(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -808,6 +819,7 @@ func TestService_Deploy_ReplacesExistingContainer(t *testing.T) {
 // from killing the real active container after a Gordon restart.
 func TestService_Deploy_ResolvesExistingFromRuntime_WhenMemoryStale(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -907,6 +919,7 @@ func TestService_Deploy_ResolvesExistingFromRuntime_WhenMemoryStale(t *testing.T
 
 func TestService_Deploy_SkipRedundantDeploy_GetImageIDError(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -969,6 +982,7 @@ func TestService_Deploy_SkipRedundantDeploy_GetImageIDError(t *testing.T) {
 
 func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -1027,6 +1041,7 @@ func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 
 func TestService_Deploy_WithVolumeAutoCreate(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -1295,7 +1310,7 @@ func TestService_EnsureManagedContainerRestartPolicies_EnsuresRoutesAttachmentsA
 	runtime.AssertNumberOfCalls(t, "EnsureContainerRestartPolicy", 3)
 }
 
-func TestService_EnsureManagedContainerRestartPolicies_ErrorIsNonFatal(t *testing.T) {
+func TestService_EnsureManagedContainerRestartPolicies_ContinuesAndReturnsError(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
@@ -1311,12 +1326,23 @@ func TestService_EnsureManagedContainerRestartPolicies_ErrorIsNonFatal(t *testin
 			domain.LabelDomain:  "app.example.com",
 		},
 	}
+	routeContainer2 := &domain.Container{
+		ID:   "route-2",
+		Name: "gordon-api.example.com",
+		Labels: map[string]string{
+			domain.LabelManaged: "true",
+			domain.LabelDomain:  "api.example.com",
+		},
+	}
 
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{routeContainer}, nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{routeContainer, routeContainer2}, nil).Once()
 	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(errors.New("update failed")).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-2", domain.RestartPolicyAlways).Return(nil).Once()
 	err := svc.EnsureManagedContainerRestartPolicies(ctx)
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "route-1")
+	assert.Contains(t, err.Error(), "update failed")
 }
 
 func TestService_SyncContainers(t *testing.T) {
@@ -1327,7 +1353,6 @@ func TestService_SyncContainers(t *testing.T) {
 	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
 	ctx := testContext()
 
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
 		{
 			ID:   "container-1",
@@ -1535,8 +1560,6 @@ func TestService_Restart_WithAttachments(t *testing.T) {
 			},
 		},
 	}, nil).Maybe()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
-
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-attach-1").Return(nil)
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-attach-2").Return(fmt.Errorf("boom"))
@@ -1612,8 +1635,6 @@ func TestService_Restart_WithAttachments_ErrorsWhenPartiallyDeployed(t *testing.
 			},
 		},
 	}, nil).Maybe()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
-
 	err := svc.Restart(testContext(), "test.example.com", true)
 
 	assert.Error(t, err)
@@ -1659,8 +1680,6 @@ func TestService_Restart_WithAttachments_SucceedsWhenAllDeployed(t *testing.T) {
 			},
 		},
 	}, nil).Maybe()
-	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, mock.Anything, domain.RestartPolicyAlways).Return(nil).Maybe()
-
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
 	runtime.EXPECT().RestartContainer(mock.Anything, "attach-456").Return(nil)
 
@@ -2036,6 +2055,7 @@ func TestRewriteToLocalRegistry(t *testing.T) {
 
 func TestService_Deploy_InternalDeployForcesPull(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2116,6 +2136,7 @@ func TestService_Deploy_InternalDeployForcesPull(t *testing.T) {
 
 func TestService_AutoStart_StartsNewContainers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2165,6 +2186,7 @@ func TestService_AutoStart_StartsNewContainers(t *testing.T) {
 
 func TestService_AutoStart_SkipsExistingContainers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2214,6 +2236,7 @@ func TestService_AutoStart_SkipsExistingContainers(t *testing.T) {
 
 func TestService_AutoStart_HandlesDeployErrors(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2242,6 +2265,7 @@ func TestService_AutoStart_HandlesDeployErrors(t *testing.T) {
 
 func TestService_AutoStart_UsesInternalDeployContext(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2294,6 +2318,7 @@ func TestService_AutoStart_UsesInternalDeployContext(t *testing.T) {
 // until the new container is ready and traffic is switched.
 func TestService_Deploy_OrphanCleanupSkipsTrackedContainer(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -2390,6 +2415,7 @@ func TestService_Deploy_OrphanCleanupSkipsTrackedContainer(t *testing.T) {
 // Running canonical containers are preserved (see NeverKillsRunningCanonical test).
 func TestService_Deploy_OrphanCleanupRemovesTrueOrphans(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2470,6 +2496,7 @@ func TestService_Deploy_OrphanCleanupRemovesTrueOrphans(t *testing.T) {
 
 func TestService_Deploy_OrphanCleanupRemovesStaleNewContainer(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -2542,6 +2569,7 @@ func TestService_Deploy_OrphanCleanupRemovesStaleNewContainer(t *testing.T) {
 
 func TestService_Deploy_TrackedTempContainerUsesAlternateTempName(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -2731,6 +2759,7 @@ func TestService_Deploy_ConcurrentSameDomain(t *testing.T) {
 	// Verify that concurrent Deploy calls for the same domain are serialized
 	// and both succeed without container name conflicts.
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -2841,6 +2870,7 @@ func TestService_Deploy_ConcurrentSameDomain(t *testing.T) {
 func TestService_Deploy_ContextCancellation(t *testing.T) {
 	// Verify that deploy lock acquisition respects context cancellation.
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -2871,6 +2901,7 @@ func TestService_Deploy_ContextCancellation(t *testing.T) {
 // BEFORE the old container is stopped, preventing 503 errors during deployment.
 func TestService_Deploy_CacheInvalidationBeforeOldContainerStop(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -2951,6 +2982,7 @@ func TestService_Deploy_CacheInvalidationBeforeOldContainerStop(t *testing.T) {
 // when no cache invalidator is set (e.g., in tests or minimal configurations).
 func TestService_Deploy_NilCacheInvalidator(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3000,6 +3032,7 @@ func TestService_Deploy_NilCacheInvalidator(t *testing.T) {
 
 func TestService_Deploy_SkipsRedundantDeploy(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3060,6 +3093,7 @@ func TestService_Deploy_SkipsRedundantDeploy(t *testing.T) {
 
 func TestService_Deploy_SkipsRedundantDeploy_WhenTrackedImageIDMissing(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3121,6 +3155,7 @@ func TestService_Deploy_SkipsRedundantDeploy_WhenTrackedImageIDMissing(t *testin
 
 func TestService_Deploy_DoesNotSkipWhenImageIDDiffers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -3223,6 +3258,7 @@ func TestSyncContainersRebuildsAttachmentMap(t *testing.T) {
 
 func TestService_Deploy_SkipRedundantDeploy_ContainerNotRunning(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3286,6 +3322,7 @@ func TestService_Deploy_SkipRedundantDeploy_ContainerNotRunning(t *testing.T) {
 
 func TestService_Deploy_DoesNotSkip_WhenEnvHashDiffers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3344,6 +3381,7 @@ func TestService_Deploy_DoesNotSkip_WhenEnvHashDiffers(t *testing.T) {
 
 func TestService_Deploy_DoesNotSkip_WhenEnvHashMissing(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3470,6 +3508,7 @@ func TestService_attachmentEnvDrifted_ReturnsTrueWhenHashMissing(t *testing.T) {
 // disallows creating a container with the same name as an existing running container.
 func TestService_Deploy_OrphanCleanup_NeverKillsRunningCanonical(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3566,6 +3605,7 @@ func TestService_Deploy_OrphanCleanup_NeverKillsRunningCanonical(t *testing.T) {
 // and the failed new container is cleaned up.
 func TestService_Deploy_RollbackOnPostSwitchCrash(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -3660,6 +3700,7 @@ func TestService_Deploy_RollbackOnPostSwitchCrash(t *testing.T) {
 // container is finalized (stopped and removed).
 func TestService_Deploy_StabilizationSuccess(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -3748,6 +3789,7 @@ func TestService_Deploy_StabilizationSuccess(t *testing.T) {
 // Uses testify's NotBefore() to enforce mock call ordering.
 func TestService_Deploy_ZeroDowntime_OldNeverStoppedBeforeNewReady(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 	cacheInvalidator := mocks.NewMockProxyCacheInvalidator(t)
@@ -3844,6 +3886,7 @@ func TestService_Deploy_ZeroDowntime_OldNeverStoppedBeforeNewReady(t *testing.T)
 // the old container remains as the tracked container.
 func TestService_Deploy_ZeroDowntime_ReadinessFailure_OldUntouched(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -3934,6 +3977,7 @@ func TestService_Deploy_ZeroDowntime_ReadinessFailure_OldUntouched(t *testing.T)
 // finalize/drain logic being triggered.
 func TestService_Deploy_ZeroDowntime_NoExisting_FirstDeploy(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -4010,6 +4054,7 @@ func TestService_Deploy_ZeroDowntime_NoExisting_FirstDeploy(t *testing.T) {
 
 func TestService_Deploy_PropagatesImageLabelsToContainerConfig(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
+	allowRestartPolicyEnsure(t, runtime)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
 
@@ -4267,7 +4312,7 @@ func TestDeployAttachedService_SetsAliasOnContainerConfig(t *testing.T) {
 			assert.Equal(t, []string{"postgres"}, cfg.Aliases, "attachment container must have network aliases for DNS resolution")
 			assert.Equal(t, "postgres", cfg.Hostname)
 			assert.Equal(t, networkName, cfg.NetworkMode)
-			assert.Equal(t, domain.RestartPolicyAlways, cfg.RestartPolicy)
+			assert.Empty(t, cfg.RestartPolicy)
 		}).
 		Return(&domain.Container{ID: "pg-container-1", Name: containerName}, nil)
 
@@ -4280,6 +4325,7 @@ func TestDeployAttachedService_SetsAliasOnContainerConfig(t *testing.T) {
 	runtime.EXPECT().GetContainerHealthStatus(mock.Anything, "pg-container-1").Return("", false, nil)
 	// TCP probe: resolve endpoint fails -> falls back to delay
 	runtime.EXPECT().GetContainerNetworkInfo(mock.Anything, "pg-container-1").Return("", 0, errors.New("no network"))
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "pg-container-1", domain.RestartPolicyAlways).Return(nil).Once()
 
 	err := svc.deployAttachedService(ctx, ownerDomain, serviceImage, networkName)
 	require.NoError(t, err)
@@ -4405,10 +4451,10 @@ func TestService_BuildContainerConfig_CompatSecurityProfileDefault(t *testing.T)
 	assert.Nil(t, cfg.CapAdd)
 }
 
-func TestService_BuildContainerConfig_SetsRestartPolicyAlways(t *testing.T) {
+func TestService_BuildContainerConfig_OmitsRestartPolicyBeforeReadiness(t *testing.T) {
 	svc := NewService(nil, nil, nil, nil, Config{}, nil)
 
 	cfg := svc.buildContainerConfig(containerConfigInput{Domain: "app.example.com", Image: "app:latest", ImageRef: "app:latest"})
 
-	assert.Equal(t, domain.RestartPolicyAlways, cfg.RestartPolicy)
+	assert.Empty(t, cfg.RestartPolicy)
 }

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -256,6 +256,7 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	metrics, reader := setupMetricsTest(t)
 	svc.SetMetrics(metrics)
 
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-1",
@@ -280,6 +281,7 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	assert.Equal(t, 0, points[0].Attributes.Len())
 
 	// No runtime change: metric should remain stable.
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-1",
@@ -304,6 +306,7 @@ func TestService_SyncContainers_ManagedContainersMetricTracksDelta(t *testing.T)
 	assert.Equal(t, 0, points[0].Attributes.Len())
 
 	// One container removed in runtime: metric should decrement by one.
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-1",
@@ -1238,6 +1241,92 @@ func TestService_HealthCheck(t *testing.T) {
 	assert.False(t, result["unhealthy.example.com"])
 }
 
+func TestService_SyncContainers_EnsuresRestartPolicyForManagedRoutesAndAttachments(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	ctx := testContext()
+
+	routeContainer := &domain.Container{
+		ID:   "route-1",
+		Name: "gordon-app.example.com",
+		Labels: map[string]string{
+			domain.LabelManaged: "true",
+			domain.LabelDomain:  "app.example.com",
+		},
+	}
+	attachmentContainer := &domain.Container{
+		ID:   "attachment-1",
+		Name: "gordon-app-example-com-postgres",
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: "app.example.com",
+		},
+	}
+	unmanagedContainer := &domain.Container{
+		ID:     "other-1",
+		Labels: map[string]string{},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		routeContainer,
+		attachmentContainer,
+		unmanagedContainer,
+	}, nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "attachment-1", domain.RestartPolicyAlways).Return(nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
+		routeContainer,
+		attachmentContainer,
+	}, nil).Once()
+
+	err := svc.SyncContainers(ctx)
+
+	require.NoError(t, err)
+	tracked, exists := svc.Get(ctx, "app.example.com")
+	require.True(t, exists)
+	assert.Equal(t, "route-1", tracked.ID)
+
+	svc.mu.RLock()
+	attachmentIDs := append([]string{}, svc.attachments["app.example.com"]...)
+	svc.mu.RUnlock()
+	assert.Equal(t, []string{"attachment-1"}, attachmentIDs)
+	assert.NotContains(t, svc.containers, "other-1")
+	runtime.AssertNumberOfCalls(t, "EnsureContainerRestartPolicy", 2)
+}
+
+func TestService_SyncContainers_RestartPolicyMigrationErrorIsNonFatal(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	ctx := testContext()
+
+	routeContainer := &domain.Container{
+		ID:   "route-1",
+		Name: "gordon-app.example.com",
+		Labels: map[string]string{
+			domain.LabelManaged: "true",
+			domain.LabelDomain:  "app.example.com",
+		},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{routeContainer}, nil).Once()
+	runtime.EXPECT().EnsureContainerRestartPolicy(mock.Anything, "route-1", domain.RestartPolicyAlways).Return(errors.New("update failed")).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{routeContainer}, nil).Once()
+
+	err := svc.SyncContainers(ctx)
+
+	require.NoError(t, err)
+	tracked, exists := svc.Get(ctx, "app.example.com")
+	require.True(t, exists)
+	assert.Equal(t, "route-1", tracked.ID)
+}
+
 func TestService_SyncContainers(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
@@ -1246,6 +1335,7 @@ func TestService_SyncContainers(t *testing.T) {
 	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
 	ctx := testContext()
 
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID:   "container-1",
@@ -1372,6 +1462,7 @@ func TestService_Restart_ReconcilesStaleContainerID(t *testing.T) {
 	runtime.EXPECT().RestartContainer(mock.Anything, "stale-container-id").
 		Return(errors.New("no container with name or ID \"stale-container-id\" found")).
 		Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID:   "fresh-container-id",
@@ -1406,6 +1497,7 @@ func TestService_Restart_ReconcilesStaleContainerID_NotFoundAfterSync(t *testing
 	runtime.EXPECT().RestartContainer(mock.Anything, "stale-container-id").
 		Return(errors.New("no such container")).
 		Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil).Once()
 
 	err := svc.Restart(ctx, "test.example.com", false)
@@ -1428,6 +1520,7 @@ func TestService_Restart_WithAttachments(t *testing.T) {
 		Status: "running",
 	}
 	svc.attachments["test.example.com"] = []string{"container-attach-1", "container-attach-2"}
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-123",
@@ -1482,6 +1575,7 @@ func TestService_Restart_WithAttachments_ErrorsWhenConfiguredButNotDeployed(t *t
 		Status: "running",
 	}
 	// No attachment containers tracked — s.attachments is empty
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil).Maybe()
 
 	err := svc.Restart(testContext(), "test.example.com", true)
@@ -1512,6 +1606,7 @@ func TestService_Restart_WithAttachments_ErrorsWhenPartiallyDeployed(t *testing.
 	}
 	// Only 1 of 2 attachments deployed
 	svc.attachments["test.example.com"] = []string{"attach-postgres"}
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-123",
@@ -1558,6 +1653,7 @@ func TestService_Restart_WithAttachments_SucceedsWhenAllDeployed(t *testing.T) {
 		Status: "running",
 	}
 	svc.attachments["test.example.com"] = []string{"attach-456"}
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "container-123",
@@ -1626,6 +1722,7 @@ func TestService_Restart_WithAttachments_NoConfiguredNoDeployed_Succeeds(t *test
 		Name:   "gordon-test.example.com",
 		Status: "running",
 	}
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Maybe()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{}, nil).Maybe()
 
 	runtime.EXPECT().RestartContainer(mock.Anything, "container-123").Return(nil)
@@ -3101,6 +3198,7 @@ func TestSyncContainersRebuildsAttachmentMap(t *testing.T) {
 	ctx := testContext()
 
 	// ListContainers returns one main container and one attachment container
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
 	runtime.EXPECT().ListContainers(mock.Anything, false).Return([]*domain.Container{
 		{
 			ID: "main-container-1",


### PR DESCRIPTION
## Summary
- set restart policy `always` on Gordon-managed route containers
- set restart policy `always` on managed attachment containers
- map the domain restart policy onto Docker/Podman HostConfig and cover it with tests

Fixes #188

## Verification
- `go test ./internal/usecase/container ./internal/adapters/out/docker/...`
- `go test ./...`
- `golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Containers (application and attachments) now default to an automatic restart policy of "always".
  * Sync process includes a migration/enforcement step that updates managed containers to the desired restart policy; failures are logged and non-fatal.

* **Behavior**
  * When updating restart policy, existing container resource settings are preserved.

* **Tests**
  * Added tests for creation, enforcement/migration, resource-preservation during updates, and host-config error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->