### PR TITLE
Fix route status for configured local and remote routes

### DIFF
--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -57,7 +57,14 @@ func NewLocalControlPlane(kernel *app.Kernel) ControlPlane {
 
 func (l *localControlPlane) ListRoutesWithDetails(ctx context.Context) ([]remote.RouteInfo, error) {
 	if l.containerSvc != nil {
-		return toRemoteRouteInfos(l.containerSvc.ListRoutesWithDetails(ctx)), nil
+		if err := l.containerSvc.SyncContainers(ctx); err != nil {
+			return nil, err
+		}
+		detailed := l.containerSvc.ListRoutesWithDetails(ctx)
+		if l.configSvc == nil {
+			return toRemoteRouteInfos(detailed), nil
+		}
+		return mergeConfiguredRemoteRouteInfos(l.configSvc.GetRoutes(ctx), detailed), nil
 	}
 
 	if l.configSvc == nil {
@@ -604,6 +611,26 @@ func (l *localControlPlane) PruneVolumes(ctx context.Context, req dto.VolumePrun
 		SpaceReclaimed: report.SpaceReclaimed,
 		Volumes:        vols,
 	}, nil
+}
+
+func mergeConfiguredRemoteRouteInfos(configured []domain.Route, detailed []domain.RouteInfo) []remote.RouteInfo {
+	detailedByDomain := make(map[string]domain.RouteInfo, len(detailed))
+	for _, info := range detailed {
+		detailedByDomain[info.Domain] = info
+	}
+
+	merged := make([]domain.RouteInfo, 0, len(configured))
+	for _, route := range configured {
+		info, ok := detailedByDomain[route.Domain]
+		if !ok {
+			info = domain.RouteInfo{Domain: route.Domain, Image: route.Image}
+		} else if info.Image == "" {
+			info.Image = route.Image
+		}
+		merged = append(merged, info)
+	}
+
+	return toRemoteRouteInfos(merged)
 }
 
 func toRemoteRouteInfos(routes []domain.RouteInfo) []remote.RouteInfo {

--- a/internal/adapters/in/cli/controlplane_local_test.go
+++ b/internal/adapters/in/cli/controlplane_local_test.go
@@ -123,6 +123,52 @@ func TestLocalControlPlane_RestartWithAttachments(t *testing.T) {
 	require.Equal(t, "app.local", result.Domain)
 }
 
+func TestLocalControlPlane_ListRoutesWithDetailsSyncsBeforeListing(t *testing.T) {
+	t.Parallel()
+
+	containerSvc := inmocks.NewMockContainerService(t)
+	syncCall := containerSvc.EXPECT().SyncContainers(mock.Anything).Return(nil).Once()
+	listCall := containerSvc.EXPECT().ListRoutesWithDetails(mock.Anything).Return([]domain.RouteInfo{{
+		Domain:          "app.local",
+		Image:           "repo/app:latest",
+		ContainerID:     "container-1",
+		ContainerStatus: "running",
+	}}).Once()
+	mock.InOrder(syncCall, listCall)
+
+	cp := &localControlPlane{containerSvc: containerSvc}
+	routes, err := cp.ListRoutesWithDetails(context.Background())
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	require.Equal(t, "app.local", routes[0].Domain)
+	require.Equal(t, "repo/app:latest", routes[0].Image)
+	require.Equal(t, "container-1", routes[0].ContainerID)
+	require.Equal(t, "running", routes[0].ContainerStatus)
+}
+
+func TestLocalControlPlane_ListRoutesWithDetails_IncludesConfiguredRouteWithoutRuntimeDetail(t *testing.T) {
+	t.Parallel()
+
+	configSvc := inmocks.NewMockConfigService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+
+	configSvc.EXPECT().GetRoutes(mock.Anything).Return([]domain.Route{{
+		Domain: "app.local",
+		Image:  "repo/app:latest",
+	}}).Once()
+	containerSvc.EXPECT().SyncContainers(mock.Anything).Return(nil).Once()
+	containerSvc.EXPECT().ListRoutesWithDetails(mock.Anything).Return(nil).Once()
+
+	cp := &localControlPlane{configSvc: configSvc, containerSvc: containerSvc}
+	routes, err := cp.ListRoutesWithDetails(context.Background())
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	require.Equal(t, "app.local", routes[0].Domain)
+	require.Equal(t, "repo/app:latest", routes[0].Image)
+	require.Empty(t, routes[0].ContainerID)
+	require.Empty(t, routes[0].ContainerStatus)
+}
+
 func TestLocalControlPlane_GetTLSStatusWithoutService(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -835,45 +835,43 @@ func loadRoutesStatusRemoteSection(ctx context.Context, name string, entry remot
 func routeStatusItemsFromInfos(routes []remote.RouteInfo, health map[string]*remote.RouteHealth) []routeStatusItem {
 	items := make([]routeStatusItem, 0, len(routes))
 	for _, route := range routes {
-		item := routeStatusItem{
-			Domain:          route.Domain,
-			Image:           route.Image,
-			ContainerID:     route.ContainerID,
-			ContainerStatus: route.ContainerStatus,
-			Network:         route.Network,
-		}
-		if item.ContainerStatus == "" {
-			if routeHealth := health[route.Domain]; routeHealth != nil {
-				item.ContainerStatus = routeHealth.ContainerStatus
-				item.HTTPStatus = routeHealth.HTTPStatus
-				item.HealthError = routeHealth.Error
-			}
-		}
-		if item.ContainerStatus == "" {
-			item.ContainerStatus = "unknown"
-		}
-		if item.HTTPStatus == 0 {
-			if routeHealth := health[route.Domain]; routeHealth != nil {
-				item.HTTPStatus = routeHealth.HTTPStatus
-				item.HealthError = routeHealth.Error
-			}
-		}
-		if item.HealthError == "" {
-			if routeHealth := health[route.Domain]; routeHealth != nil {
-				item.HealthError = routeHealth.Error
-			}
-		}
-		item.Attachments = make([]routeStatusAttachment, 0, len(route.Attachments))
-		for _, attachment := range route.Attachments {
-			status := attachment.Status
-			if status == "" {
-				status = "unknown"
-			}
-			item.Attachments = append(item.Attachments, routeStatusAttachment{Name: attachment.Name, Image: attachment.Image, Status: status})
-		}
-		items = append(items, item)
+		items = append(items, routeStatusItemFromInfo(route, health[route.Domain]))
 	}
 	return items
+}
+
+func routeStatusItemFromInfo(route remote.RouteInfo, routeHealth *remote.RouteHealth) routeStatusItem {
+	item := routeStatusItem{
+		Domain:          route.Domain,
+		Image:           route.Image,
+		ContainerID:     route.ContainerID,
+		ContainerStatus: route.ContainerStatus,
+		Network:         route.Network,
+	}
+	if item.ContainerStatus == "" && routeHealth != nil {
+		item.ContainerStatus = routeHealth.ContainerStatus
+		item.HTTPStatus = routeHealth.HTTPStatus
+		item.HealthError = routeHealth.Error
+	}
+	if item.ContainerStatus == "" {
+		item.ContainerStatus = "unknown"
+	}
+	if item.HTTPStatus == 0 && routeHealth != nil {
+		item.HTTPStatus = routeHealth.HTTPStatus
+		item.HealthError = routeHealth.Error
+	}
+	if item.HealthError == "" && routeHealth != nil {
+		item.HealthError = routeHealth.Error
+	}
+	item.Attachments = make([]routeStatusAttachment, 0, len(route.Attachments))
+	for _, attachment := range route.Attachments {
+		status := attachment.Status
+		if status == "" {
+			status = "unknown"
+		}
+		item.Attachments = append(item.Attachments, routeStatusAttachment{Name: attachment.Name, Image: attachment.Image, Status: status})
+	}
+	return item
 }
 
 func routeListItemsFromInfos(routes []remote.RouteInfo) []routeListItem {

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -97,6 +97,25 @@ func toRouteResponse(r domain.Route) dto.Route {
 	}
 }
 
+func mergeConfiguredRouteDetails(configured []domain.Route, detailed []domain.RouteInfo) []domain.RouteInfo {
+	detailedByDomain := make(map[string]domain.RouteInfo, len(detailed))
+	for _, info := range detailed {
+		detailedByDomain[info.Domain] = info
+	}
+
+	merged := make([]domain.RouteInfo, 0, len(configured))
+	for _, route := range configured {
+		info, ok := detailedByDomain[route.Domain]
+		if !ok {
+			info = domain.RouteInfo{Domain: route.Domain, Image: route.Image}
+		} else if info.Image == "" {
+			info.Image = route.Image
+		}
+		merged = append(merged, info)
+	}
+	return merged
+}
+
 func toBackupJobResponse(job domain.BackupJob) dto.BackupJob {
 	var startedAt *time.Time
 	if !job.StartedAt.IsZero() {
@@ -527,7 +546,13 @@ func (h *Handler) handleRoutesGet(w http.ResponseWriter, r *http.Request, routeD
 
 	if routeDomain == "" {
 		if r.URL.Query().Get("detailed") == "true" {
-			routes := h.containerSvc.ListRoutesWithDetails(ctx)
+			if err := h.containerSvc.SyncContainers(ctx); err != nil {
+				h.log.Error().Err(err).Msg("failed to sync containers before detailed route listing")
+				h.sendError(w, http.StatusInternalServerError, "failed to list routes")
+				return
+			}
+			configured := h.configSvc.GetRoutes(ctx)
+			routes := mergeConfiguredRouteDetails(configured, h.containerSvc.ListRoutesWithDetails(ctx))
 			response := make([]routeInfoResponse, 0, len(routes))
 			for _, route := range routes {
 				response = append(response, toRouteInfoResponse(route))

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -1357,6 +1357,45 @@ func TestHandler_RoutesGet_ReturnsRoutes(t *testing.T) {
 	assert.Len(t, response.Routes, 2)
 }
 
+func TestHandler_RoutesGet_DetailedSyncsAndIncludesConfiguredRouteWithoutContainer(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+	})
+
+	configSvc.EXPECT().GetRoutes(mock.Anything).Return([]domain.Route{{
+		Domain: "app.example.com",
+		Image:  "app:latest",
+	}}).Once()
+	syncCall := containerSvc.EXPECT().SyncContainers(mock.Anything).Return(nil).Once()
+	listCall := containerSvc.EXPECT().ListRoutesWithDetails(mock.Anything).Return(nil).Once()
+	mock.InOrder(syncCall, listCall)
+
+	req := httptest.NewRequest("GET", "/admin/routes?detailed=true", nil)
+	req = req.WithContext(ctxWithScopes("admin:routes:read"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var response dto.RoutesDetailResponse
+	err := json.NewDecoder(rec.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Len(t, response.Routes, 1)
+	assert.Equal(t, "app.example.com", response.Routes[0].Domain)
+	assert.Equal(t, "app:latest", response.Routes[0].Image)
+	assert.Empty(t, response.Routes[0].ContainerID)
+	assert.Empty(t, response.Routes[0].ContainerStatus)
+}
+
 func TestHandler_RoutesGet_SingleRoute(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	authSvc := inmocks.NewMockAuthService(t)


### PR DESCRIPTION
## Summary
- sync detailed route listings before reading runtime state for local control-plane and admin API paths
- keep configured routes visible in detailed status output even when no managed container is currently running
- add regression coverage for local CLI and admin detailed routes

## Test Plan
- go test ./...
- golangci-lint run ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routes listing now syncs container state before displaying detailed information.
  * Configured routes are included in route details even when container information is unavailable.
  * Route details merge configured domains with runtime container data.

* **Tests**
  * Added coverage for container synchronization and route detail merging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/gordon/pull/199)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->