### PR TITLE
cli: auto infer remote targets from saved remotes

### DIFF
--- a/docs/cli/attachments.md
+++ b/docs/cli/attachments.md
@@ -3,6 +3,9 @@
 Manage attachments on local or remote Gordon instances.
 
 Remote targeting uses client config or an active remote by default.
+When you provide a concrete target (for example `attachments list app.example.com`
+or `attachments remove app.example.com postgres:18`) and no remote is selected,
+Gordon can also auto-infer a saved remote when exactly one match is found.
 Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 ## Requirements

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -168,6 +168,25 @@ The CLI can target remote Gordon instances using client config, an active remote
 or `GORDON_REMOTE` environment variable. Use `--remote` and `--token` as global overrides
 when you want to bypass your saved configuration.
 
+When no explicit remote is selected and no active remote is configured, Gordon can now
+**auto-infer a saved remote** for commands that already have a concrete target. It probes your
+saved remotes and uses the remote automatically when exactly one matches. If multiple remotes
+match, Gordon stops with an ambiguity error and asks you to use `--remote`. If any remote probe
+fails, Gordon also stops rather than guessing.
+
+Auto-inference currently applies to target-based commands such as:
+- `gordon push`
+- `gordon attachments push`
+- `gordon deploy <domain>`
+- `gordon restart <domain>`
+- `gordon pin <domain>` / `gordon pin list <domain>`
+- `gordon routes show <domain>` / `gordon routes remove <domain>`
+- `gordon secrets list|set|remove <domain>`
+- `gordon attachments list <target>` / `gordon attachments add|remove <target> ...`
+- `gordon backups list <domain>` / `gordon backups run <domain>` / `gordon backups detect <domain>`
+- `gordon images tags <repository>`
+- `gordon logs <domain>`
+
 `gordon routes list` and `gordon routes status` are the exceptions: when neither `--remote`
 nor `GORDON_REMOTE` is set, they show local routes first, then every saved remote. Set either
 one to force a single target.
@@ -180,6 +199,10 @@ gordon routes status
 # Single-target override
 gordon routes list --remote prod
 GORDON_REMOTE=prod gordon routes status
+
+# Auto-inferred single match from saved remotes
+gordon push myapp --build
+gordon deploy app.example.com
 ```
 
 **Important:** The remote URL must be the `gordon_domain` configured on the remote Gordon instance. This is the domain that serves both the container registry and the Admin API.

--- a/docs/cli/push.md
+++ b/docs/cli/push.md
@@ -36,6 +36,12 @@ gordon push [image] [options]
 `gordon push` tags the selected image for the Gordon registry, pushes it, and
 optionally deploys matching routes.
 
+If you do not pass `--remote` and no active remote is configured, Gordon tries to
+infer the correct saved remote by probing your saved remotes for a matching route.
+It auto-selects only when exactly one remote matches. If multiple remotes match,
+or a saved remote cannot be probed safely, the command stops and asks you to use
+`--remote` explicitly.
+
 Image resolution order:
 1. `--domain` is the explicit deploy target override for legacy workflows
 2. Positional refs resolve routes by image name; tagged refs still use the image name for lookup

--- a/docs/cli/remotes.md
+++ b/docs/cli/remotes.md
@@ -165,6 +165,8 @@ gordon remotes use <name>
 When a remote is active, it's used automatically for most remote-capable commands without needing to specify `--remote` and `--token`.
 `gordon routes list` and `gordon routes status` are the exception: they aggregate local + saved remotes unless you set `--remote` or `GORDON_REMOTE`.
 
+If no remote is active and you do not pass `--remote`, Gordon can also auto-infer a saved remote for commands with a concrete target (for example `gordon push myapp`, `gordon deploy app.example.com`, or `gordon images tags myapp`). It only auto-selects when exactly one saved remote matches. Ambiguous matches and probe failures require an explicit `--remote`.
+
 ```bash
 gordon remotes use prod
 gordon secrets list app.com     # Uses prod remote automatically
@@ -245,11 +247,13 @@ token = "eyJ..."
 When multiple sources specify remote or token, the CLI uses this priority:
 
 For `routes list` and `routes status`, `--remote` and `GORDON_REMOTE` are the explicit single-target selectors. Without either one, those commands aggregate local + saved remotes even when an active remote exists.
+Auto-inference is not used for those aggregate views.
 
-**Remote URL:**
+**Remote target selection:**
 1. `--remote` flag
 2. `GORDON_REMOTE` environment variable
 3. Active remote from `remotes.toml`
+4. Auto-inferred saved remote for supported target-based commands
 
 **Token:**
 1. `--token` flag

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -3,6 +3,8 @@
 Manage secrets on local or remote Gordon instances.
 
 Remote targeting uses client config or an active remote by default.
+When you provide a concrete domain and no remote is selected, Gordon can also
+auto-infer a saved remote when exactly one match is found.
 Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 Storage depends on the secrets backend:

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -248,6 +248,8 @@ gordon logs [domain] [options]
 | `--token` | | | Authentication token for remote |
 
 Remote targeting uses client config or an active remote by default.
+When you provide a concrete domain and no remote is selected, Gordon can also
+auto-infer a saved remote when exactly one match is found.
 Use `--remote` and `--token` to override. See [CLI Overview](./index.md).
 
 Remote log access requires an admin token with `admin:logs:read` (or `admin:*:*`). `admin:status:read` is not sufficient for logs.

--- a/internal/adapters/in/cli/attachments.go
+++ b/internal/adapters/in/cli/attachments.go
@@ -86,22 +86,14 @@ func runAttachmentsList(ctx context.Context, cp ControlPlane, target string, jso
 		if err != nil {
 			return fmt.Errorf("failed to get attachments: %w", err)
 		}
-
 		if len(images) == 0 {
-			fmt.Printf("No attachments configured for '%s'\n", target)
-			return nil
+			_, err := fmt.Fprintf(out, "No attachments configured for '%s'\n", target)
+			return err
 		}
-
 		if jsonOut {
 			return writeJSON(out, map[string]any{"target": target, "images": images})
 		}
-
-		fmt.Println(styles.Theme.Title.Render(fmt.Sprintf("Attachments for %s", target)))
-		fmt.Println()
-		for _, img := range images {
-			fmt.Printf("  %s\n", img)
-		}
-		return nil
+		return renderAttachmentTargetList(out, fmt.Sprintf("Attachments for %s", target), images)
 	}
 
 	attachments, err := cp.GetAllAttachmentsConfig(ctx)
@@ -109,29 +101,53 @@ func runAttachmentsList(ctx context.Context, cp ControlPlane, target string, jso
 		return fmt.Errorf("failed to list attachments: %w", err)
 	}
 	if len(attachments) == 0 {
-		fmt.Println(styles.Theme.Muted.Render("No attachments configured"))
-		return nil
+		return cliWriteLine(out, styles.Theme.Muted.Render("No attachments configured"))
 	}
 	if jsonOut {
 		return writeJSON(out, map[string]any{"attachments": attachments})
 	}
+	return renderAllAttachmentsList(out, "Attachments", attachments)
+}
 
+func renderAttachmentTargetList(out io.Writer, title string, images []string) error {
+	if _, err := fmt.Fprintln(out, styles.Theme.Title.Render(title)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
+	for _, img := range images {
+		if _, err := fmt.Fprintf(out, "  %s\n", img); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderAllAttachmentsList(out io.Writer, title string, attachments map[string][]string) error {
 	targets := make([]string, 0, len(attachments))
 	for t := range attachments {
 		targets = append(targets, t)
 	}
 	sort.Strings(targets)
 
-	fmt.Println(styles.Theme.Title.Render("Attachments"))
-	fmt.Println()
+	if _, err := fmt.Fprintln(out, styles.Theme.Title.Render(title)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
 	for _, t := range targets {
 		images := attachments[t]
-		fmt.Printf("%s\n", styles.Theme.Bold.Render(t))
+		if _, err := fmt.Fprintf(out, "%s\n", styles.Theme.Bold.Render(t)); err != nil {
+			return err
+		}
 		for _, img := range images {
-			fmt.Printf("  %s\n", img)
+			if _, err := fmt.Fprintf(out, "  %s\n", img); err != nil {
+				return err
+			}
 		}
 	}
-
 	return nil
 }
 

--- a/internal/adapters/in/cli/attachments.go
+++ b/internal/adapters/in/cli/attachments.go
@@ -52,7 +52,7 @@ Examples:
   gordon attachments list backend            # List attachments for network group`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			target := ""
 			if len(args) > 0 {
 				target = args[0]
@@ -110,14 +110,14 @@ func runAttachmentsList(ctx context.Context, cp ControlPlane, target string, jso
 }
 
 func renderAttachmentTargetList(out io.Writer, title string, images []string) error {
-	if _, err := fmt.Fprintln(out, styles.Theme.Title.Render(title)); err != nil {
+	if err := cliWriteLine(out, cliRenderTitle(title)); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(out); err != nil {
+	if err := cliWriteLine(out, ""); err != nil {
 		return err
 	}
 	for _, img := range images {
-		if _, err := fmt.Fprintf(out, "  %s\n", img); err != nil {
+		if err := cliWritef(out, "  %s\n", img); err != nil {
 			return err
 		}
 	}
@@ -131,19 +131,19 @@ func renderAllAttachmentsList(out io.Writer, title string, attachments map[strin
 	}
 	sort.Strings(targets)
 
-	if _, err := fmt.Fprintln(out, styles.Theme.Title.Render(title)); err != nil {
+	if err := cliWriteLine(out, cliRenderTitle(title)); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintln(out); err != nil {
+	if err := cliWriteLine(out, ""); err != nil {
 		return err
 	}
 	for _, t := range targets {
 		images := attachments[t]
-		if _, err := fmt.Fprintf(out, "%s\n", styles.Theme.Bold.Render(t)); err != nil {
+		if err := cliWritef(out, "%s\n", styles.Theme.Bold.Render(t)); err != nil {
 			return err
 		}
 		for _, img := range images {
-			if _, err := fmt.Fprintf(out, "  %s\n", img); err != nil {
+			if err := cliWritef(out, "  %s\n", img); err != nil {
 				return err
 			}
 		}
@@ -295,7 +295,7 @@ Examples:
   gordon --remote https://gordon.mydomain.com attachments add api.mydomain.com memcached:latest`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			target := args[0]
 			image := args[1]
 
@@ -347,7 +347,7 @@ Examples:
   gordon attachments remove backend redis:7-alpine --force`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			target := args[0]
 			image := args[1]
 

--- a/internal/adapters/in/cli/attachments.go
+++ b/internal/adapters/in/cli/attachments.go
@@ -58,6 +58,15 @@ Examples:
 				target = args[0]
 			}
 
+			if target != "" {
+				handle, err := resolveControlPlaneForAttachmentTarget(ctx, target)
+				if err != nil {
+					return err
+				}
+				defer handle.close()
+				return runAttachmentsList(ctx, handle.plane, target, jsonOut, cmd.OutOrStdout())
+			}
+
 			client, isRemote := GetRemoteClient()
 			if isRemote {
 				return runAttachmentsListRemote(ctx, client, target, jsonOut, cmd.OutOrStdout())
@@ -69,6 +78,61 @@ Examples:
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+func runAttachmentsList(ctx context.Context, cp ControlPlane, target string, jsonOut bool, out io.Writer) error {
+	if target != "" {
+		images, err := cp.GetAttachmentsConfig(ctx, target)
+		if err != nil {
+			return fmt.Errorf("failed to get attachments: %w", err)
+		}
+
+		if len(images) == 0 {
+			fmt.Printf("No attachments configured for '%s'\n", target)
+			return nil
+		}
+
+		if jsonOut {
+			return writeJSON(out, map[string]any{"target": target, "images": images})
+		}
+
+		fmt.Println(styles.Theme.Title.Render(fmt.Sprintf("Attachments for %s", target)))
+		fmt.Println()
+		for _, img := range images {
+			fmt.Printf("  %s\n", img)
+		}
+		return nil
+	}
+
+	attachments, err := cp.GetAllAttachmentsConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list attachments: %w", err)
+	}
+	if len(attachments) == 0 {
+		fmt.Println(styles.Theme.Muted.Render("No attachments configured"))
+		return nil
+	}
+	if jsonOut {
+		return writeJSON(out, map[string]any{"attachments": attachments})
+	}
+
+	targets := make([]string, 0, len(attachments))
+	for t := range attachments {
+		targets = append(targets, t)
+	}
+	sort.Strings(targets)
+
+	fmt.Println(styles.Theme.Title.Render("Attachments"))
+	fmt.Println()
+	for _, t := range targets {
+		images := attachments[t]
+		fmt.Printf("%s\n", styles.Theme.Bold.Render(t))
+		for _, img := range images {
+			fmt.Printf("  %s\n", img)
+		}
+	}
+
+	return nil
 }
 
 // runAttachmentsListRemote lists attachments from a remote Gordon instance.
@@ -219,12 +283,13 @@ Examples:
 			target := args[0]
 			image := args[1]
 
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				if err := client.AddAttachment(ctx, target, image); err != nil {
-					return fmt.Errorf("failed to add attachment: %w", err)
-				}
-			} else {
+			handle, err := resolveControlPlaneForAttachmentTarget(ctx, target)
+			if err != nil {
+				return err
+			}
+			defer handle.close()
+
+			if !handle.isRemote {
 				local, err := GetLocalServices(configPath)
 				if err != nil {
 					return fmt.Errorf("failed to initialize local services: %w", err)
@@ -238,10 +303,10 @@ Examples:
 					fmt.Println(styles.Theme.Muted.Render("  Enable with: [network_isolation] enabled = true"))
 					fmt.Println()
 				}
+			}
 
-				if err := local.GetConfigService().AddAttachment(ctx, target, image); err != nil {
-					return fmt.Errorf("failed to add attachment: %w", err)
-				}
+			if err := handle.plane.AddAttachment(ctx, target, image); err != nil {
+				return fmt.Errorf("failed to add attachment: %w", err)
 			}
 
 			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Attachment added: %s -> %s", target, image)))
@@ -285,19 +350,13 @@ Examples:
 				}
 			}
 
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				if err := client.RemoveAttachment(ctx, target, image); err != nil {
-					return fmt.Errorf("failed to remove attachment: %w", err)
-				}
-			} else {
-				local, err := GetLocalServices(configPath)
-				if err != nil {
-					return fmt.Errorf("failed to initialize local services: %w", err)
-				}
-				if err := local.GetConfigService().RemoveAttachment(ctx, target, image); err != nil {
-					return fmt.Errorf("failed to remove attachment: %w", err)
-				}
+			handle, err := resolveControlPlaneForAttachmentTarget(ctx, target)
+			if err != nil {
+				return err
+			}
+			defer handle.close()
+			if err := handle.plane.RemoveAttachment(ctx, target, image); err != nil {
+				return fmt.Errorf("failed to remove attachment: %w", err)
 			}
 
 			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Attachment removed: %s -> %s", target, image)))

--- a/internal/adapters/in/cli/attachments_push.go
+++ b/internal/adapters/in/cli/attachments_push.go
@@ -57,16 +57,29 @@ func newAttachmentsPushCmd() *cobra.Command {
 }
 
 func runAttachmentsPush(ctx context.Context, req attachmentPushRequest, out io.Writer) error {
-	handle, err := resolveControlPlaneFn(configPath)
-	if err != nil {
-		return err
-	}
-	defer handle.close()
-
 	dockerfile, err := resolveDockerfile(req.Build.Dockerfile, req.Build.Enabled)
 	if err != nil {
 		return err
 	}
+
+	inferredRemote, err := inferRemoteForAttachmentImage(ctx, req.ImageArg)
+	if err != nil {
+		return err
+	}
+
+	var handle *controlPlaneHandle
+	if inferredRemote != nil {
+		handle = newRemoteControlPlaneHandle(inferredRemote)
+		if err := cliWritef(out, "Remote:           %s %s\n", styles.Theme.Bold.Render(inferredRemote.DisplayName()), styles.Theme.Muted.Render("(auto-detected)")); err != nil {
+			return err
+		}
+	} else {
+		handle, err = resolveControlPlaneFn(configPath)
+		if err != nil {
+			return err
+		}
+	}
+	defer handle.close()
 
 	for _, ba := range req.Build.BuildArgs {
 		if err := validateBuildArg(ba); err != nil {
@@ -91,7 +104,12 @@ func runAttachmentsPush(ctx context.Context, req attachmentPushRequest, out io.W
 	}
 	img.VersionRef, img.LatestRef = resolveImageRefs(registry, imageName, version)
 
-	imageOps, err := newImageOpsFn()
+	var imageOps pushImageOps
+	if inferredRemote != nil {
+		imageOps, err = newImageOpsForResolvedRemote(inferredRemote)
+	} else {
+		imageOps, err = newImageOpsFn()
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/adapters/in/cli/backup.go
+++ b/internal/adapters/in/cli/backup.go
@@ -42,16 +42,24 @@ func newBackupListCmd() *cobra.Command {
 		Long:  cliRenderMuted("List backups for all domains or a specific domain."),
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			handle, err := resolveControlPlane(configPath)
-			if err != nil {
-				return err
-			}
-			defer handle.close()
-
 			domainName := ""
 			if len(args) == 1 {
 				domainName = args[0]
 			}
+
+			var (
+				handle *controlPlaneHandle
+				err    error
+			)
+			if domainName != "" {
+				handle, err = resolveControlPlaneForRouteDomain(cmd.Context(), domainName)
+			} else {
+				handle, err = resolveControlPlane(configPath)
+			}
+			if err != nil {
+				return err
+			}
+			defer handle.close()
 
 			jobs, err := handle.plane.ListBackups(cmd.Context(), domainName)
 			if err != nil {
@@ -103,7 +111,7 @@ func newBackupRunCmd() *cobra.Command {
 		Short: "Run backup now",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRouteDomain(cmd.Context(), args[0])
 			if err != nil {
 				return err
 			}
@@ -145,7 +153,7 @@ func newBackupDetectCmd() *cobra.Command {
 		Short: "Detect databases for domain",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRouteDomain(cmd.Context(), args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/adapters/in/cli/controlplane_resolver.go
+++ b/internal/adapters/in/cli/controlplane_resolver.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
 	"github.com/bnema/gordon/internal/app"
 )
 
@@ -29,6 +31,40 @@ func resolveControlPlane(configPath string) (*controlPlaneHandle, error) {
 	}
 
 	return resolveLocalControlPlane(configPath)
+}
+
+func newRemoteControlPlaneHandle(target *remote.ResolvedRemote) *controlPlaneHandle {
+	client := remote.NewClient(target.URL, remoteClientOptions(target.Token, target.InsecureTLS)...)
+	return &controlPlaneHandle{plane: NewRemoteControlPlane(client), isRemote: true}
+}
+
+func resolveControlPlaneForRouteDomain(ctx context.Context, routeDomain string) (*controlPlaneHandle, error) {
+	return resolveControlPlaneWithInference(ctx, func(ctx context.Context) (*remote.ResolvedRemote, error) {
+		return inferRemoteForRouteDomain(ctx, routeDomain)
+	})
+}
+
+func resolveControlPlaneForAttachmentTarget(ctx context.Context, target string) (*controlPlaneHandle, error) {
+	return resolveControlPlaneWithInference(ctx, func(ctx context.Context) (*remote.ResolvedRemote, error) {
+		return inferRemoteForAttachmentTarget(ctx, target)
+	})
+}
+
+func resolveControlPlaneForRepository(ctx context.Context, repository string) (*controlPlaneHandle, error) {
+	return resolveControlPlaneWithInference(ctx, func(ctx context.Context) (*remote.ResolvedRemote, error) {
+		return inferRemoteForRepository(ctx, repository)
+	})
+}
+
+func resolveControlPlaneWithInference(ctx context.Context, infer func(context.Context) (*remote.ResolvedRemote, error)) (*controlPlaneHandle, error) {
+	resolved, err := infer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resolved != nil {
+		return newRemoteControlPlaneHandle(resolved), nil
+	}
+	return resolveControlPlane(configPath)
 }
 
 func resolveLocalControlPlane(configPath string) (*controlPlaneHandle, error) {

--- a/internal/adapters/in/cli/deploy.go
+++ b/internal/adapters/in/cli/deploy.go
@@ -35,7 +35,7 @@ Examples:
   gordon deploy myapp.example.com --remote https://gordon.mydomain.com --token $TOKEN`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRouteDomain(cmd.Context(), args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/adapters/in/cli/images.go
+++ b/internal/adapters/in/cli/images.go
@@ -148,7 +148,7 @@ Examples:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRepository(ctx, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/adapters/in/cli/pin.go
+++ b/internal/adapters/in/cli/pin.go
@@ -59,7 +59,7 @@ func newPinListCmd() *cobra.Command {
 }
 
 func runPin(ctx context.Context, out, ew io.Writer, pinDomain, targetTag string) error {
-	handle, err := resolveControlPlane(configPath)
+	handle, err := resolveControlPlaneForRouteDomain(ctx, pinDomain)
 	if err != nil {
 		return fmt.Errorf("failed to resolve control plane: %w", err)
 	}
@@ -96,7 +96,7 @@ func runPin(ctx context.Context, out, ew io.Writer, pinDomain, targetTag string)
 }
 
 func runPinList(ctx context.Context, w io.Writer, pinDomain string, jsonOut bool) error {
-	handle, err := resolveControlPlane(configPath)
+	handle, err := resolveControlPlaneForRouteDomain(ctx, pinDomain)
 	if err != nil {
 		return fmt.Errorf("failed to resolve control plane: %w", err)
 	}

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -227,7 +227,7 @@ func resolveVersion(ctx context.Context, tag string) (string, error) {
 }
 
 func runPush(ctx context.Context, out io.Writer, req pushRequest) error {
-	dockerfile, inferredRemote, handle, err := resolvePushTarget(ctx, req)
+	dockerfile, inferredRemote, handle, err := resolvePushTarget(ctx, out, req)
 	if err != nil {
 		return err
 	}
@@ -254,11 +254,17 @@ func runPush(ctx context.Context, out io.Writer, req pushRequest) error {
 		return err
 	}
 
-	fmt.Printf("Image:  %s\n", styles.Theme.Bold.Render(img.VersionRef))
-	if version != "latest" {
-		fmt.Printf("Also:   %s\n", styles.Theme.Bold.Render(img.LatestRef))
+	if err := cliWritef(out, "Image:  %s\n", styles.Theme.Bold.Render(img.VersionRef)); err != nil {
+		return err
 	}
-	fmt.Printf("Domain: %s\n", styles.Theme.Bold.Render(pushDomain))
+	if version != "latest" {
+		if err := cliWritef(out, "Also:   %s\n", styles.Theme.Bold.Render(img.LatestRef)); err != nil {
+			return err
+		}
+	}
+	if err := cliWritef(out, "Domain: %s\n", styles.Theme.Bold.Render(pushDomain)); err != nil {
+		return err
+	}
 
 	skipExplicitDeploy := shouldSkipDeploy(ctx, handle.plane, imageName, req.NoDeploy)
 	build := buildConfig{Enabled: req.Build.Enabled, Platform: req.Build.Platform, Dockerfile: dockerfile, BuildArgs: req.Build.BuildArgs}
@@ -275,7 +281,7 @@ func runPush(ctx context.Context, out io.Writer, req pushRequest) error {
 	return nil
 }
 
-func resolvePushTarget(ctx context.Context, req pushRequest) (dockerfile string, inferredRemote *remote.ResolvedRemote, handle *controlPlaneHandle, err error) {
+func resolvePushTarget(ctx context.Context, out io.Writer, req pushRequest) (dockerfile string, inferredRemote *remote.ResolvedRemote, handle *controlPlaneHandle, err error) {
 	dockerfile, err = resolveDockerfile(req.Build.Dockerfile, req.Build.Enabled)
 	if err != nil {
 		return "", nil, nil, err
@@ -286,7 +292,9 @@ func resolvePushTarget(ctx context.Context, req pushRequest) (dockerfile string,
 	}
 	if inferredRemote != nil {
 		handle = newRemoteControlPlaneHandle(inferredRemote)
-		fmt.Printf("Remote: %s %s\n", styles.Theme.Bold.Render(inferredRemote.DisplayName()), styles.Theme.Muted.Render("(auto-detected)"))
+		if err := cliWritef(out, "Remote: %s %s\n", styles.Theme.Bold.Render(inferredRemote.DisplayName()), styles.Theme.Muted.Render("(auto-detected)")); err != nil {
+			return "", nil, nil, err
+		}
 		return dockerfile, inferredRemote, handle, nil
 	}
 	handle, err = resolveControlPlane(configPath)

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -92,7 +93,7 @@ Examples:
 			if len(args) > 0 {
 				imageArg = args[0]
 			}
-			return runPush(cmd.Context(), pushRequest{
+			return runPush(cmd.Context(), cmd.OutOrStdout(), pushRequest{
 				ImageArg:  imageArg,
 				Domain:    domainFlag,
 				Tag:       tag,
@@ -225,7 +226,7 @@ func resolveVersion(ctx context.Context, tag string) (string, error) {
 	return version, nil
 }
 
-func runPush(ctx context.Context, req pushRequest) error {
+func runPush(ctx context.Context, out io.Writer, req pushRequest) error {
 	dockerfile, inferredRemote, handle, err := resolvePushTarget(ctx, req)
 	if err != nil {
 		return err
@@ -265,7 +266,9 @@ func runPush(ctx context.Context, req pushRequest) error {
 		return err
 	}
 
-	fmt.Println(styles.RenderSuccess("Push complete"))
+	if err := cliWriteLine(out, styles.RenderSuccess("Push complete")); err != nil {
+		return err
+	}
 	if !skipExplicitDeploy {
 		return deployAfterPush(ctx, handle.plane, pushDomain, req.NoConfirm)
 	}
@@ -429,7 +432,7 @@ func selectDomain(routes []domain.Route, dockerfile string) (domain.Route, error
 		labelDomainList = append(labelDomainList, labelDomain)
 	}
 	if labelDomains != "" {
-		for _, d := range strings.Split(labelDomains, ",") {
+		for d := range strings.SplitSeq(labelDomains, ",") {
 			d = strings.TrimSpace(d)
 			if d != "" {
 				labelDomainList = append(labelDomainList, d)
@@ -583,12 +586,10 @@ func splitLabelPairs(content string) []string {
 
 // parseLabelPair parses a single "key=value" or "key=\"value\"" pair.
 func parseLabelPair(pair string) (key, value string, ok bool) {
-	idx := strings.Index(pair, "=")
-	if idx == -1 {
+	key, value, ok = strings.Cut(pair, "=")
+	if !ok {
 		return "", "", false
 	}
-	key = pair[:idx]
-	value = pair[idx+1:]
 	// Strip surrounding quotes
 	value = strings.Trim(value, "\"'")
 	return key, value, true

--- a/internal/adapters/in/cli/push.go
+++ b/internal/adapters/in/cli/push.go
@@ -226,16 +226,11 @@ func resolveVersion(ctx context.Context, tag string) (string, error) {
 }
 
 func runPush(ctx context.Context, req pushRequest) error {
-	handle, err := resolveControlPlane(configPath)
+	dockerfile, inferredRemote, handle, err := resolvePushTarget(ctx, req)
 	if err != nil {
 		return err
 	}
 	defer handle.close()
-
-	dockerfile, err := resolveDockerfile(req.Build.Dockerfile, req.Build.Enabled)
-	if err != nil {
-		return err
-	}
 
 	registry, imageName, pushDomain, err := resolveRoute(ctx, handle.plane, req.ImageArg, req.Domain, dockerfile)
 	if err != nil {
@@ -246,21 +241,14 @@ func runPush(ctx context.Context, req pushRequest) error {
 	if err != nil {
 		return err
 	}
-
-	for _, ba := range req.Build.BuildArgs {
-		if err := validateBuildArg(ba); err != nil {
-			return err
-		}
+	if err := validateBuildArgsList(req.Build.BuildArgs); err != nil {
+		return err
 	}
 
-	img := imagePush{
-		Registry:  registry,
-		ImageName: imageName,
-		Version:   version,
-	}
+	img := imagePush{Registry: registry, ImageName: imageName, Version: version}
 	img.VersionRef, img.LatestRef = resolveImageRefs(registry, imageName, version)
 
-	imageOps, err := newImageOpsFn()
+	imageOps, err := newPushImageOps(inferredRemote)
 	if err != nil {
 		return err
 	}
@@ -272,31 +260,60 @@ func runPush(ctx context.Context, req pushRequest) error {
 	fmt.Printf("Domain: %s\n", styles.Theme.Bold.Render(pushDomain))
 
 	skipExplicitDeploy := shouldSkipDeploy(ctx, handle.plane, imageName, req.NoDeploy)
-
-	build := buildConfig{
-		Enabled:    req.Build.Enabled,
-		Platform:   req.Build.Platform,
-		Dockerfile: dockerfile,
-		BuildArgs:  req.Build.BuildArgs,
-	}
-
-	if build.Enabled {
-		if err := buildAndPush(ctx, imageOps, build, img); err != nil {
-			return err
-		}
-	} else {
-		if err := tagAndPush(ctx, imageOps, img); err != nil {
-			return err
-		}
+	build := buildConfig{Enabled: req.Build.Enabled, Platform: req.Build.Platform, Dockerfile: dockerfile, BuildArgs: req.Build.BuildArgs}
+	if err := pushResolvedImage(ctx, imageOps, build, img); err != nil {
+		return err
 	}
 
 	fmt.Println(styles.RenderSuccess("Push complete"))
-
 	if !skipExplicitDeploy {
 		return deployAfterPush(ctx, handle.plane, pushDomain, req.NoConfirm)
 	}
-
 	return nil
+}
+
+func resolvePushTarget(ctx context.Context, req pushRequest) (dockerfile string, inferredRemote *remote.ResolvedRemote, handle *controlPlaneHandle, err error) {
+	dockerfile, err = resolveDockerfile(req.Build.Dockerfile, req.Build.Enabled)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	inferredRemote, err = inferPushRemote(ctx, req.ImageArg, req.Domain, dockerfile)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if inferredRemote != nil {
+		handle = newRemoteControlPlaneHandle(inferredRemote)
+		fmt.Printf("Remote: %s %s\n", styles.Theme.Bold.Render(inferredRemote.DisplayName()), styles.Theme.Muted.Render("(auto-detected)"))
+		return dockerfile, inferredRemote, handle, nil
+	}
+	handle, err = resolveControlPlane(configPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	return dockerfile, nil, handle, nil
+}
+
+func validateBuildArgsList(buildArgs []string) error {
+	for _, ba := range buildArgs {
+		if err := validateBuildArg(ba); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newPushImageOps(inferredRemote *remote.ResolvedRemote) (pushImageOps, error) {
+	if inferredRemote != nil {
+		return newImageOpsForResolvedRemote(inferredRemote)
+	}
+	return newImageOpsFn()
+}
+
+func pushResolvedImage(ctx context.Context, imageOps pushImageOps, build buildConfig, img imagePush) error {
+	if build.Enabled {
+		return buildAndPush(ctx, imageOps, build, img)
+	}
+	return tagAndPush(ctx, imageOps, img)
 }
 
 // shouldSkipDeploy signals deploy intent and returns whether the explicit deploy
@@ -345,15 +362,7 @@ func resolveFromImage(ctx context.Context, cp ControlPlane, imageArg, dockerfile
 		return "", "", "", fmt.Errorf("failed to find routes for image %q: %w", imageArg, err)
 	}
 
-	// Filter out preview routes (domains containing "--") so they don't
-	// pollute the selection when pushing the base image.
-	filtered := routes[:0]
-	for _, r := range routes {
-		if !strings.Contains(r.Domain, domain.DefaultPreviewSeparator) {
-			filtered = append(filtered, r)
-		}
-	}
-	routes = filtered
+	routes = filterPreviewRoutes(routes)
 
 	if len(routes) == 0 {
 		return "", "", "", noRouteForImageError(imageArg)

--- a/internal/adapters/in/cli/push_image_ops.go
+++ b/internal/adapters/in/cli/push_image_ops.go
@@ -55,6 +55,10 @@ func newDockerImageOps(insecureTLS bool, progress io.Writer) (*dockerImageOps, e
 // newImageOpsFromFlags resolves TLS settings from CLI flags/config and creates ops.
 func newImageOpsFromFlags() (pushImageOps, error) {
 	resolved, _ := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
+	return newImageOpsForResolvedRemote(resolved)
+}
+
+func newImageOpsForResolvedRemote(resolved *remote.ResolvedRemote) (pushImageOps, error) {
 	insecureTLS := false
 	if resolved != nil {
 		insecureTLS = resolved.InsecureTLS
@@ -64,12 +68,7 @@ func newImageOpsFromFlags() (pushImageOps, error) {
 		return nil, err
 	}
 	if resolved != nil && resolved.Token != "" {
-		var clientOpts []remote.ClientOption
-		clientOpts = append(clientOpts, remote.WithToken(resolved.Token))
-		if resolved.InsecureTLS {
-			clientOpts = append(clientOpts, remote.WithInsecureTLS(true))
-		}
-		ops.remoteClient = remote.NewClient(resolved.URL, clientOpts...)
+		ops.remoteClient = remote.NewClient(resolved.URL, remoteClientOptions(resolved.Token, resolved.InsecureTLS)...)
 	}
 	return ops, nil
 }

--- a/internal/adapters/in/cli/push_remote_inference_test.go
+++ b/internal/adapters/in/cli/push_remote_inference_test.go
@@ -1,0 +1,457 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bnema/gordon/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInferPushRemote_UsesUniqueMatchingSavedRemote(t *testing.T) {
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		assert.Equal(t, "myapp", image)
+		return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+	staging := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		assert.Equal(t, "myapp", image)
+		return nil, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+	assert.Equal(t, prod.URL, resolved.URL)
+}
+
+func TestInferPushRemote_ReturnsAmbiguousErrorWhenMultipleRemotesMatch(t *testing.T) {
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+	staging := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		return []domain.Route{{Domain: "staging.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `multiple saved remotes match image "myapp"`)
+	assert.Contains(t, err.Error(), "prod")
+	assert.Contains(t, err.Error(), "staging")
+}
+
+func TestInferPushRemote_SkipsGuessWhenExplicitRemoteSelected(t *testing.T) {
+	originalRemoteFlag := remoteFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+	})
+
+	called := false
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		called = true
+		return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+`)
+	t.Setenv("GORDON_REMOTE", "")
+	remoteFlag = "prod"
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.NoError(t, err)
+	assert.Nil(t, resolved)
+	assert.False(t, called)
+}
+
+func TestInferPushRemote_SkipsGuessWhenActiveRemoteConfigured(t *testing.T) {
+	called := false
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		called = true
+		return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+active = "prod"
+
+[remotes.prod]
+url = "`+prod.URL+`"
+`)
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.NoError(t, err)
+	assert.Nil(t, resolved)
+	assert.False(t, called)
+}
+
+func TestInferPushRemote_IgnoresPreviewOnlyMatches(t *testing.T) {
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		return []domain.Route{{Domain: "preview--pr-42.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+`)
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.NoError(t, err)
+	assert.Nil(t, resolved)
+}
+
+func TestInferPushRemote_FailsSafeWhenSomeRemotesCannotBeProbed(t *testing.T) {
+	prod := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		return []domain.Route{{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}}, http.StatusOK
+	})
+	broken := newFindRoutesByImageTestServer(t, func(image string) ([]domain.Route, int) {
+		return nil, http.StatusInternalServerError
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.broken]
+url = "`+broken.URL+`"
+`)
+
+	resolved, err := inferPushRemote(context.Background(), "myapp", "", "Dockerfile")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `could not safely infer remote for image "myapp"`)
+	assert.Contains(t, err.Error(), "broken")
+}
+
+func TestInferRemoteForRouteDomain_UsesUniqueMatchingSavedRemote(t *testing.T) {
+	prod := newGetRouteTestServer(t, func(domainName string) (*domain.Route, int) {
+		return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, http.StatusOK
+	})
+	staging := newGetRouteTestServer(t, func(domainName string) (*domain.Route, int) {
+		return nil, http.StatusNotFound
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForRouteDomain(context.Background(), "app.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+}
+
+func TestInferRemoteForRouteDomain_ReturnsAmbiguousErrorWhenMultipleRemotesMatch(t *testing.T) {
+	prod := newGetRouteTestServer(t, func(domainName string) (*domain.Route, int) {
+		return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, http.StatusOK
+	})
+	staging := newGetRouteTestServer(t, func(domainName string) (*domain.Route, int) {
+		return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForRouteDomain(context.Background(), "app.example.com")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `multiple saved remotes match route "app.example.com"`)
+}
+
+func TestInferRemoteForAttachmentImage_UsesUniqueMatchingSavedRemote(t *testing.T) {
+	prod := newAttachmentTargetsByImageTestServer(t, func(image string) ([]string, int) {
+		return []string{"app.example.com"}, http.StatusOK
+	})
+	staging := newAttachmentTargetsByImageTestServer(t, func(image string) ([]string, int) {
+		return nil, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForAttachmentImage(context.Background(), "postgres:18")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+}
+
+func TestInferRemoteForAttachmentTarget_FallsBackToRouteLookup(t *testing.T) {
+	prod := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return &domain.Route{Domain: domainName, Image: "registry.example.com/myapp:latest"}, http.StatusOK
+		},
+		getAttachmentsConfig: func(target string) ([]string, int) {
+			return nil, http.StatusNotFound
+		},
+	})
+	staging := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getAttachmentsConfig: func(target string) ([]string, int) {
+			return nil, http.StatusNotFound
+		},
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForAttachmentTarget(context.Background(), "app.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+}
+
+func TestInferRemoteForRepository_ReturnsAmbiguousErrorWhenMultipleRemotesMatch(t *testing.T) {
+	prod := newTagsTestServer(t, func(repository string) ([]string, int) {
+		return []string{"latest", "v1.0.0"}, http.StatusOK
+	})
+	staging := newTagsTestServer(t, func(repository string) ([]string, int) {
+		return []string{"latest"}, http.StatusOK
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForRepository(context.Background(), "myapp")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `multiple saved remotes match repository "myapp"`)
+}
+
+func configurePushRemoteInferenceTestEnv(t *testing.T, remotesTOML string) {
+	t.Helper()
+
+	originalRemoteFlag := remoteFlag
+	originalTokenFlag := tokenFlag
+	originalInsecureTLSFlag := insecureTLSFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+		tokenFlag = originalTokenFlag
+		insecureTLSFlag = originalInsecureTLSFlag
+	})
+
+	remoteFlag = ""
+	tokenFlag = ""
+	insecureTLSFlag = false
+	t.Setenv("GORDON_REMOTE", "")
+	t.Setenv("GORDON_TOKEN", "")
+	t.Setenv("GORDON_INSECURE", "")
+	t.Setenv("HOME", t.TempDir())
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	configPath := filepath.Join(configHome, "gordon", "remotes.toml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, os.WriteFile(configPath, []byte(strings.TrimSpace(remotesTOML)), 0o600))
+}
+
+func newFindRoutesByImageTestServer(t *testing.T, handler func(image string) ([]domain.Route, int)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/admin/routes/by-image/") {
+			http.NotFound(w, r)
+			return
+		}
+
+		image, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/routes/by-image/"))
+		require.NoError(t, err)
+
+		routes, status := handler(image)
+		if status >= http.StatusBadRequest {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"image":  image,
+			"routes": routes,
+		}))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newGetRouteTestServer(t *testing.T, handler func(domainName string) (*domain.Route, int)) *httptest.Server {
+	t.Helper()
+	return newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{getRoute: handler})
+}
+
+type multiAdminProbeHandlers struct {
+	getRoute             func(domainName string) (*domain.Route, int)
+	getAttachmentsConfig func(target string) ([]string, int)
+	listTags             func(repository string) ([]string, int)
+	findAttachmentTarget func(image string) ([]string, int)
+}
+
+func newMultiAdminProbeTestServer(t *testing.T, handlers multiAdminProbeHandlers) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/admin/routes/"):
+			handleGetRouteProbe(t, w, r, handlers.getRoute)
+		case strings.HasPrefix(r.URL.Path, "/admin/attachments/by-image/"):
+			handleAttachmentTargetsByImageProbe(t, w, r, handlers.findAttachmentTarget)
+		case strings.HasPrefix(r.URL.Path, "/admin/attachments/"):
+			handleGetAttachmentsConfigProbe(t, w, r, handlers.getAttachmentsConfig)
+		case strings.HasPrefix(r.URL.Path, "/admin/tags/"):
+			handleListTagsProbe(t, w, r, handlers.listTags)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newAttachmentTargetsByImageTestServer(t *testing.T, handler func(image string) ([]string, int)) *httptest.Server {
+	t.Helper()
+	return newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{findAttachmentTarget: handler})
+}
+
+func newTagsTestServer(t *testing.T, handler func(repository string) ([]string, int)) *httptest.Server {
+	t.Helper()
+	return newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{listTags: handler})
+}
+
+func handleGetRouteProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(domainName string) (*domain.Route, int)) {
+	t.Helper()
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	domainName, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/routes/"))
+	require.NoError(t, err)
+	route, status := handler(domainName)
+	if status >= http.StatusBadRequest {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusNotFound {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": domain.ErrRouteNotFound.Error()}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(route))
+}
+
+func handleAttachmentTargetsByImageProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(image string) ([]string, int)) {
+	t.Helper()
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	image, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/attachments/by-image/"))
+	require.NoError(t, err)
+	targets, status := handler(image)
+	if status >= http.StatusBadRequest {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"image": image, "targets": targets}))
+}
+
+func handleGetAttachmentsConfigProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(target string) ([]string, int)) {
+	t.Helper()
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	target, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/attachments/"))
+	require.NoError(t, err)
+	images, status := handler(target)
+	if status >= http.StatusBadRequest {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusNotFound {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "no attachments found for target"}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"target": target, "images": images}))
+}
+
+func handleListTagsProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(repository string) ([]string, int)) {
+	t.Helper()
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	repository, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/tags/"))
+	require.NoError(t, err)
+	tags, status := handler(repository)
+	if status >= http.StatusBadRequest {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status == http.StatusNotFound {
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "repository not found"}))
+			return
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"repository": repository, "tags": tags}))
+}

--- a/internal/adapters/in/cli/push_remote_inference_test.go
+++ b/internal/adapters/in/cli/push_remote_inference_test.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bnema/gordon/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestInferPushRemote_UsesUniqueMatchingSavedRemote(t *testing.T) {
@@ -305,21 +306,27 @@ func newFindRoutesByImageTestServer(t *testing.T, handler func(image string) ([]
 		}
 
 		image, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/routes/by-image/"))
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		routes, status := handler(image)
 		if status >= http.StatusBadRequest {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)
-			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+			if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+				return
+			}
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"image":  image,
 			"routes": routes,
-		}))
+		})) {
+			return
+		}
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -375,20 +382,28 @@ func handleGetRouteProbe(t *testing.T, w http.ResponseWriter, r *http.Request, h
 		return
 	}
 	domainName, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/routes/"))
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	route, status := handler(domainName)
 	if status >= http.StatusBadRequest {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		if status == http.StatusNotFound {
-			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": domain.ErrRouteNotFound.Error()}))
+			if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": domain.ErrRouteNotFound.Error()})) {
+				return
+			}
 			return
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+			return
+		}
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	require.NoError(t, json.NewEncoder(w).Encode(route))
+	if !assert.NoError(t, json.NewEncoder(w).Encode(route)) {
+		return
+	}
 }
 
 func handleAttachmentTargetsByImageProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(image string) ([]string, int)) {
@@ -398,16 +413,22 @@ func handleAttachmentTargetsByImageProbe(t *testing.T, w http.ResponseWriter, r 
 		return
 	}
 	image, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/attachments/by-image/"))
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	targets, status := handler(image)
 	if status >= http.StatusBadRequest {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+			return
+		}
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"image": image, "targets": targets}))
+	if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"image": image, "targets": targets})) {
+		return
+	}
 }
 
 func handleGetAttachmentsConfigProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(target string) ([]string, int)) {
@@ -417,20 +438,28 @@ func handleGetAttachmentsConfigProbe(t *testing.T, w http.ResponseWriter, r *htt
 		return
 	}
 	target, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/attachments/"))
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	images, status := handler(target)
 	if status >= http.StatusBadRequest {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		if status == http.StatusNotFound {
-			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "no attachments found for target"}))
+			if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "no attachments found for target"})) {
+				return
+			}
 			return
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+			return
+		}
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"target": target, "images": images}))
+	if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"target": target, "images": images})) {
+		return
+	}
 }
 
 func handleListTagsProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(repository string) ([]string, int)) {
@@ -440,18 +469,26 @@ func handleListTagsProbe(t *testing.T, w http.ResponseWriter, r *http.Request, h
 		return
 	}
 	repository, err := url.PathUnescape(strings.TrimPrefix(r.URL.Path, "/admin/tags/"))
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	tags, status := handler(repository)
 	if status >= http.StatusBadRequest {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		if status == http.StatusNotFound {
-			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "repository not found"}))
+			if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "repository not found"})) {
+				return
+			}
 			return
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"}))
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+			return
+		}
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"repository": repository, "tags": tags}))
+	if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"repository": repository, "tags": tags})) {
+		return
+	}
 }

--- a/internal/adapters/in/cli/remote_inference.go
+++ b/internal/adapters/in/cli/remote_inference.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/pkg/validation"
+)
+
+type remoteInferenceProbe func(context.Context, *remote.Client) (bool, error)
+
+func inferPushRemote(ctx context.Context, imageArg, domainFlag, dockerfile string) (*remote.ResolvedRemote, error) {
+	if domainFlag != "" {
+		return inferRemoteForRouteDomain(ctx, domainFlag)
+	}
+
+	if imageArg == "" {
+		detected, err := detectImageName(dockerfile)
+		if err != nil {
+			return nil, err
+		}
+		imageArg = detected
+	}
+
+	if looksLikeLegacyDomain(imageArg) {
+		lookupImage := imageArg
+		domainLookupArg := imageArg
+		if parsedImage, ref := validation.ParseImageReference(imageArg); parsedImage != imageArg {
+			domainLookupArg = parsedImage
+			if !strings.HasPrefix(ref, "sha256:") {
+				lookupImage = parsedImage
+			}
+		}
+
+		resolved, err := inferRemoteForImage(ctx, lookupImage)
+		if err != nil || resolved != nil {
+			return resolved, err
+		}
+
+		return inferRemoteForRouteDomain(ctx, domainLookupArg)
+	}
+
+	classified := classifyPushArgument(imageArg)
+	return inferRemoteForImage(ctx, classified.lookupImage)
+}
+
+func inferRemoteForImage(ctx context.Context, imageName string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "image", imageName, func(ctx context.Context, client *remote.Client) (bool, error) {
+		routes, err := client.FindRoutesByImage(ctx, imageName)
+		if err != nil {
+			return false, err
+		}
+		return len(filterPreviewRoutes(routes)) > 0, nil
+	})
+}
+
+func inferRemoteForRouteDomain(ctx context.Context, routeDomain string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "route", routeDomain, func(ctx context.Context, client *remote.Client) (bool, error) {
+		_, err := client.GetRoute(ctx, routeDomain)
+		if err != nil {
+			if isRemoteNotFoundError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func inferRemoteForAttachmentImage(ctx context.Context, imageName string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "attachment image", imageName, func(ctx context.Context, client *remote.Client) (bool, error) {
+		targets, err := client.FindAttachmentTargetsByImage(ctx, imageName)
+		if err != nil {
+			return false, err
+		}
+		return len(targets) > 0, nil
+	})
+}
+
+func inferRemoteForAttachmentTarget(ctx context.Context, target string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "attachment target", target, func(ctx context.Context, client *remote.Client) (bool, error) {
+		images, err := client.GetAttachmentsConfig(ctx, target)
+		if err == nil {
+			return len(images) > 0, nil
+		}
+		if !isRemoteNotFoundError(err) {
+			return false, err
+		}
+
+		_, err = client.GetRoute(ctx, target)
+		if err != nil {
+			if isRemoteNotFoundError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func inferRemoteForRepository(ctx context.Context, repository string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "repository", repository, func(ctx context.Context, client *remote.Client) (bool, error) {
+		tags, err := client.ListTags(ctx, repository)
+		if err != nil {
+			if isRemoteNotFoundError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return len(tags) > 0, nil
+	})
+}
+
+func inferSavedRemote(ctx context.Context, targetKind, target string, probe remoteInferenceProbe) (*remote.ResolvedRemote, error) {
+	remotes, ok := loadInferenceCandidateRemotes()
+	if !ok {
+		return nil, nil
+	}
+
+	names := sortedRemoteNames(remotes)
+	matches := make([]*remote.ResolvedRemote, 0, len(names))
+	probeFailures := make([]string, 0)
+
+	for _, name := range names {
+		entry := remotes[name]
+		matched, err := probe(ctx, newRoutesTargetClient(name, entry))
+		if err != nil {
+			probeFailures = append(probeFailures, fmt.Sprintf("%s (%v)", name, err))
+			continue
+		}
+		if matched {
+			matches = append(matches, resolvedRemoteFromEntry(name, entry))
+		}
+	}
+
+	if len(probeFailures) > 0 {
+		return nil, fmt.Errorf("could not safely infer remote for %s %q because probing failed for: %s; use --remote", targetKind, target, strings.Join(probeFailures, ", "))
+	}
+
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, match := range matches {
+			names = append(names, match.DisplayName())
+		}
+		return nil, fmt.Errorf("multiple saved remotes match %s %q: %s; use --remote", targetKind, target, strings.Join(names, ", "))
+	}
+
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+
+	return nil, nil
+}
+
+func loadInferenceCandidateRemotes() (map[string]remote.RemoteEntry, bool) {
+	if _, ok := resolveRoutesExplicitTarget(); ok {
+		return nil, false
+	}
+
+	remotes, err := remote.LoadRemotes("")
+	if err != nil || remotes == nil {
+		return nil, false
+	}
+	if remotes.Active != "" {
+		return nil, false
+	}
+	if len(remotes.Remotes) == 0 {
+		return nil, false
+	}
+
+	return remotes.Remotes, true
+}
+
+func resolvedRemoteFromEntry(name string, entry remote.RemoteEntry) *remote.ResolvedRemote {
+	return &remote.ResolvedRemote{
+		Name:        name,
+		URL:         entry.URL,
+		Token:       resolveRoutesTokenForTarget(name, entry),
+		InsecureTLS: resolveRoutesInsecureForTarget(name, entry),
+	}
+}
+
+func isRemoteNotFoundError(err error) bool {
+	var httpErr *remote.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusNotFound
+	}
+	return errors.Is(err, domain.ErrRouteNotFound)
+}
+
+func filterPreviewRoutes(routes []domain.Route) []domain.Route {
+	filtered := routes[:0]
+	for _, route := range routes {
+		if !strings.Contains(route.Domain, domain.DefaultPreviewSeparator) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}

--- a/internal/adapters/in/cli/remote_inference.go
+++ b/internal/adapters/in/cli/remote_inference.go
@@ -186,8 +186,7 @@ func resolvedRemoteFromEntry(name string, entry remote.RemoteEntry) *remote.Reso
 }
 
 func isRemoteNotFoundError(err error) bool {
-	var httpErr *remote.HTTPError
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*remote.HTTPError](err); ok {
 		return httpErr.StatusCode == http.StatusNotFound
 	}
 	return errors.Is(err, domain.ErrRouteNotFound)

--- a/internal/adapters/in/cli/remote_inference.go
+++ b/internal/adapters/in/cli/remote_inference.go
@@ -194,7 +194,7 @@ func isRemoteNotFoundError(err error) bool {
 }
 
 func filterPreviewRoutes(routes []domain.Route) []domain.Route {
-	filtered := routes[:0]
+	filtered := make([]domain.Route, 0, len(routes))
 	for _, route := range routes {
 		if !strings.Contains(route.Domain, domain.DefaultPreviewSeparator) {
 			filtered = append(filtered, route)

--- a/internal/adapters/in/cli/restart.go
+++ b/internal/adapters/in/cli/restart.go
@@ -28,7 +28,7 @@ Examples:
 			ctx := cmd.Context()
 			restartDomain := args[0]
 
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRouteDomain(ctx, restartDomain)
 			if err != nil {
 				return err
 			}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -298,7 +298,7 @@ Remote mode:
 			if len(args) > 0 {
 				logDomain = args[0]
 			}
-			return runLogs(logsConfigPath, logDomain, follow, lines)
+			return runLogs(cmd.Context(), logsConfigPath, logDomain, follow, lines)
 		},
 	}
 
@@ -310,7 +310,16 @@ Remote mode:
 }
 
 // runLogs handles the logs command logic.
-func runLogs(logsConfigPath, logDomain string, follow bool, lines int) error {
+func runLogs(ctx context.Context, logsConfigPath, logDomain string, follow bool, lines int) error {
+	if logDomain != "" {
+		handle, err := resolveControlPlaneForRouteDomain(ctx, logDomain)
+		if err != nil {
+			return err
+		}
+		defer handle.close()
+		return runContainerLogs(ctx, handle.plane, logDomain, follow, lines)
+	}
+
 	client, isRemote := GetRemoteClient()
 	if isRemote {
 		return runLogsRemote(client, logDomain, follow, lines)
@@ -382,15 +391,40 @@ func runLogsLocal(logsConfigPath, logDomain string, follow bool, lines int) erro
 		return app.ShowLogs(logsConfigPath, follow, lines)
 	}
 
-	// Container logs - use local services
 	return showContainerLogsLocal(logsConfigPath, logDomain, follow, lines)
 }
 
-// showContainerLogsLocal shows container logs using local Docker access.
+func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, follow bool, lines int) error {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if follow {
+		ch, err := cp.StreamContainerLogs(ctx, logDomain, lines)
+		if err != nil {
+			return fmt.Errorf("failed to stream container logs: %w", err)
+		}
+		for line := range ch {
+			if err := cliWriteLine(os.Stdout, line); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	logLines, err := cp.GetContainerLogs(ctx, logDomain, lines)
+	if err != nil {
+		return fmt.Errorf("failed to get container logs: %w", err)
+	}
+	for _, line := range logLines {
+		if err := cliWriteLine(os.Stdout, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// showContainerLogsLocal is retained for UI adoption coverage and fallback messaging.
 func showContainerLogsLocal(_ string, logDomain string, follow bool, lines int) error {
-	// For local container logs, we need Docker access which requires
-	// the runtime to be initialized. For now, suggest using remote mode
-	// or direct docker logs command.
 	if err := cliWriteLine(os.Stdout, cliRenderTitle(fmt.Sprintf("Container logs for %s", logDomain))); err != nil {
 		return err
 	}

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -298,7 +299,7 @@ Remote mode:
 			if len(args) > 0 {
 				logDomain = args[0]
 			}
-			return runLogs(cmd.Context(), logsConfigPath, logDomain, follow, lines)
+			return runLogs(cmd.Context(), logsConfigPath, logDomain, follow, lines, cmd.OutOrStdout())
 		},
 	}
 
@@ -310,30 +311,30 @@ Remote mode:
 }
 
 // runLogs handles the logs command logic.
-func runLogs(ctx context.Context, logsConfigPath, logDomain string, follow bool, lines int) error {
+func runLogs(ctx context.Context, logsConfigPath, logDomain string, follow bool, lines int, out io.Writer) error {
 	if logDomain != "" {
 		handle, err := resolveControlPlaneForRouteDomain(ctx, logDomain)
 		if err != nil {
 			return err
 		}
 		defer handle.close()
-		return runContainerLogs(ctx, handle.plane, logDomain, follow, lines)
+		return runContainerLogs(ctx, handle.plane, logDomain, follow, lines, out)
 	}
 
 	client, isRemote := GetRemoteClient()
 	if isRemote {
-		return runLogsRemote(client, logDomain, follow, lines)
+		return runLogsRemote(ctx, client, logDomain, follow, lines, out)
 	}
-	return runLogsLocal(logsConfigPath, logDomain, follow, lines)
+	return runLogsLocal(logsConfigPath, logDomain, follow, lines, out)
 }
 
 // runLogsRemote fetches logs from a remote Gordon instance.
-func runLogsRemote(client *remote.Client, logDomain string, follow bool, lines int) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+func runLogsRemote(ctx context.Context, client *remote.Client, logDomain string, follow bool, lines int, out io.Writer) error {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	if follow {
-		return streamLogsRemote(ctx, client, logDomain, lines)
+		return streamLogsRemote(ctx, client, logDomain, lines, out)
 	}
 
 	if logDomain == "" {
@@ -343,7 +344,7 @@ func runLogsRemote(client *remote.Client, logDomain string, follow bool, lines i
 			return fmt.Errorf("failed to get process logs: %w", err)
 		}
 		for _, line := range logLines {
-			if err := cliWriteLine(os.Stdout, line); err != nil {
+			if err := cliWriteLine(out, line); err != nil {
 				return err
 			}
 		}
@@ -354,7 +355,7 @@ func runLogsRemote(client *remote.Client, logDomain string, follow bool, lines i
 			return fmt.Errorf("failed to get container logs: %w", err)
 		}
 		for _, line := range logLines {
-			if err := cliWriteLine(os.Stdout, line); err != nil {
+			if err := cliWriteLine(out, line); err != nil {
 				return err
 			}
 		}
@@ -363,7 +364,7 @@ func runLogsRemote(client *remote.Client, logDomain string, follow bool, lines i
 }
 
 // streamLogsRemote streams logs from a remote Gordon instance.
-func streamLogsRemote(ctx context.Context, client *remote.Client, logDomain string, lines int) error {
+func streamLogsRemote(ctx context.Context, client *remote.Client, logDomain string, lines int, out io.Writer) error {
 	var ch <-chan string
 	var err error
 
@@ -377,7 +378,7 @@ func streamLogsRemote(ctx context.Context, client *remote.Client, logDomain stri
 	}
 
 	for line := range ch {
-		if err := cliWriteLine(os.Stdout, line); err != nil {
+		if err := cliWriteLine(out, line); err != nil {
 			return err
 		}
 	}
@@ -385,16 +386,16 @@ func streamLogsRemote(ctx context.Context, client *remote.Client, logDomain stri
 }
 
 // runLogsLocal shows logs from a local Gordon instance.
-func runLogsLocal(logsConfigPath, logDomain string, follow bool, lines int) error {
+func runLogsLocal(logsConfigPath, logDomain string, follow bool, lines int, out io.Writer) error {
 	if logDomain == "" {
 		// Process logs - use existing app.ShowLogs
 		return app.ShowLogs(logsConfigPath, follow, lines)
 	}
 
-	return showContainerLogsLocal(logsConfigPath, logDomain, follow, lines)
+	return showContainerLogsLocal(out, logsConfigPath, logDomain, follow, lines)
 }
 
-func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, follow bool, lines int) error {
+func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, follow bool, lines int, out io.Writer) error {
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
@@ -404,7 +405,7 @@ func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, fo
 			return fmt.Errorf("failed to stream container logs: %w", err)
 		}
 		for line := range ch {
-			if err := cliWriteLine(os.Stdout, line); err != nil {
+			if err := cliWriteLine(out, line); err != nil {
 				return err
 			}
 		}
@@ -416,7 +417,7 @@ func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, fo
 		return fmt.Errorf("failed to get container logs: %w", err)
 	}
 	for _, line := range logLines {
-		if err := cliWriteLine(os.Stdout, line); err != nil {
+		if err := cliWriteLine(out, line); err != nil {
 			return err
 		}
 	}
@@ -424,25 +425,25 @@ func runContainerLogs(ctx context.Context, cp ControlPlane, logDomain string, fo
 }
 
 // showContainerLogsLocal is retained for UI adoption coverage and fallback messaging.
-func showContainerLogsLocal(_ string, logDomain string, follow bool, lines int) error {
-	if err := cliWriteLine(os.Stdout, cliRenderTitle(fmt.Sprintf("Container logs for %s", logDomain))); err != nil {
+func showContainerLogsLocal(out io.Writer, _ string, logDomain string, follow bool, lines int) error {
+	if err := cliWriteLine(out, cliRenderTitle(fmt.Sprintf("Container logs for %s", logDomain))); err != nil {
 		return err
 	}
-	if err := cliWriteLine(os.Stdout, cliRenderInfo("To view container logs locally, use:")); err != nil {
+	if err := cliWriteLine(out, cliRenderInfo("To view container logs locally, use:")); err != nil {
 		return err
 	}
-	if err := cliWritef(os.Stdout, "  docker logs --tail %d %s\n", lines, logDomain); err != nil {
+	if err := cliWritef(out, "  docker logs --tail %d %s\n", lines, logDomain); err != nil {
 		return err
 	}
 	if follow {
-		if err := cliWritef(os.Stdout, "  docker logs -f --tail %d %s\n", lines, logDomain); err != nil {
+		if err := cliWritef(out, "  docker logs -f --tail %d %s\n", lines, logDomain); err != nil {
 			return err
 		}
 	}
-	if err := cliWriteLine(os.Stdout, ""); err != nil {
+	if err := cliWriteLine(out, ""); err != nil {
 		return err
 	}
-	if err := cliWriteLine(os.Stdout, cliRenderMuted("Or use remote mode to access logs via the admin API.")); err != nil {
+	if err := cliWriteLine(out, cliRenderMuted("Or use remote mode to access logs via the admin API.")); err != nil {
 		return err
 	}
 	return nil

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -988,7 +988,7 @@ Examples:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			handle, err := resolveControlPlane(configPath)
+			handle, err := resolveControlPlaneForRouteDomain(ctx, args[0])
 			if err != nil {
 				return err
 			}
@@ -1180,19 +1180,13 @@ Examples:
 				}
 			}
 
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				if err := client.RemoveRoute(ctx, routeDomain); err != nil {
-					return fmt.Errorf("failed to remove route: %w", err)
-				}
-			} else {
-				local, err := GetLocalServices(configPath)
-				if err != nil {
-					return fmt.Errorf("failed to initialize local services: %w", err)
-				}
-				if err := local.GetConfigService().RemoveRoute(ctx, routeDomain); err != nil {
-					return fmt.Errorf("failed to remove route: %w", err)
-				}
+			handle, err := resolveControlPlaneForRouteDomain(ctx, routeDomain)
+			if err != nil {
+				return err
+			}
+			defer handle.close()
+			if err := handle.plane.RemoveRoute(ctx, routeDomain); err != nil {
+				return fmt.Errorf("failed to remove route: %w", err)
 			}
 
 			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Route removed: %s", routeDomain)))

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -1162,7 +1162,7 @@ Examples:
   gordon routes remove app.mydomain.com --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			routeDomain := args[0]
 
 			// Confirm unless --force

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -61,10 +61,16 @@ Examples:
 
 // runSecretsListCmd executes the secrets list command.
 func runSecretsListCmd(cmd *cobra.Command, args []string, jsonOut bool) error {
-	ctx := context.Background()
+	ctx := cmd.Context()
 	secretDomain := args[0]
 
-	keys, attachments, isRemote, err := fetchSecretsWithAttachments(ctx, secretDomain)
+	handle, err := resolveControlPlaneForRouteDomain(ctx, secretDomain)
+	if err != nil {
+		return err
+	}
+	defer handle.close()
+
+	keys, attachments, err := fetchSecretsWithAttachments(ctx, handle.plane, secretDomain)
 	if err != nil {
 		return err
 	}
@@ -98,7 +104,7 @@ func runSecretsListCmd(cmd *cobra.Command, args []string, jsonOut bool) error {
 	}
 
 	title := fmt.Sprintf("Secrets for %s", secretDomain)
-	if !isRemote {
+	if !handle.isRemote {
 		title = fmt.Sprintf("Secrets for %s (local)", secretDomain)
 	}
 	fmt.Println(styles.Theme.Title.Render(title))
@@ -118,37 +124,13 @@ func runSecretsListCmd(cmd *cobra.Command, args []string, jsonOut bool) error {
 	return nil
 }
 
-// fetchSecretsWithAttachments retrieves secrets from remote or local source.
-func fetchSecretsWithAttachments(ctx context.Context, secretDomain string) ([]string, []remote.AttachmentSecrets, bool, error) {
-	client, isRemote := GetRemoteClient()
-	if isRemote {
-		result, err := client.ListSecretsWithAttachments(ctx, secretDomain)
-		if err != nil {
-			return nil, nil, isRemote, fmt.Errorf("failed to list secrets: %w", err)
-		}
-		return result.Keys, result.Attachments, isRemote, nil
-	}
-
-	local, err := GetLocalServices(configPath)
+// fetchSecretsWithAttachments retrieves secrets from the selected control plane.
+func fetchSecretsWithAttachments(ctx context.Context, cp ControlPlane, secretDomain string) ([]string, []remote.AttachmentSecrets, error) {
+	result, err := cp.ListSecretsWithAttachments(ctx, secretDomain)
 	if err != nil {
-		return nil, nil, isRemote, fmt.Errorf("failed to initialize local services: %w", err)
+		return nil, nil, fmt.Errorf("failed to list secrets: %w", err)
 	}
-
-	keys, domainAttachments, err := local.GetSecretService().ListKeysWithAttachments(ctx, secretDomain)
-	if err != nil {
-		return nil, nil, isRemote, fmt.Errorf("failed to list secrets: %w", err)
-	}
-
-	// Convert to remote.AttachmentSecrets format
-	var attachments []remote.AttachmentSecrets
-	for _, att := range domainAttachments {
-		attachments = append(attachments, remote.AttachmentSecrets{
-			Service: att.Service,
-			Keys:    att.Keys,
-		})
-	}
-
-	return keys, attachments, isRemote, nil
+	return result.Keys, result.Attachments, nil
 }
 
 // buildSecretsTableRows builds table rows with tree structure for attachments.
@@ -259,7 +241,7 @@ Examples:
   gordon secrets set app.mydomain.com --attachment redis REDIS_PASSWORD=secret`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			secretDomain := args[0]
 			pairs := args[1:]
 
@@ -273,30 +255,18 @@ Examples:
 				secrets[parts[0]] = parts[1]
 			}
 
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				if attachment != "" {
-					if err := client.SetAttachmentSecrets(ctx, secretDomain, attachment, secrets); err != nil {
-						return fmt.Errorf("failed to set secrets: %w", err)
-					}
-				} else {
-					if err := client.SetSecrets(ctx, secretDomain, secrets); err != nil {
-						return fmt.Errorf("failed to set secrets: %w", err)
-					}
+			handle, err := resolveControlPlaneForRouteDomain(ctx, secretDomain)
+			if err != nil {
+				return err
+			}
+			defer handle.close()
+			if attachment != "" {
+				if err := handle.plane.SetAttachmentSecrets(ctx, secretDomain, attachment, secrets); err != nil {
+					return fmt.Errorf("failed to set secrets: %w", err)
 				}
 			} else {
-				local, err := GetLocalServices(configPath)
-				if err != nil {
-					return fmt.Errorf("failed to initialize local services: %w", err)
-				}
-				if attachment != "" {
-					if err := local.GetSecretService().SetAttachment(ctx, secretDomain, attachment, secrets); err != nil {
-						return fmt.Errorf("failed to set secrets: %w", err)
-					}
-				} else {
-					if err := local.GetSecretService().Set(ctx, secretDomain, secrets); err != nil {
-						return fmt.Errorf("failed to set secrets: %w", err)
-					}
+				if err := handle.plane.SetSecrets(ctx, secretDomain, secrets); err != nil {
+					return fmt.Errorf("failed to set secrets: %w", err)
 				}
 			}
 
@@ -343,7 +313,7 @@ Examples:
   gordon secrets remove app.mydomain.com --attachment postgres POSTGRES_PASSWORD`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			secretDomain := args[0]
 			key := args[1]
 
@@ -366,30 +336,18 @@ Examples:
 				}
 			}
 
-			client, isRemote := GetRemoteClient()
-			if isRemote {
-				if attachment != "" {
-					if err := client.DeleteAttachmentSecret(ctx, secretDomain, attachment, key); err != nil {
-						return fmt.Errorf("failed to remove secret: %w", err)
-					}
-				} else {
-					if err := client.DeleteSecret(ctx, secretDomain, key); err != nil {
-						return fmt.Errorf("failed to remove secret: %w", err)
-					}
+			handle, err := resolveControlPlaneForRouteDomain(ctx, secretDomain)
+			if err != nil {
+				return err
+			}
+			defer handle.close()
+			if attachment != "" {
+				if err := handle.plane.DeleteAttachmentSecret(ctx, secretDomain, attachment, key); err != nil {
+					return fmt.Errorf("failed to remove secret: %w", err)
 				}
 			} else {
-				local, err := GetLocalServices(configPath)
-				if err != nil {
-					return fmt.Errorf("failed to initialize local services: %w", err)
-				}
-				if attachment != "" {
-					if err := local.GetSecretService().DeleteAttachment(ctx, secretDomain, attachment, key); err != nil {
-						return fmt.Errorf("failed to remove secret: %w", err)
-					}
-				} else {
-					if err := local.GetSecretService().Delete(ctx, secretDomain, key); err != nil {
-						return fmt.Errorf("failed to remove secret: %w", err)
-					}
+				if err := handle.plane.DeleteSecret(ctx, secretDomain, key); err != nil {
+					return fmt.Errorf("failed to remove secret: %w", err)
 				}
 			}
 


### PR DESCRIPTION
## Summary
- auto-infer a saved remote for target-based CLI commands when no explicit or active remote is selected
- fail safely on ambiguous matches or probe failures, and reuse shared inference helpers across push, deploy, restart, secrets, attachments, logs, backups, pin, images tags, and route detail/removal flows
- document the new remote targeting behavior and apply final cleanup from review feedback

## Verification
- rtk go test ./internal/adapters/in/cli -run 'TestInferPushRemote|TestInferRemoteForRouteDomain|TestInferRemoteForAttachment|TestInferRemoteForRepository' -count=1
- rtk go test ./...
- rtk golangci-lint run ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote auto-inference: CLI commands (push, deploy, attachments, secrets, logs, images, routes, restart, pin, backups) can auto-select a matching saved remote when a concrete target/domain is provided and no explicit remote is chosen; inference applies only when exactly one saved remote matches.

* **Documentation**
  * CLI docs updated across commands to describe inference behavior, examples, precedence, and when to pass --remote explicitly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/gordon/pull/198)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->