### PR TITLE
fix: harden Gordon v2.31 release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ See the [Deploy Action README](.github/actions/deploy/README.md) for multi-platf
 - Network isolation per application
 - Single binary, ~15MB RAM
 
-> [!WARNING]
-> Gordon does not handle TLS termination. Place it behind Cloudflare Proxy or any upstream reverse proxy that manages HTTPS certificates.
+> [!NOTE]
+> Gordon can terminate TLS directly via its internal CA (default `server.tls_port = 8443`), static certificates, or public ACME certificates. Cloudflare and upstream reverse proxies are optional deployment choices, not requirements.
 
 ## Documentation
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -90,12 +90,8 @@ gordon auth show-token | pbcopy  # copy to clipboard
 Remove the stored token for a remote.
 
 ```bash
-gordon auth logout [--remote <name>] [--revoke]
+gordon auth logout [--remote <name>]
 ```
-
-| Option | Description |
-|--------|-------------|
-| `--revoke` | Also revoke the token server-side (not yet implemented) |
 
 Use the global `--remote, -r` flag to target a specific remote. See [CLI Overview](./index.md).
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -241,7 +241,7 @@ gordon routes list
 Gordon reads configuration from environment variables:
 
 ```bash
-GORDON_SERVER_PORT=8080 gordon serve
+GORDON_SERVER_PORT=8088 gordon serve
 GORDON_LOGGING_LEVEL=debug gordon serve
 ```
 

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -57,7 +57,7 @@ gordon serve --config /path/to/gordon.toml
 gordon serve -c ./my-config.toml
 
 # With environment override
-GORDON_SERVER_PORT=8080 gordon serve
+GORDON_SERVER_PORT=8088 gordon serve
 GORDON_LOGGING_LEVEL=debug gordon serve
 ```
 

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -21,9 +21,9 @@ gordon status --remote https://gordon.mydomain.com --token $TOKEN
 ```
 Gordon Status
 
-Domain: registry.example.com
+Gordon Domain: gordon.example.com
 Registry Port: 5000
-Server Port: 8080
+Server Port: 8088
 Routes: 3
 Auto-Route: true
 Network Isolation: false
@@ -38,9 +38,9 @@ Container Status:
 
 | Field | Description |
 |-------|-------------|
-| Domain | Registry domain from configuration |
+| Gordon Domain | Public Gordon domain from configuration |
 | Registry Port | Docker registry port |
-| Server Port | Gordon admin API port |
+| Server Port | Gordon HTTP proxy port |
 | Routes | Total configured routes |
 | Auto-Route | Whether auto-routing is enabled |
 | Network Isolation | Whether network isolation is enabled |
@@ -51,6 +51,7 @@ Container Status:
 | State | Description |
 |-------|-------------|
 | running | Container is running and healthy |
+| restarting | Container is in runtime restart backoff or restart cycle |
 | stopped | Container was stopped |
 | exited | Container exited (check logs for errors) |
 | paused | Container is paused |

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -13,7 +13,8 @@ Gordon uses a single TOML configuration file located at `~/.config/gordon/gordon
 
 ```toml
 [server]
-port = 8080
+port = 8088
+tls_port = 8443
 registry_port = 5000
 gordon_domain = "gordon.mydomain.com"
 
@@ -272,7 +273,7 @@ gordon reload
 Configuration values can be overridden with environment variables:
 
 ```bash
-GORDON_SERVER_PORT=8080 gordon serve
+GORDON_SERVER_PORT=8088 gordon serve
 GORDON_LOGGING_LEVEL=debug gordon serve
 ```
 

--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -22,6 +22,13 @@ dir = "~/.gordon/logs/containers"
 max_size = 100
 max_backups = 3
 max_age = 28
+
+[logging.access_log]
+enabled = false
+format = "json"
+output = "stdout"
+exclude_health_checks = true
+syslog_identifier = "gordon-access"
 ```
 
 ## Options
@@ -55,6 +62,22 @@ The Admin API and `gordon logs` read from the process log file. Keep
 | `container_logs.max_size` | int | `100` | Max file size in MB |
 | `container_logs.max_backups` | int | `3` | Old files to keep |
 | `container_logs.max_age` | int | `28` | Days to keep files |
+
+### Access Log
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `access_log.enabled` | bool | `false` | Enable a dedicated HTTP access log |
+| `access_log.format` | string | `"json"` | Access log format: `json`, `clf`, `combined` |
+| `access_log.output` | string | `"stdout"` | Output sink: `stdout`, `file`, `journald` |
+| `access_log.file_path` | string | - | File path when `output = "file"` |
+| `access_log.max_size` | int | `100` | Max file size in MB for file output |
+| `access_log.max_backups` | int | `3` | Old files to keep for file output |
+| `access_log.max_age` | int | `28` | Days to keep file output |
+| `access_log.exclude_health_checks` | bool | `true` | Skip health and readiness checks |
+| `access_log.syslog_identifier` | string | `"gordon-access"` | Journald identifier |
+
+Use the access log for reverse-proxy traffic analysis, CrowdSec/fail2ban ingestion, or request auditing without mixing entries into the main process log.
 
 ## Log Levels
 
@@ -114,6 +137,13 @@ dir = "./logs/containers"
 max_size = 10
 max_backups = 2
 max_age = 7
+
+[logging.access_log]
+enabled = true
+format = "json"
+output = "file"
+file_path = "./logs/access.log"
+exclude_health_checks = true
 ```
 
 ### Production

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -232,7 +232,7 @@ keep_last = 3                                # Keep N newest tags per repository
 | `tls.acme.obtain_batch_size` | `1` | Maximum new ACME certificate orders per reconcile run |
 | `auth.enabled` | `true` | Enable authentication; when `false`, run local-only mode (loopback-only `/v2/*`, `/admin/*` disabled) |
 | `auth.secrets_backend` | `"unsafe"` | Secrets storage |
-| `auth.token_expiry` | `"720h"` | 30 days |
+| `auth.token_expiry` | `"30d"` | 30 days |
 | `auth.access_token_ttl` | `"15m"` | Ephemeral access token lifetime |
 | `api.rate_limit.enabled` | `true` | Enable rate limiting |
 | `api.rate_limit.global_rps` | `500` | Global requests/second |

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -38,7 +38,7 @@ polling_interval = "5s"                    # Interval between DNS-01 propagation
 enabled = true                               # Enable registry authentication (default: true)
 secrets_backend = "unsafe"                   # "pass", "sops", or "unsafe"
 token_secret = ""                            # Path in secrets backend to JWT signing key (REQUIRED)
-token_expiry = "720h"                        # Token expiry duration (720h = 30 days)
+token_expiry = "30d"                         # Token expiry duration
 access_token_ttl = "15m"                     # Ephemeral access token lifetime (default: 15m)
 
 # =============================================================================
@@ -80,6 +80,17 @@ dir = ""                                     # Log directory (default: {data_dir
 max_size = 100                               # Max size in MB before rotation
 max_backups = 3                              # Number of old files to keep
 max_age = 28                                 # Days to keep old files
+
+[logging.access_log]
+enabled = false                              # Dedicated HTTP access log for reverse-proxy traffic
+format = "json"                             # "json", "clf", or "combined"
+output = "stdout"                           # "stdout", "file", or "journald"
+file_path = ""                               # Required when output = "file"
+max_size = 100                               # Max size in MB before rotation (file output)
+max_backups = 3                              # Number of old files to keep (file output)
+max_age = 28                                 # Days to keep old files (file output)
+exclude_health_checks = true                 # Skip noisy readiness/liveness requests
+syslog_identifier = "gordon-access"         # Journald identifier when output = "journald"
 
 # =============================================================================
 # TELEMETRY (OpenTelemetry)
@@ -238,6 +249,14 @@ keep_last = 3                                # Keep N newest tags per repository
 | `logging.container_logs.max_size` | `100` | 100 MB |
 | `logging.container_logs.max_backups` | `3` | Keep 3 old files |
 | `logging.container_logs.max_age` | `28` | 28 days |
+| `logging.access_log.enabled` | `false` | Dedicated HTTP access log disabled |
+| `logging.access_log.format` | `"json"` | Access log format (`json`, `clf`, `combined`) |
+| `logging.access_log.output` | `"stdout"` | Access log sink (`stdout`, `file`, `journald`) |
+| `logging.access_log.max_size` | `100` | 100 MB for file output |
+| `logging.access_log.max_backups` | `3` | Keep 3 old files for file output |
+| `logging.access_log.max_age` | `28` | 28 days for file output |
+| `logging.access_log.exclude_health_checks` | `true` | Skip health-check requests |
+| `logging.access_log.syslog_identifier` | `"gordon-access"` | Journald identifier |
 | `telemetry.enabled` | `false` | Enable OTLP telemetry export |
 | `telemetry.endpoint` | `""` | OTLP HTTP endpoint URL |
 | `telemetry.auth_token` | `""` | Base64 `user:password` for Basic auth |
@@ -285,7 +304,7 @@ GORDON_<SECTION>_<KEY>=value
 
 Examples:
 ```bash
-GORDON_SERVER_PORT=8080
+GORDON_SERVER_PORT=8088
 GORDON_SERVER_GORDON_DOMAIN=gordon.example.com
 GORDON_AUTH_ENABLED=true
 GORDON_LOGGING_LEVEL=debug

--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -48,14 +48,14 @@ The `port` setting controls where Gordon listens for HTTP traffic:
 
 ```toml
 [server]
-port = 8080  # Use 8080 for rootless containers with port forwarding
+port = 8088  # Default high port for rootless or forwarded setups
 ```
 
 For rootless containers, you'll typically use a high port and configure firewall port forwarding:
 
 ```bash
-# Forward port 80 to 8080
-sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8080
+# Forward port 80 to 8088
+sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8088
 ```
 
 ### Internal CA and TLS
@@ -115,7 +115,7 @@ HTTP-01 requires public access to port 80 for each hostname being validated. If 
 
 Gordon limits new ACME certificate orders to `obtain_batch_size` per reconcile run (default `1`) so enabling ACME on an existing multi-route server does not burst through every route and hit Let's Encrypt rate limits. Later reloads, restarts, or other explicit reconcile runs continue issuing remaining certificates.
 
-If the initial ACME reconcile fails (e.g. due to a transient network error or misconfiguration), Gordon logs the failure but still starts the renewal loop for already cached certificates. Operators should fix the underlying error and restart/reload Gordon to trigger a new obtain attempt for missing certificates.
+If the initial ACME reconcile fails (e.g. due to a transient network error or misconfiguration), Gordon logs the failure and keeps serving any existing certificates. The renewal loop retries reconcile work periodically, so missing certificates self-heal after the underlying issue is fixed without requiring a restart.
 
 For Cloudflare Full/Strict, Cloudflare terminates browser TLS at the edge and connects to Gordon over HTTPS. A public ACME certificate served by Gordon is the preferred origin certificate because Cloudflare Strict can validate it without custom origin trust. Cloudflare Flexible mode (HTTPS at the edge, HTTP to Gordon) is not end-to-end HTTPS.
 
@@ -412,7 +412,7 @@ HSTS headers are sent automatically on the HTTPS listener (when `r.TLS != nil`).
 
 ```toml
 [server]
-port = 8080
+port = 8088
 registry_port = 5000
 gordon_domain = "gordon.local"
 data_dir = "./dev-data"
@@ -422,7 +422,7 @@ data_dir = "./dev-data"
 
 ```toml
 [server]
-port = 8080
+port = 8088
 registry_port = 5000
 gordon_domain = "gordon.company.com"
 data_dir = "/var/lib/gordon"
@@ -432,14 +432,14 @@ data_dir = "/var/lib/gordon"
 
 ```toml
 [server]
-port = 8080      # High port for rootless
+port = 8088      # High port for rootless
 registry_port = 5000
 gordon_domain = "gordon.mydomain.com"
 ```
 
 With firewall port forwarding:
 ```bash
-sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8080
+sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8088
 sudo firewall-cmd --reload
 ```
 

--- a/docs/config/server.md
+++ b/docs/config/server.md
@@ -438,6 +438,7 @@ gordon_domain = "gordon.mydomain.com"
 ```
 
 With firewall port forwarding:
+
 ```bash
 sudo firewall-cmd --permanent --add-forward-port=port=80:proto=tcp:toport=8088
 sudo firewall-cmd --reload

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -2,6 +2,18 @@
 
 Roll back to previous versions when deployments fail.
 
+## Recommended: Use `gordon pin`
+
+`gordon pin` is the built-in rollback and roll-forward workflow for route images:
+
+```bash
+gordon pin app.example.com
+gordon pin app.example.com --tag v2.30.1
+gordon pin list app.example.com
+```
+
+Use it when the target image already exists in the Gordon registry and you want Gordon to update the route and redeploy it for you.
+
 ## Rollback Strategies
 
 ### 1. Config-Based Rollback

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,8 +73,9 @@ Edit `~/.config/gordon/gordon.toml`:
 
 ```toml
 [server]
-port = 8080                              # Proxy port (use with Cloudflare/rootless)
+port = 8088                              # HTTP proxy port (default)
 registry_port = 5000                     # Registry port
+tls_port = 8443                          # HTTPS listener (default)
 gordon_domain = "gordon.mydomain.com"    # Registry + Admin API domain
 
 [routes]
@@ -97,6 +98,8 @@ Why wildcard (`*`)?
 - You can add new domains in `[routes]` without creating DNS records one by one.
 
 If your DNS provider supports wildcard CNAME flattening (Cloudflare does), `* -> gordon.mydomain.com` is usually the cleanest option.
+
+> **Important for Cloudflare or other proxied setups:** when Gordon's internal CA is enabled (default `tls_port = 8443`), add your proxy edge IPs to `server.proxy_allowed_ips` or proxied HTTP traffic will get `403 Forbidden`. See [Installation](./installation.md#proxy-origin-allowlist). If you do not want Gordon to manage TLS at all, set `tls_port = 0`.
 
 ## 6. Start Gordon as a Service
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,8 @@ Gordon runs on your VPS and provides:
 - Linux VPS (Ubuntu/Debian recommended)
 - Docker or Podman runtime
 - Domain pointing to your server
-- Cloudflare account for HTTPS (free tier works)
+- Domain pointing to your server
+- Optional Cloudflare account or other reverse proxy for edge TLS
 
 > **Note:** Gordon can run behind Cloudflare/nginx, or terminate TLS directly via its internal CA (enabled by default on `server.tls_port`). Set `tls_port = 0` to disable.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,6 @@ Gordon runs on your VPS and provides:
 - Linux VPS (Ubuntu/Debian recommended)
 - Docker or Podman runtime
 - Domain pointing to your server
-- Domain pointing to your server
 - Optional Cloudflare account or other reverse proxy for edge TLS
 
 > **Note:** Gordon can run behind Cloudflare/nginx, or terminate TLS directly via its internal CA (enabled by default on `server.tls_port`). Set `tls_port = 0` to disable.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -249,16 +249,16 @@ Point your domains to your server:
 
 ## Cloudflare SSL Mode
 
-Gordon serves HTTP by default. Cloudflare must connect to your origin over HTTP unless you explicitly enable TLS.
+Gordon serves HTTP on `server.port` and HTTPS on `server.tls_port` by default. Choose the Cloudflare mode that matches how you want Cloudflare to reach your origin.
 
 | Mode | How it works | Use when |
 |------|-------------|----------|
-| **Flexible** | Cloudflare terminates TLS; connects to Gordon on HTTP | Gordon has no TLS cert (default setup) |
-| **Full (Strict)** | Cloudflare connects to Gordon over HTTPS with a valid cert | Set `server.tls_port` (default 8443) and provide a Cloudflare Origin CA cert via `server.tls_cert_file` and `server.tls_key_file` |
+| **Flexible** | Cloudflare terminates TLS; connects to Gordon on HTTP | You want edge HTTPS only, or you set `tls_port = 0` |
+| **Full (Strict)** | Cloudflare connects to Gordon over HTTPS with a valid cert | You want end-to-end HTTPS using Gordon's public ACME certs or a static cert (`tls_cert_file` / `tls_key_file`) |
 
 Wrong mode causes: **521** (Cloudflare can't connect) or **525** (TLS handshake failed).
 
-> **Important:** You must also set `proxy_allowed_ips` with Cloudflare edge IPs — see [Proxy Origin Allowlist](#proxy-origin-allowlist) below.
+> **Important:** When `tls_port != 0`, you must also set `proxy_allowed_ips` with Cloudflare edge IPs — see [Proxy Origin Allowlist](#proxy-origin-allowlist) below.
 
 > **Rootless note:** Unprivileged users can't bind port 80. Forward port 80→8088 (or your configured port) via firewall — see the firewall section above.
 
@@ -282,6 +282,18 @@ proxy_allowed_ips = [
 Without this setting, Cloudflare traffic receives `403 Forbidden: Only certificate onboarding is available over HTTP`.
 
 > **Note:** This is separate from `[api.rate_limit] trusted_proxies`, which controls IP extraction from `X-Forwarded-For`. Both should list your proxy IPs. See [Proxy Origin IP Allowlist](./config/server.md#proxy-origin-ip-allowlist) for details.
+
+## Installing a Specific Version or Pre-Release
+
+```bash
+# Install an exact version
+curl -fsSL https://gordon.bnema.dev/install | GORDON_VERSION=v2.30.1 bash
+
+# Install the latest pre-release instead of the latest stable release
+curl -fsSL https://gordon.bnema.dev/install | GORDON_PRERELEASE=1 bash
+```
+
+By default, the installer resolves `latest` to the newest stable release and verifies the downloaded checksum before installing.
 
 ## Verify Installation
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -406,7 +406,7 @@ docker inspect gordon-app-mydomain-com
 
 # Check connectivity
 curl -v http://localhost:5000/v2/
-curl -v http://localhost:8080/
+curl -v http://localhost:8088/
 ```
 
 ## Getting Help

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -97,6 +97,60 @@ Recommended rollout:
 
 During the transition, Gordon treats both the current and legacy hosts as its own registry for image matching and internal pulls, then saves canonical refs back to `gordon_domain`. Remote CLI and admin API traffic should use the new `gordon_domain`.
 
+### Breaking: `gordon rollback` Renamed to `gordon pin`
+
+If you have scripts or runbooks using `gordon rollback`, switch them to `gordon pin`:
+
+```bash
+gordon pin app.example.com
+gordon pin app.example.com --tag v2.30.1
+gordon pin list app.example.com
+```
+
+### Breaking-ish: `routes list` Is Inventory-Only
+
+`gordon routes list` now shows domain/image inventory only. Detailed runtime state, HTTP probe status, and attachment status moved to `gordon routes status`.
+
+If you have automation parsing status-like fields from `routes list`, migrate it to `routes status --json`.
+
+### New: Public ACME TLS
+
+Gordon can now obtain public certificates with `[tls.acme]` using either `http-01` or `cloudflare-dns-01`.
+
+- `server.tls_port` must stay enabled (`> 0`)
+- `http-01` needs public HTTP reachability for each hostname being validated
+- `cloudflare-dns-01` needs a Cloudflare token with zone-read and DNS-edit access for every zone used by HTTPS routes
+- `obtain_batch_size` limits new ACME orders per reconcile pass to reduce rate-limit spikes
+
+### New: DNS Resolver Settings for ACME DNS-01
+
+`[dns]` controls the recursive resolvers Gordon uses to verify public DNS propagation for ACME DNS-01.
+
+Add this if you need non-default resolvers, split-horizon-aware testing, or a slower propagation window:
+
+```toml
+[dns]
+resolvers = ["1.1.1.1:53", "8.8.8.8:53"]
+propagation_timeout = "5m"
+polling_interval = "5s"
+```
+
+### Runtime Change: Managed Containers Use Restart Policy `always`
+
+Newly created managed route containers now use the runtime restart policy `always`. Existing containers pick this up on redeploy/recreate.
+
+This improves crash recovery and keeps Docker/Podman behavior aligned with Gordon's startup reconciliation.
+
+### New: Saved Remote Inference for Targeted Commands
+
+When you do not pass `--remote`, Gordon can now infer a saved remote for some target-based commands when exactly one configured remote matches the route, image, attachment target, or repository.
+
+If multiple remotes match or probing fails, Gordon now stops and asks you to pass `--remote` explicitly instead of guessing.
+
+### New: Dedicated Access Log
+
+You can now enable `logging.access_log.*` for a dedicated HTTP access log separate from the main process log. This is useful for request auditing, GoAccess, CrowdSec, or fail2ban-style tooling.
+
 ## v2.16.0 to v2.30.0
 
 ### Breaking: Password Authentication Removed
@@ -116,7 +170,7 @@ Gordon v2.30.0 removes password-based authentication entirely. Only token-based 
 
 - `auth.access_token_ttl` configures the lifetime of ephemeral access tokens issued by `/auth/token` (default: `"15m"`)
 - `gordon auth show-token` prints the stored token for a remote
-- `gordon auth logout` removes the stored token (with optional `--revoke`)
+- `gordon auth logout` removes the stored token locally
 - Automatic token exchange: the CLI transparently exchanges long-lived tokens for ephemeral ones before API calls
 - Admin scopes (`admin:*:*`, `admin:routes:read`, etc.) allow fine-grained access control for remote CLI operations
 

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -3,10 +3,33 @@
 
 [server]
 port = 8088
+tls_port = 8443
 registry_port = 5000
 gordon_domain = "gordon.example.com"
 # legacy_registry_domains = ["registry.example.com:5000"]
+# proxy_allowed_ips = ["173.245.48.0/20"]
+# registry_allowed_ips = []
+# registry_listen_address = ""
+# tls_cert_file = ""
+# tls_key_file = ""
+# force_https_redirect = false
 # data_dir = "~/.gordon"
+# max_blob_chunk_size = "95MB"
+# max_blob_size = "1GB"
+# max_proxy_body_size = "512MB"
+# max_proxy_response_size = "1GB"
+# max_concurrent_connections = 10000
+
+[dns]
+resolvers = ["1.1.1.1:53", "8.8.8.8:53"]
+propagation_timeout = "5m"
+polling_interval = "5s"
+
+[tls.acme]
+enabled = false
+email = ""
+challenge = "auto"
+obtain_batch_size = 1
 
 [auth]
 enabled = true
@@ -68,8 +91,42 @@ enabled = false
 level = "info"
 format = "console"
 
+[logging.file]
+enabled = false
+# path = "~/.gordon/logs/gordon.log"
+# max_size = 100
+# max_backups = 3
+# max_age = 28
+
 [logging.container_logs]
 enabled = true
+# dir = "~/.gordon/logs/containers"
+# max_size = 100
+# max_backups = 3
+# max_age = 28
+
+[logging.access_log]
+enabled = false
+format = "json"
+output = "stdout"
+# file_path = "~/.gordon/logs/access.log"
+max_size = 100
+max_backups = 3
+max_age = 28
+exclude_health_checks = true
+syslog_identifier = "gordon-access"
+
+[telemetry]
+enabled = false
+# endpoint = "http://localhost:4318"
+# auth_token = ""
+traces = true
+metrics = true
+logs = true
+trace_sample_rate = 1.0
+
+[env]
+# dir = "~/.gordon/env"
 
 [backups]
 enabled = false

--- a/internal/adapters/in/cli/attachments.go
+++ b/internal/adapters/in/cli/attachments.go
@@ -70,7 +70,10 @@ Examples:
 				return runAttachmentsList(ctx, handle.plane, target, jsonOut, cmd.OutOrStdout())
 			}
 
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if isRemote {
 				return runAttachmentsListRemote(ctx, client, target, jsonOut, cmd.OutOrStdout())
 			}

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -236,7 +236,10 @@ Examples:
 }
 
 func resolveRequiredRemote(flagToken string) (*remote.ResolvedRemote, error) {
-	resolved, isRemote := remote.Resolve(remoteFlag, flagToken, insecureTLSFlag)
+	resolved, isRemote, err := remote.ResolveStrict(remoteFlag, flagToken, insecureTLSFlag)
+	if err != nil {
+		return nil, err
+	}
 	if !isRemote {
 		return nil, fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")
 	}

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -238,7 +238,7 @@ Examples:
 func resolveRequiredRemote(flagToken string) (*remote.ResolvedRemote, error) {
 	resolved, isRemote, err := remote.ResolveStrict(remoteFlag, flagToken, insecureTLSFlag)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve remote %q: %w", remoteFlag, err)
 	}
 	if !isRemote {
 		return nil, fmt.Errorf("no remote specified. Use --remote or 'gordon remotes use <name>'")

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -153,6 +153,54 @@ func (l *localControlPlane) RemoveRouteWithCleanup(ctx context.Context, routeDom
 	return resp, nil
 }
 
+func (l *localControlPlane) GetRouteCleanupPreview(ctx context.Context, routeDomain string) (*domain.CleanupReport, error) {
+	previewer, ok := any(l.containerSvc).(interface {
+		PreviewRemovedRouteCleanup(context.Context, string) (*domain.CleanupReport, error)
+	})
+	if !ok {
+		return nil, fmt.Errorf("route cleanup preview unavailable")
+	}
+
+	report, err := previewer.PreviewRemovedRouteCleanup(ctx, routeDomain)
+	if err != nil {
+		return nil, err
+	}
+	if l.volumeSvc == nil {
+		return report, nil
+	}
+
+	volumes, err := l.ListVolumes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list volumes: %w", err)
+	}
+	if len(volumes) == 0 {
+		return report, nil
+	}
+
+	scope := newRouteResourceScope(routeDomain, l.routeCleanupVolumePrefix(), nil, report.PreservedAttachments)
+	for _, volume := range volumesForRouteDiagnosis(volumes, scope) {
+		report.PreservedVolumes = append(report.PreservedVolumes, domain.CleanupVolume{
+			Name:   volume.Name,
+			Reason: "volume preserved for explicit cleanup review",
+		})
+	}
+	return report, nil
+}
+
+func (l *localControlPlane) routeCleanupVolumePrefix() string {
+	const defaultPrefix = "gordon"
+	if l.configSvc == nil {
+		return defaultPrefix
+	}
+	if volumeCfg, ok := any(l.configSvc).(interface{ GetVolumeConfig() (bool, string, bool) }); ok {
+		_, prefix, _ := volumeCfg.GetVolumeConfig()
+		if prefix != "" {
+			return prefix
+		}
+	}
+	return defaultPrefix
+}
+
 func (l *localControlPlane) Bootstrap(ctx context.Context, req dto.BootstrapRequest) (*dto.BootstrapResponse, error) {
 	registryDomain := ""
 	if l.configSvc != nil {

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -165,6 +165,9 @@ func (l *localControlPlane) GetRouteCleanupPreview(ctx context.Context, routeDom
 	if err != nil {
 		return nil, err
 	}
+	if report == nil {
+		return nil, nil
+	}
 	if l.volumeSvc == nil {
 		return report, nil
 	}

--- a/internal/adapters/in/cli/controlplane_local_test.go
+++ b/internal/adapters/in/cli/controlplane_local_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type previewContainerService struct {
+	*inmocks.MockContainerService
+	preview func(context.Context, string) (*domain.CleanupReport, error)
+}
+
+func (s *previewContainerService) PreviewRemovedRouteCleanup(ctx context.Context, routeDomain string) (*domain.CleanupReport, error) {
+	if s.preview == nil {
+		return nil, nil
+	}
+	return s.preview(ctx, routeDomain)
+}
+
 func TestLocalControlPlane_GetStatus(t *testing.T) {
 	t.Parallel()
 
@@ -214,6 +226,22 @@ func TestLocalControlPlane_GetContainerLogs(t *testing.T) {
 	lines, err := cp.GetContainerLogs(context.Background(), "app.local", 50)
 	require.NoError(t, err)
 	require.Equal(t, []string{"line1", "line2"}, lines)
+}
+
+func TestLocalControlPlane_GetRouteCleanupPreview_ReturnsNilReportWithoutPanic(t *testing.T) {
+	ctx := context.Background()
+	volumeSvc := inmocks.NewMockVolumeService(t)
+	containerSvc := &previewContainerService{
+		MockContainerService: inmocks.NewMockContainerService(t),
+		preview: func(context.Context, string) (*domain.CleanupReport, error) {
+			return nil, nil
+		},
+	}
+	cp := &localControlPlane{containerSvc: containerSvc, volumeSvc: volumeSvc}
+
+	report, err := cp.GetRouteCleanupPreview(ctx, "app.local")
+	require.NoError(t, err)
+	assert.Nil(t, report)
 }
 
 func TestLocalControlPlane_RemoveRouteReconcilesRuntimeWhenRouteAlreadyMissing(t *testing.T) {

--- a/internal/adapters/in/cli/controlplane_remote.go
+++ b/internal/adapters/in/cli/controlplane_remote.go
@@ -49,6 +49,10 @@ func (r *remoteControlPlane) RemoveRouteWithCleanup(ctx context.Context, routeDo
 	return r.client.RemoveRouteWithCleanup(ctx, routeDomain)
 }
 
+func (r *remoteControlPlane) GetRouteCleanupPreview(ctx context.Context, routeDomain string) (*domain.CleanupReport, error) {
+	return r.client.GetRouteCleanupPreview(ctx, routeDomain)
+}
+
 func (r *remoteControlPlane) Bootstrap(ctx context.Context, req dto.BootstrapRequest) (*dto.BootstrapResponse, error) {
 	return r.client.Bootstrap(ctx, req)
 }

--- a/internal/adapters/in/cli/controlplane_resolver.go
+++ b/internal/adapters/in/cli/controlplane_resolver.go
@@ -25,7 +25,10 @@ func (h *controlPlaneHandle) close() {
 }
 
 func resolveControlPlane(configPath string) (*controlPlaneHandle, error) {
-	client, isRemote := GetRemoteClient()
+	client, isRemote, err := GetRemoteClient()
+	if err != nil {
+		return nil, err
+	}
 	if isRemote {
 		return &controlPlaneHandle{plane: NewRemoteControlPlane(client), isRemote: true}, nil
 	}
@@ -41,6 +44,12 @@ func newRemoteControlPlaneHandle(target *remote.ResolvedRemote) *controlPlaneHan
 func resolveControlPlaneForRouteDomain(ctx context.Context, routeDomain string) (*controlPlaneHandle, error) {
 	return resolveControlPlaneWithInference(ctx, func(ctx context.Context) (*remote.ResolvedRemote, error) {
 		return inferRemoteForRouteDomain(ctx, routeDomain)
+	})
+}
+
+func resolveControlPlaneForRouteCleanupDomain(ctx context.Context, routeDomain string) (*controlPlaneHandle, error) {
+	return resolveControlPlaneWithInference(ctx, func(ctx context.Context) (*remote.ResolvedRemote, error) {
+		return inferRemoteForRouteCleanupDomain(ctx, routeDomain)
 	})
 }
 

--- a/internal/adapters/in/cli/controlplane_resolver_test.go
+++ b/internal/adapters/in/cli/controlplane_resolver_test.go
@@ -75,3 +75,36 @@ secrets_backend = "unsafe"
 	require.NotNil(t, handle.plane)
 	defer handle.close()
 }
+
+func TestResolveControlPlane_ExplicitUnknownRemoteReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+	t.Setenv("GORDON_REMOTE", "")
+	t.Setenv("GORDON_TOKEN", "")
+	originalRemoteFlag, originalTokenFlag, originalInsecureTLSFlag := remoteFlag, tokenFlag, insecureTLSFlag
+	t.Cleanup(func() {
+		remoteFlag = originalRemoteFlag
+		tokenFlag = originalTokenFlag
+		insecureTLSFlag = originalInsecureTLSFlag
+	})
+
+	remoteFlag = "does-not-exist"
+	tokenFlag = ""
+	insecureTLSFlag = false
+
+	configPath := filepath.Join(tmpDir, "gordon.toml")
+	err := os.WriteFile(configPath, []byte(`[server]
+gordon_domain = "gordon.local"
+data_dir = "`+filepath.Join(tmpDir, "data")+`"
+
+[auth]
+enabled = false
+secrets_backend = "unsafe"
+`), 0o600)
+	require.NoError(t, err)
+
+	handle, err := resolveControlPlane(configPath)
+	require.Error(t, err)
+	require.Nil(t, handle)
+	require.Contains(t, err.Error(), "does-not-exist")
+}

--- a/internal/adapters/in/cli/images.go
+++ b/internal/adapters/in/cli/images.go
@@ -89,7 +89,10 @@ func newImagesListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List runtime images and registry tags",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if !isRemote {
 				return fmt.Errorf("images commands require a configured remote target")
 			}
@@ -114,7 +117,10 @@ func newImagesPruneCmd() *cobra.Command {
 By default both runtime and registry cleanup run, keeping latest + 3 previous
 release tags per repository. Use --dangling or --registry to restrict scope.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if !isRemote {
 				return fmt.Errorf("images commands require a configured remote target")
 			}

--- a/internal/adapters/in/cli/pin.go
+++ b/internal/adapters/in/cli/pin.go
@@ -240,9 +240,9 @@ func deploySelectedTag(ctx context.Context, cp ControlPlane, route *domain.Route
 		route.Image = oldImage
 		if revertErr := cp.UpdateRoute(ctx, *route); revertErr != nil {
 			_ = cliWritef(ew, "WARNING: deploy failed and could not revert route: %v\n", revertErr)
-			return fmt.Errorf("failed to deploy; revert failed: %v; deploy error: %w", revertErr, formattedErr)
+			return fmt.Errorf("failed to deploy; revert failed: %w; deploy error: %v", revertErr, formattedErr)
 		}
-		return fmt.Errorf("%w\nroute reverted to previous image", formattedErr)
+		return fmt.Errorf("deploy failed; route reverted to previous image: %w", formattedErr)
 	}
 	containerID := shortContainerID(result.ContainerID)
 	return cliWriteLine(out, styles.RenderSuccess(fmt.Sprintf("Pinned %s to %s (container: %s)", pinDomain, selectedTag, containerID)))

--- a/internal/adapters/in/cli/pin.go
+++ b/internal/adapters/in/cli/pin.go
@@ -235,13 +235,14 @@ func deploySelectedTag(ctx context.Context, cp ControlPlane, route *domain.Route
 
 	result, err := cp.Deploy(ctx, pinDomain)
 	if err != nil {
+		formattedErr := formatDeployFailure(err)
 		// Attempt to revert route to previous image
 		route.Image = oldImage
 		if revertErr := cp.UpdateRoute(ctx, *route); revertErr != nil {
 			_ = cliWritef(ew, "WARNING: deploy failed and could not revert route: %v\n", revertErr)
-			return fmt.Errorf("failed to deploy; revert failed: %v; deploy error: %w", revertErr, err)
+			return fmt.Errorf("failed to deploy; revert failed: %v; deploy error: %w", revertErr, formattedErr)
 		}
-		return fmt.Errorf("failed to deploy (route reverted): %w", err)
+		return fmt.Errorf("%w\nroute reverted to previous image", formattedErr)
 	}
 	containerID := shortContainerID(result.ContainerID)
 	return cliWriteLine(out, styles.RenderSuccess(fmt.Sprintf("Pinned %s to %s (container: %s)", pinDomain, selectedTag, containerID)))

--- a/internal/adapters/in/cli/pin_test.go
+++ b/internal/adapters/in/cli/pin_test.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
+	climocks "github.com/bnema/gordon/internal/adapters/in/cli/mocks"
+	"github.com/bnema/gordon/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,4 +80,25 @@ func TestPrintPinTags_ReturnsWriteError(t *testing.T) {
 	err := printPinTags(failingWriter{}, "myapp.example.com", "v1.2.0", []string{"v1.2.0"}, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "write failed")
+}
+
+func TestDeploySelectedTag_FormatsDeployFailureAfterRevert(t *testing.T) {
+	cp := climocks.NewMockControlPlane(t)
+	route := &domain.Route{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}
+	deployErr := &domain.DeployFailureError{
+		Summary: "failed to deploy",
+		Cause:   "health check failed",
+		Hint:    "check DATABASE_URL",
+	}
+
+	cp.EXPECT().UpdateRoute(context.Background(), domain.Route{Domain: "app.example.com", Image: "registry.example.com/myapp:v2"}).Return(nil).Once()
+	cp.EXPECT().Deploy(context.Background(), "app.example.com").Return(nil, deployErr).Once()
+	cp.EXPECT().UpdateRoute(context.Background(), domain.Route{Domain: "app.example.com", Image: "registry.example.com/myapp:latest"}).Return(nil).Once()
+
+	err := deploySelectedTag(context.Background(), cp, route, &bytes.Buffer{}, &bytes.Buffer{}, "app.example.com", "myapp", "v2")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to deploy")
+	assert.Contains(t, err.Error(), "Cause: health check failed")
+	assert.Contains(t, err.Error(), "Hint: check DATABASE_URL")
+	assert.Contains(t, err.Error(), "route reverted")
 }

--- a/internal/adapters/in/cli/pin_test.go
+++ b/internal/adapters/in/cli/pin_test.go
@@ -100,5 +100,5 @@ func TestDeploySelectedTag_FormatsDeployFailureAfterRevert(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to deploy")
 	assert.Contains(t, err.Error(), "Cause: health check failed")
 	assert.Contains(t, err.Error(), "Hint: check DATABASE_URL")
-	assert.Contains(t, err.Error(), "route reverted")
+	assert.Contains(t, err.Error(), "route reverted to previous image")
 }

--- a/internal/adapters/in/cli/preview.go
+++ b/internal/adapters/in/cli/preview.go
@@ -102,7 +102,10 @@ func newPreviewListCmd() *cobra.Command {
 			ctx := cmd.Context()
 			out := cmd.OutOrStdout()
 
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if !isRemote {
 				return fmt.Errorf("preview list requires --remote (local preview listing is not yet supported)")
 			}
@@ -137,7 +140,10 @@ func newPreviewDeleteCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			name := args[0]
 
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if !isRemote {
 				return fmt.Errorf("preview delete requires --remote (local preview deletion is not yet supported)")
 			}
@@ -162,7 +168,10 @@ func newPreviewExtendCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			name := args[0]
 
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if !isRemote {
 				return fmt.Errorf("preview extend requires --remote (local preview extend is not yet supported)")
 			}
@@ -315,7 +324,10 @@ func waitForPreview(ctx context.Context, out io.Writer, name, ttl string, noData
 		return err
 	}
 
-	client, isRemote := GetRemoteClient()
+	client, isRemote, err := GetRemoteClient()
+	if err != nil {
+		return err
+	}
 	if !isRemote {
 		return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Push complete. Preview %q will be created by the server (use --remote to poll status).", name)))
 	}

--- a/internal/adapters/in/cli/push_image_ops.go
+++ b/internal/adapters/in/cli/push_image_ops.go
@@ -54,7 +54,10 @@ func newDockerImageOps(insecureTLS bool, progress io.Writer) (*dockerImageOps, e
 
 // newImageOpsFromFlags resolves TLS settings from CLI flags/config and creates ops.
 func newImageOpsFromFlags() (pushImageOps, error) {
-	resolved, _ := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
+	resolved, _, err := remote.ResolveStrict(remoteFlag, tokenFlag, insecureTLSFlag)
+	if err != nil {
+		return nil, err
+	}
 	return newImageOpsForResolvedRemote(resolved)
 }
 

--- a/internal/adapters/in/cli/push_remote_inference_test.go
+++ b/internal/adapters/in/cli/push_remote_inference_test.go
@@ -193,6 +193,101 @@ url = "`+staging.URL+`"
 	assert.Contains(t, err.Error(), `multiple saved remotes match route "app.example.com"`)
 }
 
+func TestInferRemoteForRouteCleanupDomain_UsesCleanupPreviewWhenRouteConfigMissing(t *testing.T) {
+	prod := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getRouteCleanup: func(domainName string) (*domain.CleanupReport, int) {
+			return &domain.CleanupReport{
+				Domain: domainName,
+				OrphanedEntities: []domain.CleanupOrphanedEntity{{
+					Kind:   "route_container",
+					ID:     "abc123",
+					Status: "running",
+				}},
+			}, http.StatusOK
+		},
+	})
+	staging := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getRouteCleanup: func(domainName string) (*domain.CleanupReport, int) {
+			return &domain.CleanupReport{Domain: domainName}, http.StatusOK
+		},
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForRouteCleanupDomain(context.Background(), "app.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+}
+
+func TestInferRemoteForRouteCleanupDomain_UsesCleanupPreviewVolumesWhenRouteConfigMissing(t *testing.T) {
+	prod := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getRouteCleanup: func(domainName string) (*domain.CleanupReport, int) {
+			return &domain.CleanupReport{
+				Domain:           domainName,
+				PreservedVolumes: []domain.CleanupVolume{{Name: "gordon-app-example-com-data"}},
+			}, http.StatusOK
+		},
+	})
+	staging := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getRouteCleanup: func(domainName string) (*domain.CleanupReport, int) {
+			return &domain.CleanupReport{Domain: domainName}, http.StatusOK
+		},
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+
+[remotes.staging]
+url = "`+staging.URL+`"
+`)
+
+	resolved, err := inferRemoteForRouteCleanupDomain(context.Background(), "app.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod", resolved.Name)
+}
+
+func TestInferRemoteForRouteCleanupDomain_FailsSafeWhenCleanupPreviewProbeFails(t *testing.T) {
+	prod := newMultiAdminProbeTestServer(t, multiAdminProbeHandlers{
+		getRoute: func(domainName string) (*domain.Route, int) {
+			return nil, http.StatusNotFound
+		},
+		getRouteCleanup: func(domainName string) (*domain.CleanupReport, int) {
+			return nil, http.StatusForbidden
+		},
+	})
+
+	configurePushRemoteInferenceTestEnv(t, `
+[remotes.prod]
+url = "`+prod.URL+`"
+`)
+
+	resolved, err := inferRemoteForRouteCleanupDomain(context.Background(), "app.example.com")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `could not safely infer remote for route cleanup "app.example.com"`)
+}
+
 func TestInferRemoteForAttachmentImage_UsesUniqueMatchingSavedRemote(t *testing.T) {
 	prod := newAttachmentTargetsByImageTestServer(t, func(image string) ([]string, int) {
 		return []string{"app.example.com"}, http.StatusOK
@@ -339,6 +434,7 @@ func newGetRouteTestServer(t *testing.T, handler func(domainName string) (*domai
 
 type multiAdminProbeHandlers struct {
 	getRoute             func(domainName string) (*domain.Route, int)
+	getRouteCleanup      func(domainName string) (*domain.CleanupReport, int)
 	getAttachmentsConfig func(target string) ([]string, int)
 	listTags             func(repository string) ([]string, int)
 	findAttachmentTarget func(image string) ([]string, int)
@@ -349,6 +445,8 @@ func newMultiAdminProbeTestServer(t *testing.T, handlers multiAdminProbeHandlers
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case strings.HasSuffix(r.URL.Path, "/cleanup") && strings.HasPrefix(r.URL.Path, "/admin/routes/"):
+			handleGetRouteCleanupProbe(t, w, r, handlers.getRouteCleanup)
 		case strings.HasPrefix(r.URL.Path, "/admin/routes/"):
 			handleGetRouteProbe(t, w, r, handlers.getRoute)
 		case strings.HasPrefix(r.URL.Path, "/admin/attachments/by-image/"):
@@ -402,6 +500,31 @@ func handleGetRouteProbe(t *testing.T, w http.ResponseWriter, r *http.Request, h
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if !assert.NoError(t, json.NewEncoder(w).Encode(route)) {
+		return
+	}
+}
+
+func handleGetRouteCleanupProbe(t *testing.T, w http.ResponseWriter, r *http.Request, handler func(domainName string) (*domain.CleanupReport, int)) {
+	t.Helper()
+	if handler == nil {
+		http.NotFound(w, r)
+		return
+	}
+	domainName, err := url.PathUnescape(strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/admin/routes/"), "/cleanup"))
+	if !assert.NoError(t, err) {
+		return
+	}
+	report, status := handler(domainName)
+	if status >= http.StatusBadRequest {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if !assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "boom"})) {
+			return
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if !assert.NoError(t, json.NewEncoder(w).Encode(report)) {
 		return
 	}
 }

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -514,6 +514,21 @@ func (c *Client) GetRoute(ctx context.Context, routeDomain string) (*domain.Rout
 	return &route, nil
 }
 
+// GetRouteCleanupPreview returns retained cleanup state for a route that may no longer be configured.
+func (c *Client) GetRouteCleanupPreview(ctx context.Context, routeDomain string) (*domain.CleanupReport, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/routes/"+url.PathEscape(routeDomain)+"/cleanup", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var report domain.CleanupReport
+	if err := parseResponse(resp, &report); err != nil {
+		return nil, err
+	}
+
+	return &report, nil
+}
+
 // FindRoutesByImage returns all routes associated with the given image name.
 func (c *Client) FindRoutesByImage(ctx context.Context, imageName string) ([]domain.Route, error) {
 	resp, err := c.request(ctx, http.MethodGet, "/routes/by-image/"+url.PathEscape(imageName), nil)

--- a/internal/adapters/in/cli/remote/config.go
+++ b/internal/adapters/in/cli/remote/config.go
@@ -241,15 +241,26 @@ func resolveInsecureForTarget(flagInsecure bool, name string, remotes *ClientCon
 // Token precedence: flag > GORDON_TOKEN env > named remote (pass > TOML token > token_env).
 // InsecureTLS precedence: flag > GORDON_INSECURE env > remote entry field.
 func Resolve(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, bool) {
+	resolved, found, _ := ResolveStrict(flagRemote, flagToken, flagInsecure)
+	return resolved, found
+}
+
+// ResolveStrict resolves the remote target like Resolve, but returns an error
+// when an explicit remote selector is invalid instead of silently falling back
+// to local mode.
+func ResolveStrict(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, bool, error) {
 	remotes, _ := LoadRemotes("")
 
 	name, url, found := resolveTarget(flagRemote, remotes)
-	if !found && flagRemote != "" && !strings.HasPrefix(flagRemote, "http://") && !strings.HasPrefix(flagRemote, "https://") {
-		return nil, false
+	if !found && flagRemote != "" {
+		return nil, false, fmt.Errorf("remote %q not found", flagRemote)
 	}
 	if !found {
 		if envRemote := os.Getenv("GORDON_REMOTE"); envRemote != "" {
 			name, url, found = resolveTarget(envRemote, remotes)
+			if !found {
+				return nil, false, fmt.Errorf("remote %q from GORDON_REMOTE not found", envRemote)
+			}
 		}
 	}
 	if !found && remotes != nil && remotes.Active != "" {
@@ -260,7 +271,7 @@ func Resolve(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, 
 		}
 	}
 	if !found {
-		return nil, false
+		return nil, false, nil
 	}
 
 	return &ResolvedRemote{
@@ -268,7 +279,7 @@ func Resolve(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, 
 		URL:         url,
 		Token:       resolveTokenForTarget(flagToken, name, remotes),
 		InsecureTLS: resolveInsecureForTarget(flagInsecure, name, remotes),
-	}, true
+	}, true, nil
 }
 
 // resolveTarget checks if value is a saved remote name or an ad-hoc URL.

--- a/internal/adapters/in/cli/remote/config.go
+++ b/internal/adapters/in/cli/remote/config.go
@@ -249,17 +249,20 @@ func Resolve(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, 
 // when an explicit remote selector is invalid instead of silently falling back
 // to local mode.
 func ResolveStrict(flagRemote, flagToken string, flagInsecure bool) (*ResolvedRemote, bool, error) {
-	remotes, _ := LoadRemotes("")
+	remotes, err := LoadRemotes("")
+	if err != nil {
+		return nil, false, fmt.Errorf("loading remotes: %w", err)
+	}
 
 	name, url, found := resolveTarget(flagRemote, remotes)
 	if !found && flagRemote != "" {
-		return nil, false, fmt.Errorf("remote %q not found", flagRemote)
+		return nil, false, fmt.Errorf("remote %q: %w", flagRemote, domain.ErrRemoteNotFound)
 	}
 	if !found {
 		if envRemote := os.Getenv("GORDON_REMOTE"); envRemote != "" {
 			name, url, found = resolveTarget(envRemote, remotes)
 			if !found {
-				return nil, false, fmt.Errorf("remote %q from GORDON_REMOTE not found", envRemote)
+				return nil, false, fmt.Errorf("remote %q from GORDON_REMOTE: %w", envRemote, domain.ErrRemoteNotFound)
 			}
 		}
 	}

--- a/internal/adapters/in/cli/remote/resolve_test.go
+++ b/internal/adapters/in/cli/remote/resolve_test.go
@@ -1,10 +1,15 @@
 package remote
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestResolve_FlagNameLookup(t *testing.T) {
@@ -201,4 +206,33 @@ func TestResolve_UnknownNameReturnsNotFound(t *testing.T) {
 	resolved, ok := Resolve("nonexistent", "", false)
 	assert.False(t, ok)
 	assert.Nil(t, resolved)
+}
+
+func TestResolveStrict_UnknownFlagRemoteWrapsErrRemoteNotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GORDON_REMOTE", "")
+	t.Setenv("GORDON_TOKEN", "")
+
+	resolved, ok, err := ResolveStrict("nonexistent", "", false)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, resolved)
+	assert.ErrorIs(t, err, domain.ErrRemoteNotFound)
+}
+
+func TestResolveStrict_LoadRemotesErrorIsReturned(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("GORDON_REMOTE", "")
+	t.Setenv("GORDON_TOKEN", "")
+
+	remotesPath := filepath.Join(configHome, "gordon", "remotes.toml")
+	require.NoError(t, os.MkdirAll(remotesPath, 0o755))
+
+	resolved, ok, err := ResolveStrict("", "", false)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), "loading remotes")
+	assert.False(t, errors.Is(err, domain.ErrRemoteNotFound))
 }

--- a/internal/adapters/in/cli/remote_inference.go
+++ b/internal/adapters/in/cli/remote_inference.go
@@ -72,6 +72,31 @@ func inferRemoteForRouteDomain(ctx context.Context, routeDomain string) (*remote
 	})
 }
 
+func inferRemoteForRouteCleanupDomain(ctx context.Context, routeDomain string) (*remote.ResolvedRemote, error) {
+	return inferSavedRemote(ctx, "route cleanup", routeDomain, func(ctx context.Context, client *remote.Client) (bool, error) {
+		_, err := client.GetRoute(ctx, routeDomain)
+		if err == nil {
+			return true, nil
+		}
+		if !isRemoteNotFoundError(err) {
+			return false, err
+		}
+
+		preview, err := client.GetRouteCleanupPreview(ctx, routeDomain)
+		if err != nil {
+			return false, err
+		}
+		return routeCleanupReportHasEvidence(preview), nil
+	})
+}
+
+func routeCleanupReportHasEvidence(report *domain.CleanupReport) bool {
+	if report == nil {
+		return false
+	}
+	return len(report.PreservedVolumes) > 0 || len(report.PreservedAttachments) > 0 || len(report.OrphanedEntities) > 0
+}
+
 func inferRemoteForAttachmentImage(ctx context.Context, imageName string) (*remote.ResolvedRemote, error) {
 	return inferSavedRemote(ctx, "attachment image", imageName, func(ctx context.Context, client *remote.Client) (bool, error) {
 		targets, err := client.FindAttachmentTargetsByImage(ctx, imageName)

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -172,15 +172,18 @@ Commands are organized by where they run:
 
 // GetRemoteClient returns a remote client if targeting a remote instance,
 // or nil if running locally.
-func GetRemoteClient() (*remote.Client, bool) {
-	resolved, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
+func GetRemoteClient() (*remote.Client, bool, error) {
+	resolved, isRemote, err := remote.ResolveStrict(remoteFlag, tokenFlag, insecureTLSFlag)
+	if err != nil {
+		return nil, false, err
+	}
 	if !isRemote {
-		return nil, false
+		return nil, false, nil
 	}
 
 	opts := remoteClientOptions(resolved.Token, resolved.InsecureTLS)
 	client := remote.NewClient(resolved.URL, opts...)
-	return client, true
+	return client, true, nil
 }
 
 func remoteClientOptions(token string, insecureTLS bool) []remote.ClientOption {
@@ -196,8 +199,8 @@ func remoteClientOptions(token string, insecureTLS bool) []remote.ClientOption {
 
 // IsRemoteMode returns true if CLI is targeting a remote Gordon instance.
 func IsRemoteMode() bool {
-	_, isRemote := remote.Resolve(remoteFlag, tokenFlag, insecureTLSFlag)
-	return isRemote
+	_, isRemote, err := remote.ResolveStrict(remoteFlag, tokenFlag, insecureTLSFlag)
+	return err == nil && isRemote
 }
 
 // newReloadCmd creates the reload command.
@@ -211,7 +214,10 @@ a running container. Running containers are never restarted to ensure 100% uptim
 Use this command after editing config.toml to add new routes, or after pushing
 images to the registry when the route was not yet configured.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if isRemote {
 				return runReloadRemote(cmd.Context(), client)
 			}
@@ -321,7 +327,10 @@ func runLogs(ctx context.Context, logsConfigPath, logDomain string, follow bool,
 		return runContainerLogs(ctx, handle.plane, logDomain, follow, lines, out)
 	}
 
-	client, isRemote := GetRemoteClient()
+	client, isRemote, err := GetRemoteClient()
+	if err != nil {
+		return err
+	}
 	if isRemote {
 		return runLogsRemote(ctx, client, logDomain, follow, lines, out)
 	}

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -1579,7 +1579,7 @@ Examples:
   gordon --remote https://gordon.mydomain.com routes add api.mydomain.com api:v2`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			routeDomain := args[0]
 
 			// Resolve image from positional argument or flag
@@ -1623,8 +1623,7 @@ Examples:
 				}
 			}
 
-			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Route configured: %s -> %s", routeDomain, image)))
-			return nil
+			return cliWriteLine(cmd.OutOrStdout(), styles.RenderSuccess(fmt.Sprintf("Route configured: %s -> %s", routeDomain, image)))
 		},
 	}
 

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -1479,7 +1479,7 @@ func runRoutePurge(ctx context.Context, cp ControlPlane, domainName string, opts
 	if diag.Runtime != nil && diag.Runtime.ContainerID != "" {
 		report.OrphanedEntities = append(report.OrphanedEntities, domain.CleanupOrphanedEntity{Kind: "route_container", ID: diag.Runtime.ContainerID, Status: diag.Runtime.ContainerStatus, Reason: "route runtime state matched purge target"})
 	}
-	report.OrphanedEntities = append(report.OrphanedEntities, diag.OrphanedEntities...)
+	report.OrphanedEntities = appendUniqueCleanupEntities(report.OrphanedEntities, diag.OrphanedEntities...)
 	if opts.Volumes {
 		for _, volume := range diag.Volumes {
 			report.PreservedVolumes = append(report.PreservedVolumes, domain.CleanupVolume{Name: volume.Name, Reason: "volume purge requires explicit --volumes and runtime support"})
@@ -1514,6 +1514,26 @@ func runRoutePurge(ctx context.Context, cp ControlPlane, domainName string, opts
 		report.Hints = append(report.Hints, "dry-run only; add --force with explicit category flags to execute supported purge actions")
 	}
 	return report, nil
+}
+
+func appendUniqueCleanupEntities(existing []domain.CleanupOrphanedEntity, candidates ...domain.CleanupOrphanedEntity) []domain.CleanupOrphanedEntity {
+	seen := make(map[string]struct{}, len(existing))
+	for _, entity := range existing {
+		seen[cleanupEntityKey(entity)] = struct{}{}
+	}
+	for _, entity := range candidates {
+		key := cleanupEntityKey(entity)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		existing = append(existing, entity)
+		seen[key] = struct{}{}
+	}
+	return existing
+}
+
+func cleanupEntityKey(entity domain.CleanupOrphanedEntity) string {
+	return entity.Kind + "|" + entity.ID + "|" + entity.Name
 }
 
 func writeRoutePurgeText(out io.Writer, report *domain.CleanupReport, force bool) error {

--- a/internal/adapters/in/cli/routes.go
+++ b/internal/adapters/in/cli/routes.go
@@ -127,15 +127,16 @@ type routeStatusSection struct {
 }
 
 type routeDiagnosis struct {
-	Domain              string                     `json:"domain"`
-	Configured          bool                       `json:"configured"`
-	Route               *domain.Route              `json:"route,omitempty"`
-	Runtime             *remote.RouteInfo          `json:"runtime,omitempty"`
-	Health              *remote.RouteHealth        `json:"health,omitempty"`
-	Volumes             []dto.Volume               `json:"volumes,omitempty"`
-	OrphanedAttachments []domain.CleanupAttachment `json:"orphaned_attachments,omitempty"`
-	Warnings            []string                   `json:"warnings,omitempty"`
-	Hints               []string                   `json:"hints,omitempty"`
+	Domain              string                         `json:"domain"`
+	Configured          bool                           `json:"configured"`
+	Route               *domain.Route                  `json:"route,omitempty"`
+	Runtime             *remote.RouteInfo              `json:"runtime,omitempty"`
+	Health              *remote.RouteHealth            `json:"health,omitempty"`
+	Volumes             []dto.Volume                   `json:"volumes,omitempty"`
+	OrphanedAttachments []domain.CleanupAttachment     `json:"orphaned_attachments,omitempty"`
+	OrphanedEntities    []domain.CleanupOrphanedEntity `json:"orphaned_entities,omitempty"`
+	Warnings            []string                       `json:"warnings,omitempty"`
+	Hints               []string                       `json:"hints,omitempty"`
 }
 
 type routesListDeps struct {
@@ -787,13 +788,13 @@ func loadRoutesListLocalSection(ctx context.Context, cfgPath string) (routeListS
 func loadRoutesListRemoteSection(ctx context.Context, name string, entry remote.RemoteEntry) (routeListSection, error) {
 	section := routeListSection{Kind: "remote", Name: name, URL: entry.URL}
 	client := newRoutesTargetClient(name, entry)
-	routes, err := client.ListRoutesWithDetails(ctx)
+	routes, err := client.ListRoutes(ctx)
 	if err != nil {
 		section.Error = err.Error()
 		return section, nil
 	}
 
-	section.Routes = routeListItemsFromInfos(routes)
+	section.Routes = routeListItemsFromRoutes(routes)
 	return section, nil
 }
 
@@ -885,7 +886,7 @@ func routeStatusItemFromInfo(route remote.RouteInfo, routeHealth *remote.RouteHe
 	return item
 }
 
-func routeListItemsFromInfos(routes []remote.RouteInfo) []routeListItem {
+func routeListItemsFromRoutes(routes []domain.Route) []routeListItem {
 	items := make([]routeListItem, 0, len(routes))
 	for _, route := range routes {
 		items = append(items, routeListItem{Domain: route.Domain, Image: route.Image})
@@ -1105,7 +1106,7 @@ func newRoutesDiagnoseCmd() *cobra.Command {
 }
 
 func runRouteDiagnosis(ctx context.Context, domainName string, out io.Writer, jsonOut bool) error {
-	handle, err := resolveControlPlaneForRouteDomain(ctx, domainName)
+	handle, err := resolveControlPlaneForRouteCleanupDomain(ctx, domainName)
 	if err != nil {
 		return err
 	}
@@ -1123,6 +1124,7 @@ func runRouteDiagnosis(ctx context.Context, domainName string, out io.Writer, js
 func buildRouteDiagnosis(ctx context.Context, cp ControlPlane, domainName string) (*routeDiagnosis, error) {
 	diag := &routeDiagnosis{Domain: domainName}
 	loadRouteDiagnosisConfig(ctx, cp, domainName, diag)
+	loadRouteDiagnosisCleanupPreview(ctx, cp, domainName, diag)
 	loadRouteDiagnosisRuntime(ctx, cp, domainName, diag)
 	loadRouteDiagnosisHealth(ctx, cp, domainName, diag)
 	loadRouteDiagnosisOrphanedAttachments(ctx, cp, domainName, diag)
@@ -1141,6 +1143,39 @@ func loadRouteDiagnosisConfig(ctx context.Context, cp ControlPlane, domainName s
 	if err != nil && !errors.Is(err, domain.ErrRouteNotFound) {
 		diag.Warnings = append(diag.Warnings, "failed to load route config: "+err.Error())
 	}
+}
+
+func loadRouteDiagnosisCleanupPreview(ctx context.Context, cp ControlPlane, domainName string, diag *routeDiagnosis) {
+	if diag.Configured {
+		return
+	}
+	previewer, ok := cp.(interface {
+		GetRouteCleanupPreview(context.Context, string) (*domain.CleanupReport, error)
+	})
+	if !ok {
+		return
+	}
+
+	report, err := previewer.GetRouteCleanupPreview(ctx, domainName)
+	if err != nil {
+		if isRemoteNotFoundError(err) {
+			return
+		}
+		diag.Warnings = append(diag.Warnings, "failed to load route cleanup preview: "+err.Error())
+		return
+	}
+	if report == nil {
+		return
+	}
+	if len(diag.OrphanedAttachments) == 0 {
+		diag.OrphanedAttachments = append(diag.OrphanedAttachments, report.PreservedAttachments...)
+	}
+	if len(diag.Volumes) == 0 {
+		diag.Volumes = cleanupVolumesForDiagnosis(report.PreservedVolumes)
+	}
+	diag.OrphanedEntities = append(diag.OrphanedEntities, report.OrphanedEntities...)
+	diag.Warnings = append(diag.Warnings, report.Warnings...)
+	diag.Hints = append(diag.Hints, report.Hints...)
 }
 
 func loadRouteDiagnosisRuntime(ctx context.Context, cp ControlPlane, domainName string, diag *routeDiagnosis) {
@@ -1165,6 +1200,9 @@ func loadRouteDiagnosisHealth(ctx context.Context, cp ControlPlane, domainName s
 }
 
 func loadRouteDiagnosisVolumes(ctx context.Context, cp ControlPlane, domainName string, diag *routeDiagnosis) {
+	if len(diag.Volumes) > 0 {
+		return
+	}
 	if volumes, err := cp.ListVolumes(ctx); err == nil {
 		if len(volumes) == 0 {
 			return
@@ -1184,6 +1222,9 @@ func routeDiagnosisVolumePrefix(ctx context.Context, cp ControlPlane) string {
 }
 
 func loadRouteDiagnosisOrphanedAttachments(ctx context.Context, cp ControlPlane, domainName string, diag *routeDiagnosis) {
+	if len(diag.OrphanedAttachments) > 0 {
+		return
+	}
 	lister, ok := cp.(interface {
 		ListOrphanedAttachments(context.Context) ([]domain.CleanupAttachment, error)
 	})
@@ -1195,8 +1236,16 @@ func loadRouteDiagnosisOrphanedAttachments(ctx context.Context, cp ControlPlane,
 	}
 }
 
+func cleanupVolumesForDiagnosis(volumes []domain.CleanupVolume) []dto.Volume {
+	result := make([]dto.Volume, 0, len(volumes))
+	for _, volume := range volumes {
+		result = append(result, dto.Volume{Name: volume.Name})
+	}
+	return result
+}
+
 func finalizeRouteDiagnosis(diag *routeDiagnosis) {
-	if !diag.Configured && diag.Runtime != nil {
+	if !diag.Configured && (diag.Runtime != nil || hasRouteCleanupEntity(diag.OrphanedEntities, "route_container")) {
 		diag.Warnings = append(diag.Warnings, "route is not configured but runtime state still exists")
 	}
 	if len(diag.Volumes) > 0 {
@@ -1205,6 +1254,15 @@ func finalizeRouteDiagnosis(diag *routeDiagnosis) {
 	if len(diag.OrphanedAttachments) > 0 {
 		diag.Hints = append(diag.Hints, fmt.Sprintf("run 'gordon routes purge %s --attachments' to review orphaned attachment cleanup for this route", diag.Domain))
 	}
+}
+
+func hasRouteCleanupEntity(entities []domain.CleanupOrphanedEntity, kind string) bool {
+	for _, entity := range entities {
+		if entity.Kind == kind {
+			return true
+		}
+	}
+	return false
 }
 
 type routeResourceScope struct {
@@ -1338,6 +1396,21 @@ func writeRouteDiagnosisSummary(out io.Writer, diag *routeDiagnosis) error {
 }
 
 func writeRouteDiagnosisLeftovers(out io.Writer, diag *routeDiagnosis) error {
+	for _, entity := range diag.OrphanedEntities {
+		label := entity.Name
+		if label == "" {
+			label = entity.ID
+		}
+		if label == "" {
+			label = entity.Kind
+		}
+		if entity.Status != "" {
+			label = fmt.Sprintf("%s (%s)", label, entity.Status)
+		}
+		if err := cliWriteLine(out, cliRenderWarning("Orphaned "+strings.ReplaceAll(entity.Kind, "_", " ")+": "+label)); err != nil {
+			return err
+		}
+	}
 	volumeLabel := "Volume:"
 	if !diag.Configured {
 		volumeLabel = "Preserved volume:"
@@ -1382,7 +1455,7 @@ type routePurgeOptions struct {
 }
 
 func runRoutePurgeCommand(ctx context.Context, domainName string, out io.Writer, opts routePurgeOptions, jsonOut bool) error {
-	handle, err := resolveControlPlaneForRouteDomain(ctx, domainName)
+	handle, err := resolveControlPlaneForRouteCleanupDomain(ctx, domainName)
 	if err != nil {
 		return err
 	}
@@ -1406,6 +1479,7 @@ func runRoutePurge(ctx context.Context, cp ControlPlane, domainName string, opts
 	if diag.Runtime != nil && diag.Runtime.ContainerID != "" {
 		report.OrphanedEntities = append(report.OrphanedEntities, domain.CleanupOrphanedEntity{Kind: "route_container", ID: diag.Runtime.ContainerID, Status: diag.Runtime.ContainerStatus, Reason: "route runtime state matched purge target"})
 	}
+	report.OrphanedEntities = append(report.OrphanedEntities, diag.OrphanedEntities...)
 	if opts.Volumes {
 		for _, volume := range diag.Volumes {
 			report.PreservedVolumes = append(report.PreservedVolumes, domain.CleanupVolume{Name: volume.Name, Reason: "volume purge requires explicit --volumes and runtime support"})
@@ -1511,7 +1585,10 @@ Examples:
 				Image:  image,
 			}
 
-			client, isRemote := GetRemoteClient()
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
 			if isRemote {
 				if err := client.AddRoute(ctx, route); err != nil {
 					return fmt.Errorf("failed to add route: %w", err)
@@ -1568,7 +1645,7 @@ Examples:
 				}
 			}
 
-			handle, err := resolveControlPlaneForRouteDomain(ctx, routeDomain)
+			handle, err := resolveControlPlaneForRouteCleanupDomain(ctx, routeDomain)
 			if err != nil {
 				return err
 			}

--- a/internal/adapters/in/cli/routes_test.go
+++ b/internal/adapters/in/cli/routes_test.go
@@ -809,6 +809,30 @@ func TestRenderRoutesListSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T
 	assert.Contains(t, rendered, "No routes configured")
 }
 
+func TestLoadRoutesListRemoteSection_UsesInventoryEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/admin/routes" && r.URL.RawQuery == "":
+			_, _ = w.Write([]byte(`{"routes":[{"domain":"app.example.com","image":"app:latest"}]}`))
+		case r.URL.Path == "/admin/routes" && r.URL.RawQuery == "detailed=true":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"detailed route status unavailable"}`))
+		default:
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer srv.Close()
+
+	section, err := loadRoutesListRemoteSection(context.Background(), "prod", remote.RemoteEntry{URL: srv.URL})
+
+	require.NoError(t, err)
+	require.Empty(t, section.Error)
+	require.Len(t, section.Routes, 1)
+	assert.Equal(t, "app.example.com", section.Routes[0].Domain)
+	assert.Equal(t, "app:latest", section.Routes[0].Image)
+}
+
 func TestRenderRoutesStatusSections_HidesLocalErrorWhenRemoteIsUsable(t *testing.T) {
 	sections := []routeStatusSection{
 		{Kind: "local", Name: "local", Error: "failed to initialize local control plane"},
@@ -931,6 +955,8 @@ func TestBuildRouteDiagnosis_UsesConfiguredVolumePrefixForPreservedVolumes(t *te
 		case "/admin/routes/example.test":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"route not found"}`))
+		case "/admin/routes/example.test/cleanup":
+			_, _ = w.Write([]byte(`{"domain":"example.test","preserved_volumes":[{"name":"custom-example-test-data-docs"}]}`))
 		case "/admin/routes":
 			require.Equal(t, "detailed=true", r.URL.RawQuery)
 			_, _ = w.Write([]byte(`{"routes":[]}`))
@@ -984,6 +1010,40 @@ func TestBuildRouteDiagnosis_IncludesAttachmentVolumesWithDoubleUnderscoreOwnerE
 	assert.Equal(t, "gordon-gordon-app__example__test-postgres-var-lib-postgresql", diag.Volumes[0].Name)
 }
 
+func TestBuildRouteDiagnosis_UsesCleanupPreviewForRemovedRouteRuntimeState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/admin/routes/example.test":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"route not found"}`))
+		case "/admin/routes/example.test/cleanup":
+			_, _ = w.Write([]byte(`{"domain":"example.test","orphaned_entities":[{"kind":"route_container","id":"ctr-1","name":"gordon-example.test","status":"running"}],"preserved_attachments":[{"name":"old-postgres","container_id":"att-1","owner":"example.test"}],"preserved_volumes":[{"name":"gordon-example-test-data"}]}`))
+		case "/admin/routes":
+			require.Equal(t, "detailed=true", r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"routes":[]}`))
+		case "/admin/health":
+			_, _ = w.Write([]byte(`{"health":{}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cp := NewRemoteControlPlane(remote.NewClient(srv.URL))
+	diag, err := buildRouteDiagnosis(context.Background(), cp, "example.test")
+
+	require.NoError(t, err)
+	assert.False(t, diag.Configured)
+	require.Len(t, diag.OrphanedEntities, 1)
+	assert.Equal(t, "route_container", diag.OrphanedEntities[0].Kind)
+	require.Len(t, diag.OrphanedAttachments, 1)
+	assert.Equal(t, "old-postgres", diag.OrphanedAttachments[0].Name)
+	require.Len(t, diag.Volumes, 1)
+	assert.Equal(t, "gordon-example-test-data", diag.Volumes[0].Name)
+	assert.Contains(t, diag.Warnings, "route is not configured but runtime state still exists")
+}
+
 func TestBuildRouteDiagnosis_RemoteMissingRouteDoesNotWarnOnExpectedNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -991,6 +1051,8 @@ func TestBuildRouteDiagnosis_RemoteMissingRouteDoesNotWarnOnExpectedNotFound(t *
 		case "/admin/routes/missing.example.test":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"route not found"}`))
+		case "/admin/routes/missing.example.test/cleanup":
+			_, _ = w.Write([]byte(`{"domain":"missing.example.test"}`))
 		case "/admin/routes":
 			require.Equal(t, "detailed=true", r.URL.RawQuery)
 			_, _ = w.Write([]byte(`{"routes":[]}`))
@@ -1021,6 +1083,8 @@ func TestRunRoutePurge_VolumesUsesConfiguredVolumePrefix(t *testing.T) {
 		case "/admin/routes/example.test":
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"route not found"}`))
+		case "/admin/routes/example.test/cleanup":
+			_, _ = w.Write([]byte(`{"domain":"example.test","preserved_volumes":[{"name":"custom-example-test-data-docs"}]}`))
 		case "/admin/routes":
 			require.Equal(t, "detailed=true", r.URL.RawQuery)
 			_, _ = w.Write([]byte(`{"routes":[]}`))

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -628,6 +628,15 @@ func (h *Handler) handleRoutesGet(w http.ResponseWriter, r *http.Request, routeD
 		return
 	}
 
+	if parentDomain, ok := strings.CutSuffix(routeDomain, "/cleanup"); ok {
+		if parentDomain == "" {
+			h.sendError(w, http.StatusBadRequest, "domain required in path")
+			return
+		}
+		h.handleRouteCleanupPreview(w, r, parentDomain)
+		return
+	}
+
 	if parentDomain, ok := strings.CutSuffix(routeDomain, "/attachments"); ok {
 		if parentDomain == "" {
 			h.sendError(w, http.StatusBadRequest, "domain required in path")
@@ -648,6 +657,151 @@ func (h *Handler) handleRoutesGet(w http.ResponseWriter, r *http.Request, routeD
 		return
 	}
 	h.sendJSON(w, http.StatusOK, toRouteResponse(*route))
+}
+
+func (h *Handler) handleRouteCleanupPreview(w http.ResponseWriter, r *http.Request, routeDomain string) {
+	ctx := r.Context()
+	log := zerowrap.FromCtx(ctx)
+
+	if !HasAccess(ctx, domain.AdminResourceConfig, domain.AdminActionRead) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for config:read")
+		return
+	}
+	if !HasAccess(ctx, domain.AdminResourceVolumes, domain.AdminActionRead) {
+		h.sendError(w, http.StatusForbidden, "insufficient permissions for volumes:read")
+		return
+	}
+
+	previewer, ok := any(h.containerSvc).(interface {
+		PreviewRemovedRouteCleanup(context.Context, string) (*domain.CleanupReport, error)
+	})
+	if !ok {
+		log.Error().Str("domain", routeDomain).Msg("route cleanup preview unavailable")
+		h.sendError(w, http.StatusInternalServerError, "route cleanup preview unavailable")
+		return
+	}
+
+	report, err := previewer.PreviewRemovedRouteCleanup(ctx, routeDomain)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRouteDomainInvalid), errors.Is(err, domain.ErrRouteDomainEmpty):
+			h.sendError(w, http.StatusBadRequest, "invalid route domain")
+		default:
+			log.Error().Err(err).Str("domain", routeDomain).Msg("failed to inspect route cleanup state")
+			h.sendError(w, http.StatusInternalServerError, "failed to inspect route cleanup state")
+		}
+		return
+	}
+
+	if h.volumeSvc == nil {
+		log.Error().Str("domain", routeDomain).Msg("volume service not available for route cleanup preview")
+		h.sendError(w, http.StatusServiceUnavailable, "volume service not available")
+		return
+	}
+
+	volumes, err := h.volumeSvc.ListVolumes(ctx)
+	if err != nil {
+		log.Error().Err(err).Str("domain", routeDomain).Msg("failed to list volumes for route cleanup preview")
+		h.sendError(w, http.StatusInternalServerError, "failed to inspect route cleanup state")
+		return
+	}
+	report.PreservedVolumes = append(
+		report.PreservedVolumes,
+		matchingRouteCleanupVolumes(routeDomain, h.routeCleanupVolumePrefix(), volumes, report.PreservedAttachments)...,
+	)
+
+	h.sendJSON(w, http.StatusOK, dto.CleanupReportFromDomain(report))
+}
+
+func (h *Handler) routeCleanupVolumePrefix() string {
+	const defaultPrefix = "gordon"
+	if h.configSvc == nil {
+		return defaultPrefix
+	}
+	if volumeCfg, ok := any(h.configSvc).(interface{ GetVolumeConfig() (bool, string, bool) }); ok {
+		_, prefix, _ := volumeCfg.GetVolumeConfig()
+		if prefix != "" {
+			return prefix
+		}
+	}
+	return defaultPrefix
+}
+
+type routeCleanupVolumeScope struct {
+	containerNames map[string]struct{}
+	volumePrefixes []string
+}
+
+func newRouteCleanupVolumeScope(routeDomain, volumePrefix string, attachments []domain.CleanupAttachment) routeCleanupVolumeScope {
+	if volumePrefix == "" {
+		volumePrefix = "gordon"
+	}
+	scope := routeCleanupVolumeScope{
+		containerNames: make(map[string]struct{}),
+		volumePrefixes: []string{volumePrefix + "-" + strings.ReplaceAll(routeDomain, ".", "-") + "-"},
+	}
+	for _, name := range []string{
+		fmt.Sprintf("gordon-%s", routeDomain),
+		fmt.Sprintf("gordon-%s-new", routeDomain),
+		fmt.Sprintf("gordon-%s-next", routeDomain),
+	} {
+		scope.containerNames[name] = struct{}{}
+	}
+	for _, attachment := range attachments {
+		if attachment.Name == "" {
+			continue
+		}
+		scope.containerNames[attachment.Name] = struct{}{}
+		scope.volumePrefixes = append(scope.volumePrefixes, volumePrefix+"-"+attachment.Name+"-")
+		for _, name := range routeAttachmentContainerNamesForCleanup(routeDomain, attachment.Name) {
+			scope.containerNames[name] = struct{}{}
+			scope.volumePrefixes = append(scope.volumePrefixes, volumePrefix+"-"+name+"-")
+		}
+	}
+	return scope
+}
+
+func routeAttachmentContainerNamesForCleanup(routeDomain, serviceName string) []string {
+	if serviceName == "" {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("gordon-%s-%s", domain.SanitizeDomainForContainer(routeDomain), serviceName),
+		fmt.Sprintf("gordon-%s-%s", domain.SanitizeDomainForContainerLegacy(routeDomain), serviceName),
+	}
+}
+
+func matchingRouteCleanupVolumes(routeDomain, volumePrefix string, volumes []*domain.VolumeInfo, attachments []domain.CleanupAttachment) []domain.CleanupVolume {
+	scope := newRouteCleanupVolumeScope(routeDomain, volumePrefix, attachments)
+	matched := make([]domain.CleanupVolume, 0)
+	for _, volume := range volumes {
+		if volume == nil || !scope.matches(volume) {
+			continue
+		}
+		matched = append(matched, domain.CleanupVolume{
+			Name:          volume.Name,
+			ContainerPath: "",
+			Reason:        "volume preserved for explicit cleanup review",
+		})
+	}
+	return matched
+}
+
+func (s routeCleanupVolumeScope) matches(volume *domain.VolumeInfo) bool {
+	if volume == nil {
+		return false
+	}
+	for _, containerName := range volume.Containers {
+		if _, ok := s.containerNames[containerName]; ok {
+			return true
+		}
+	}
+	for _, prefix := range s.volumePrefixes {
+		if strings.HasPrefix(volume.Name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) handleRoutesPost(w http.ResponseWriter, r *http.Request) {
@@ -823,9 +977,15 @@ func (h *Handler) handleRoutesByImage(w http.ResponseWriter, r *http.Request, pa
 		return
 	}
 
-	imageName := strings.TrimPrefix(path, "/routes/by-image/")
-	if imageName == "" || imageName == "/routes/by-image" {
+	rawImageName := strings.TrimPrefix(path, "/routes/by-image/")
+	if rawImageName == "" || rawImageName == "/routes/by-image" {
 		h.sendError(w, http.StatusBadRequest, "image name required in path")
+		return
+	}
+
+	imageName, err := url.PathUnescape(rawImageName)
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, "invalid image name encoding")
 		return
 	}
 
@@ -1519,9 +1679,14 @@ func (h *Handler) handleTags(w http.ResponseWriter, r *http.Request, path string
 		return
 	}
 
-	repository := strings.TrimPrefix(path, "/tags/")
-	if repository == "" || repository == "/tags" {
+	rawRepository := strings.TrimPrefix(path, "/tags/")
+	if rawRepository == "" || rawRepository == "/tags" {
 		h.sendError(w, http.StatusBadRequest, "repository name required in path")
+		return
+	}
+	repository, err := url.PathUnescape(rawRepository)
+	if err != nil {
+		h.sendError(w, http.StatusBadRequest, "invalid repository name encoding")
 		return
 	}
 	if err := validation.ValidateRepositoryName(repository); err != nil {

--- a/internal/adapters/in/http/admin/handler_test.go
+++ b/internal/adapters/in/http/admin/handler_test.go
@@ -29,6 +29,18 @@ type stubImageService struct {
 	pruneFunc      func(context.Context, domain.ImagePruneOptions) (domain.ImagePruneReport, error)
 }
 
+type previewContainerService struct {
+	*inmocks.MockContainerService
+	preview func(context.Context, string) (*domain.CleanupReport, error)
+}
+
+func (s *previewContainerService) PreviewRemovedRouteCleanup(ctx context.Context, routeDomain string) (*domain.CleanupReport, error) {
+	if s.preview == nil {
+		return nil, nil
+	}
+	return s.preview(ctx, routeDomain)
+}
+
 type noopReloadTrigger struct{}
 
 func (noopReloadTrigger) Trigger(context.Context) error { return nil }
@@ -685,6 +697,34 @@ func TestHandler_AttachmentsByImageGet_RequiresReadScope(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.JSONEq(t, `{"error":"insufficient permissions for config:read"}`, rec.Body.String())
+}
+
+func TestHandler_RoutesByImageGet_URLDecodedImage(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+	})
+
+	configSvc.EXPECT().FindRoutesByImage(mock.Anything, "registry/org/image:tag").Return([]domain.Route{{
+		Domain: "app.example.com",
+		Image:  "registry/org/image:tag",
+	}}).Once()
+
+	req := httptest.NewRequest("GET", "/admin/routes/by-image/registry%2Forg%2Fimage:tag", nil)
+	req = req.WithContext(ctxWithScopes("admin:routes:read"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"image":"registry/org/image:tag","routes":[{"domain":"app.example.com","image":"registry/org/image:tag","https":false}]}`, rec.Body.String())
 }
 
 func TestHandler_RoutesDelete_RequiresWriteScope(t *testing.T) {
@@ -1566,6 +1606,58 @@ func TestHandler_RoutesGet_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestHandler_RouteCleanupPreview_RequiresRoutesConfigAndVolumesReadScopes(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	volumeSvc := inmocks.NewMockVolumeService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+	containerMock := inmocks.NewMockContainerService(t)
+	containerSvc := &previewContainerService{
+		MockContainerService: containerMock,
+		preview: func(_ context.Context, routeDomain string) (*domain.CleanupReport, error) {
+			return &domain.CleanupReport{
+				Domain:           routeDomain,
+				OrphanedEntities: []domain.CleanupOrphanedEntity{{Kind: "route_container", ID: "ctr-1", Status: "running"}},
+			}, nil
+		},
+	}
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.VolumeSvc = volumeSvc
+		d.SecretSvc = secretSvc
+	})
+
+	volumeSvc.EXPECT().ListVolumes(mock.Anything).Return([]*domain.VolumeInfo{{Name: "gordon-app-example-com-data"}}, nil).Once()
+
+	req := httptest.NewRequest("GET", "/admin/routes/app.example.com/cleanup", nil)
+	req = req.WithContext(ctxWithScopes("admin:routes:read", "admin:config:read", "admin:volumes:read"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var report dto.CleanupReport
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&report))
+	require.Len(t, report.OrphanedEntities, 1)
+	assert.Equal(t, "route_container", report.OrphanedEntities[0].Kind)
+	require.Len(t, report.PreservedVolumes, 1)
+	assert.Equal(t, "gordon-app-example-com-data", report.PreservedVolumes[0].Name)
+
+	for _, scopes := range [][]string{
+		{"admin:routes:read", "admin:volumes:read"},
+		{"admin:routes:read", "admin:config:read"},
+	} {
+		req := httptest.NewRequest("GET", "/admin/routes/app.example.com/cleanup", nil)
+		req = req.WithContext(ctxWithScopes(scopes...))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	}
+}
+
 func TestHandler_RoutesPost_MissingFields(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -2091,6 +2183,33 @@ func TestHandler_Tags_Error(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.NotContains(t, rec.Body.String(), "registry error")
+}
+
+func TestHandler_Tags_URLDecodedRepository(t *testing.T) {
+	configSvc := inmocks.NewMockConfigService(t)
+	authSvc := inmocks.NewMockAuthService(t)
+	containerSvc := inmocks.NewMockContainerService(t)
+	secretSvc := inmocks.NewMockSecretService(t)
+	registrySvc := inmocks.NewMockRegistryService(t)
+
+	handler := newTestHandler(t, func(d *HandlerDeps) {
+		d.ConfigSvc = configSvc
+		d.AuthSvc = authSvc
+		d.ContainerSvc = containerSvc
+		d.SecretSvc = secretSvc
+		d.RegistrySvc = registrySvc
+	})
+
+	registrySvc.EXPECT().ListTags(mock.Anything, "repo/app").Return([]string{"latest"}, nil)
+
+	req := httptest.NewRequest("GET", "/admin/tags/repo%2Fapp", nil)
+	req = req.WithContext(ctxWithScopes("admin:status:read"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"repository":"repo/app","tags":["latest"]}`, rec.Body.String())
 }
 
 func TestHandler_AttachmentSecretsPost_RequiresWriteScope(t *testing.T) {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -516,6 +516,7 @@ func createServicesWithOptions(ctx context.Context, v *viper.Viper, cfg Config, 
 	}
 
 	si.svc.reloadCoordinator = newReloadCoordinator(v, si.svc.configSvc, si.svc.proxySvc, nil, si.svc.eventBus, si.svc.publicTLSSvc, log)
+	si.registerReloadCoordinatorHooks()
 
 	si.initHandlers()
 
@@ -695,6 +696,21 @@ func (si *serviceInit) initRuntimeAndProxy() error {
 }
 
 // initHandlers creates the auth, health, log, preview, and admin handlers.
+func (si *serviceInit) registerReloadCoordinatorHooks() {
+	if si.svc.reloadCoordinator == nil || si.svc.containerSvc == nil {
+		return
+	}
+
+	si.svc.reloadCoordinator.SetContainerConfigApplier(func(reloadCfg Config) error {
+		containerCfg, err := buildContainerServiceConfig(si.ctx, si.v, reloadCfg, si.svc, si.log)
+		if err != nil {
+			return err
+		}
+		si.svc.containerSvc.UpdateConfig(containerCfg)
+		return nil
+	})
+}
+
 func (si *serviceInit) initHandlers() {
 	if si.svc.authSvc != nil {
 		internalAuth := authhandler.InternalAuth{
@@ -1608,10 +1624,11 @@ type reloadCoordinator struct {
 	lastRun  time.Time
 	debounce time.Duration
 
-	configSvc      configReloader
-	v              *viper.Viper
-	proxySvc       proxyConfigUpdater
-	registryLimits interface {
+	configSvc            configReloader
+	v                    *viper.Viper
+	proxySvc             proxyConfigUpdater
+	applyContainerConfig func(Config) error
+	registryLimits       interface {
 		UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
 	}
 	eventBus  out.EventPublisher
@@ -1640,6 +1657,12 @@ func (c *reloadCoordinator) SetRegistryLimits(limits interface {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.registryLimits = limits
+}
+
+func (c *reloadCoordinator) SetContainerConfigApplier(apply func(Config) error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.applyContainerConfig = apply
 }
 
 func (c *reloadCoordinator) Trigger(ctx context.Context) error {
@@ -1693,6 +1716,12 @@ func (c *reloadCoordinator) applyLoadedConfig(ctx context.Context, now time.Time
 	c.proxySvc.UpdateConfig(reloadedProxy.proxyConfig)
 	if c.registryLimits != nil {
 		c.registryLimits.UpdateBlobLimits(reloadedProxy.maxBlobChunkSize, reloadedProxy.maxBlobSize)
+	}
+	if c.applyContainerConfig != nil {
+		if err := c.applyContainerConfig(reloadCfg); err != nil {
+			c.log.Error().Err(err).Msg("failed to apply container config on reload")
+			return fmt.Errorf("failed to apply container config on reload: %w", err)
+		}
 	}
 
 	if c.eventBus != nil {
@@ -1813,23 +1842,21 @@ func buildDNSConfig(cfg Config) (publictls.DNSConfig, error) {
 	return dnsCfg, nil
 }
 
-// createContainerService creates the container service with configuration.
-func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc *services, log zerowrap.Logger) (*container.Service, error) {
-	// Parse and validate container resource limits from config
+func buildContainerServiceConfig(ctx context.Context, v *viper.Viper, cfg Config, svc *services, log zerowrap.Logger) (container.Config, error) {
 	if cfg.Containers.CPULimit < 0 {
-		return nil, fmt.Errorf("containers.cpu_limit must be >= 0 (got %f)", cfg.Containers.CPULimit)
+		return container.Config{}, fmt.Errorf("containers.cpu_limit must be >= 0 (got %f)", cfg.Containers.CPULimit)
 	}
 	if cfg.Containers.PidsLimit < 0 {
-		return nil, fmt.Errorf("containers.pids_limit must be >= 0 (got %d)", cfg.Containers.PidsLimit)
+		return container.Config{}, fmt.Errorf("containers.pids_limit must be >= 0 (got %d)", cfg.Containers.PidsLimit)
 	}
 	var defaultMemoryLimit int64
 	if cfg.Containers.MemoryLimit != "" {
 		parsed, err := bytesize.Parse(cfg.Containers.MemoryLimit)
 		if err != nil {
-			return nil, fmt.Errorf("invalid containers.memory_limit %q: %w", cfg.Containers.MemoryLimit, err)
+			return container.Config{}, fmt.Errorf("invalid containers.memory_limit %q: %w", cfg.Containers.MemoryLimit, err)
 		}
 		if parsed <= 0 {
-			return nil, fmt.Errorf("containers.memory_limit must be positive (got %q)", cfg.Containers.MemoryLimit)
+			return container.Config{}, fmt.Errorf("containers.memory_limit must be positive (got %q)", cfg.Containers.MemoryLimit)
 		}
 		defaultMemoryLimit = parsed
 	}
@@ -1881,17 +1908,15 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 
 	if containerConfig.RegistryAuthEnabled {
 		if svc.authSvc == nil {
-			return nil, fmt.Errorf("authentication service unavailable: cannot generate registry service token")
+			return container.Config{}, fmt.Errorf("authentication service unavailable: cannot generate registry service token")
 		}
 		expiry, err := resolveServiceTokenExpiry(cfg)
 		if err != nil {
-			return nil, log.WrapErr(err, "failed to resolve service token expiry")
+			return container.Config{}, log.WrapErr(err, "failed to resolve service token expiry")
 		}
-		// Note: Service tokens are not auto-refreshed. If the token expires during
-		// container runtime, the container will need to be recreated to get a new token.
 		serviceToken, err := svc.authSvc.GenerateToken(ctx, serviceTokenSubject, []string{"pull"}, expiry)
 		if err != nil {
-			return nil, log.WrapErr(err, "failed to generate registry service token")
+			return container.Config{}, log.WrapErr(err, "failed to generate registry service token")
 		}
 		log.Info().
 			Str("subject", serviceTokenSubject).
@@ -1903,6 +1928,15 @@ func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc
 		log.Warn().Msg("registry auth disabled; container image pulls will use unauthenticated mode")
 	}
 
+	return containerConfig, nil
+}
+
+// createContainerService creates the container service with configuration.
+func createContainerService(ctx context.Context, v *viper.Viper, cfg Config, svc *services, log zerowrap.Logger) (*container.Service, error) {
+	containerConfig, err := buildContainerServiceConfig(ctx, v, cfg, svc, log)
+	if err != nil {
+		return nil, err
+	}
 	return container.NewService(svc.runtime, svc.envLoader, svc.eventBus, svc.logWriter, containerConfig, svc.configSvc), nil
 }
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -701,8 +701,8 @@ func (si *serviceInit) registerReloadCoordinatorHooks() {
 		return
 	}
 
-	si.svc.reloadCoordinator.SetContainerConfigApplier(func(reloadCfg Config) error {
-		containerCfg, err := buildContainerServiceConfig(si.ctx, si.v, reloadCfg, si.svc, si.log)
+	si.svc.reloadCoordinator.SetContainerConfigApplier(func(reloadCtx context.Context, reloadCfg Config) error {
+		containerCfg, err := buildContainerServiceConfig(reloadCtx, si.v, reloadCfg, si.svc, si.log)
 		if err != nil {
 			return err
 		}
@@ -1627,7 +1627,7 @@ type reloadCoordinator struct {
 	configSvc            configReloader
 	v                    *viper.Viper
 	proxySvc             proxyConfigUpdater
-	applyContainerConfig func(Config) error
+	applyContainerConfig func(context.Context, Config) error
 	registryLimits       interface {
 		UpdateBlobLimits(maxBlobChunkSize, maxBlobSize int64)
 	}
@@ -1659,7 +1659,7 @@ func (c *reloadCoordinator) SetRegistryLimits(limits interface {
 	c.registryLimits = limits
 }
 
-func (c *reloadCoordinator) SetContainerConfigApplier(apply func(Config) error) {
+func (c *reloadCoordinator) SetContainerConfigApplier(apply func(context.Context, Config) error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.applyContainerConfig = apply
@@ -1713,15 +1713,15 @@ func (c *reloadCoordinator) applyLoadedConfig(ctx context.Context, now time.Time
 		return fmt.Errorf("failed to parse proxy config on reload: %w", err)
 	}
 
-	c.proxySvc.UpdateConfig(reloadedProxy.proxyConfig)
-	if c.registryLimits != nil {
-		c.registryLimits.UpdateBlobLimits(reloadedProxy.maxBlobChunkSize, reloadedProxy.maxBlobSize)
-	}
 	if c.applyContainerConfig != nil {
-		if err := c.applyContainerConfig(reloadCfg); err != nil {
+		if err := c.applyContainerConfig(ctx, reloadCfg); err != nil {
 			c.log.Error().Err(err).Msg("failed to apply container config on reload")
 			return fmt.Errorf("failed to apply container config on reload: %w", err)
 		}
+	}
+	c.proxySvc.UpdateConfig(reloadedProxy.proxyConfig)
+	if c.registryLimits != nil {
+		c.registryLimits.UpdateBlobLimits(reloadedProxy.maxBlobChunkSize, reloadedProxy.maxBlobSize)
 	}
 
 	if c.eventBus != nil {

--- a/internal/app/run_reload_test.go
+++ b/internal/app/run_reload_test.go
@@ -116,11 +116,13 @@ func (r *registryLimitsRecorder) UpdateBlobLimits(maxBlobChunkSize, maxBlobSize 
 
 type containerConfigApplyRecorder struct {
 	calls int
+	ctx   context.Context
 	cfg   Config
 }
 
-func (r *containerConfigApplyRecorder) Apply(cfg Config) error {
+func (r *containerConfigApplyRecorder) Apply(ctx context.Context, cfg Config) error {
 	r.calls++
+	r.ctx = ctx
 	r.cfg = cfg
 	return nil
 }
@@ -256,7 +258,7 @@ func TestServiceInit_RegisterReloadCoordinatorHooks_WiresContainerConfigApplier(
 	reloadCfg.Server.RegistryPort = 5000
 	reloadCfg.Images.AllowedRegistries = []string{"docker.io"}
 
-	require.NoError(t, si.svc.reloadCoordinator.applyContainerConfig(reloadCfg))
+	require.NoError(t, si.svc.reloadCoordinator.applyContainerConfig(ctx, reloadCfg))
 }
 func TestReloadCoordinator_DebouncesRepeatedWatchCallbacks(t *testing.T) {
 	ctx := context.Background()

--- a/internal/app/run_reload_test.go
+++ b/internal/app/run_reload_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/in/http/registry"
 	"github.com/bnema/gordon/internal/domain"
+	cfgusecase "github.com/bnema/gordon/internal/usecase/config"
+	"github.com/bnema/gordon/internal/usecase/container"
 	"github.com/bnema/gordon/internal/usecase/proxy"
 )
 
@@ -112,6 +114,17 @@ func (r *registryLimitsRecorder) UpdateBlobLimits(maxBlobChunkSize, maxBlobSize 
 	r.maxBlobSize = maxBlobSize
 }
 
+type containerConfigApplyRecorder struct {
+	calls int
+	cfg   Config
+}
+
+func (r *containerConfigApplyRecorder) Apply(cfg Config) error {
+	r.calls++
+	r.cfg = cfg
+	return nil
+}
+
 type eventBusRecorder struct {
 	mu        sync.Mutex
 	calls     int
@@ -179,22 +192,30 @@ func TestReloadCoordinator_ApplyLoadedConfig_RebuildsProxyConfigAndPublishesEven
 	v.Set("server.max_blob_size", "8MB")
 	v.Set("server.max_proxy_response_size", "7MB")
 	v.Set("server.max_concurrent_connections", 99)
+	v.Set("server.legacy_registry_domains", []string{"old.example.com"})
+	v.Set("images.allowed_registries", []string{"docker.io"})
 
 	reloadSvc := &reloadRecorder{}
 	proxySvc := &proxyRecorder{}
 	events := &eventBusRecorder{}
+	containerCfg := &containerConfigApplyRecorder{}
 
 	registryLimits := &registryLimitsRecorder{}
 	coord := newReloadCoordinator(v, reloadSvc, proxySvc, registryLimits, events, nil, zerowrap.Default())
+	coord.SetContainerConfigApplier(containerCfg.Apply)
 	require.NoError(t, coord.ApplyLoadedConfig(ctx))
 
 	require.Equal(t, 0, reloadSvc.Calls())
 	require.Equal(t, 1, proxySvc.calls)
 	require.Equal(t, 1, events.Calls())
 	require.Equal(t, 1, registryLimits.calls)
+	require.Equal(t, 1, containerCfg.calls)
 	require.Equal(t, int64(6<<20), registryLimits.maxBlobChunkSize)
 	require.Equal(t, int64(8<<20), registryLimits.maxBlobSize)
 	require.Equal(t, domain.EventConfigReload, events.eventType)
+	require.Equal(t, "reload.example.com", containerCfg.cfg.Server.GordonDomain)
+	require.Equal(t, []string{"old.example.com"}, containerCfg.cfg.Server.LegacyRegistryDomains)
+	require.Equal(t, []string{"docker.io"}, containerCfg.cfg.Images.AllowedRegistries)
 	require.Equal(t, proxy.Config{
 		RegistryDomain:     "reload.example.com",
 		RegistryPort:       5000,
@@ -204,6 +225,39 @@ func TestReloadCoordinator_ApplyLoadedConfig_RebuildsProxyConfigAndPublishesEven
 	}, proxySvc.config)
 }
 
+func TestServiceInit_RegisterReloadCoordinatorHooks_WiresContainerConfigApplier(t *testing.T) {
+	ctx := context.Background()
+	v := viper.New()
+	v.Set("server.gordon_domain", "reload.example.com")
+	v.Set("server.registry_port", 5000)
+
+	configSvc := cfgusecase.NewService(v, nil)
+	require.NoError(t, configSvc.Load(ctx))
+
+	si := &serviceInit{
+		ctx: ctx,
+		v:   v,
+		cfg: Config{},
+		log: zerowrap.Default(),
+		svc: &services{
+			configSvc:         configSvc,
+			containerSvc:      container.NewService(nil, nil, nil, nil, container.Config{}, configSvc),
+			internalRegUser:   "gordon",
+			internalRegPass:   "secret",
+			reloadCoordinator: newReloadCoordinator(v, &reloadRecorder{}, &proxyRecorder{}, nil, nil, nil, zerowrap.Default()),
+		},
+	}
+
+	si.registerReloadCoordinatorHooks()
+	require.NotNil(t, si.svc.reloadCoordinator.applyContainerConfig)
+
+	reloadCfg := Config{}
+	reloadCfg.Server.GordonDomain = "reload.example.com"
+	reloadCfg.Server.RegistryPort = 5000
+	reloadCfg.Images.AllowedRegistries = []string{"docker.io"}
+
+	require.NoError(t, si.svc.reloadCoordinator.applyContainerConfig(reloadCfg))
+}
 func TestReloadCoordinator_DebouncesRepeatedWatchCallbacks(t *testing.T) {
 	ctx := context.Background()
 	v := viper.New()

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -1159,6 +1159,53 @@ func (s *Service) Stop(ctx context.Context, containerID string) error {
 	return nil
 }
 
+// PreviewRemovedRouteCleanup reports retained runtime state for a route that is
+// no longer configured, without mutating containers or in-memory tracking.
+func (s *Service) PreviewRemovedRouteCleanup(ctx context.Context, domainName string) (*domain.CleanupReport, error) {
+	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+	if !ok {
+		return &domain.CleanupReport{Domain: domainName}, domain.ErrRouteDomainInvalid
+	}
+	domainName = canonicalDomain
+
+	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
+		zerowrap.FieldLayer:   "usecase",
+		zerowrap.FieldUseCase: "PreviewRemovedRouteCleanup",
+		"domain":              domainName,
+	})
+	log := zerowrap.FromCtx(ctx)
+
+	report := &domain.CleanupReport{Domain: domainName}
+
+	unlock, err := s.acquireDomainDeployLock(ctx, domainName)
+	if err != nil {
+		return report, err
+	}
+	defer unlock()
+
+	allContainers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		return report, log.WrapErr(err, "failed to list containers for removed route cleanup preview")
+	}
+
+	routeContainers := routeContainersForDomain(allContainers, domainName)
+	report.PreservedAttachments = preservedAttachmentsForDomain(allContainers, domainName)
+	if len(report.PreservedAttachments) > 0 {
+		report.Hints = append(report.Hints, "attachments preserved; remove or purge attachments explicitly if they are no longer needed")
+	}
+	for _, c := range routeContainers {
+		report.OrphanedEntities = append(report.OrphanedEntities, domain.CleanupOrphanedEntity{
+			Kind:   "route_container",
+			ID:     c.ID,
+			Name:   c.Name,
+			Status: c.Status,
+			Reason: "route runtime state still exists after route removal",
+		})
+	}
+
+	return report, nil
+}
+
 // ReconcileRemovedRoute removes active runtime containers for a route that was
 // removed from configuration while preserving stateful resources for explicit
 // follow-up cleanup. It intentionally removes only main route containers, never
@@ -1510,7 +1557,7 @@ func (s *Service) ListAttachments(ctx context.Context, domainName string) []doma
 	return s.getAttachmentsForDomain(ctx, domainName)
 }
 
-// ListOrphanedAttachments returns running attachment containers no longer configured.
+// ListOrphanedAttachments returns managed attachment containers no longer configured.
 func (s *Service) ListOrphanedAttachments(ctx context.Context) ([]domain.CleanupAttachment, error) {
 	containers, err := s.runtime.ListContainers(ctx, true)
 	if err != nil {
@@ -1611,7 +1658,7 @@ func cleanupAttachmentsFromContainers(containers []*domain.Container) []domain.C
 }
 
 func isManagedAttachment(c *domain.Container) bool {
-	return c != nil && c.Status == string(domain.ContainerStatusRunning) && c.Labels != nil && c.Labels[domain.LabelManaged] == "true" && c.Labels[domain.LabelAttachment] == "true"
+	return c != nil && c.Labels != nil && c.Labels[domain.LabelManaged] == "true" && c.Labels[domain.LabelAttachment] == "true"
 }
 
 func attachmentImage(c *domain.Container) string {
@@ -1694,6 +1741,10 @@ func (s *Service) HealthCheck(ctx context.Context) map[string]bool {
 }
 
 // SyncContainers synchronizes containers with runtime state.
+func isTrackedManagedContainerStatus(status string) bool {
+	return status == "" || status == string(domain.ContainerStatusRunning) || status == "restarting"
+}
+
 func (s *Service) SyncContainers(ctx context.Context) error {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
@@ -1712,7 +1763,7 @@ func (s *Service) SyncContainers(ctx context.Context) error {
 	managed := make(map[string]*domain.Container)
 	attachments := make(map[string][]string)
 	for _, c := range allContainers {
-		if c.Status != "" && c.Status != string(domain.ContainerStatusRunning) {
+		if !isTrackedManagedContainerStatus(c.Status) {
 			continue
 		}
 		if c.Labels == nil || c.Labels[domain.LabelManaged] != "true" {
@@ -2580,15 +2631,16 @@ func (s *Service) cleanupOrphanedContainers(ctx context.Context, domainName stri
 
 	for _, c := range allContainers {
 		if (c.Name == expectedName || c.Name == expectedNewName || c.Name == expectedNextName) && c.ID != skipContainerID {
-			// Skip any running container regardless of name — a running
-			// temp container may be actively serving traffic while the
-			// new container stabilizes, or may be from a concurrent deploy.
-			if c.Status == "running" {
+			// Skip any container that is still active in the runtime, including
+			// restart backoff, regardless of name — a temp container may be
+			// serving traffic while the new container stabilizes, or may be from
+			// a concurrent deploy.
+			if c.Status == "running" || c.Status == "restarting" {
 				log.Debug().
 					Str(zerowrap.FieldEntityID, c.ID).
 					Str("container_name", c.Name).
 					Str(zerowrap.FieldStatus, c.Status).
-					Msg("skipping running container during orphan cleanup")
+					Msg("skipping active container during orphan cleanup")
 				continue
 			}
 

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1277,6 +1277,33 @@ func TestService_SyncContainers(t *testing.T) {
 	assert.Contains(t, svc.containers, "app2.example.com")
 }
 
+func TestService_SyncContainers_KeepsRestartingManagedContainers(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	ctx := testContext()
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		{
+			ID:     "container-1",
+			Name:   "gordon-app1.example.com",
+			Status: "restarting",
+			Labels: map[string]string{
+				"gordon.domain":  "app1.example.com",
+				"gordon.managed": "true",
+			},
+		},
+	}, nil)
+
+	err := svc.SyncContainers(ctx)
+
+	assert.NoError(t, err)
+	assert.Len(t, svc.containers, 1)
+	assert.Contains(t, svc.containers, "app1.example.com")
+}
+
 func TestService_Shutdown(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
@@ -3566,6 +3593,27 @@ func TestService_Deploy_OrphanCleanup_NeverKillsRunningCanonical(t *testing.T) {
 	assert.Equal(t, "new-container", tracked.ID)
 }
 
+func TestService_CleanupOrphanedContainers_SkipsRestartingContainer(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	svc := NewService(runtime, envLoader, eventBus, nil, Config{}, nil)
+	ctx := testContext()
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		{
+			ID:     "restarting-container",
+			Name:   "gordon-test.example.com",
+			Status: "restarting",
+		},
+	}, nil)
+
+	err := svc.cleanupOrphanedContainers(ctx, "test.example.com", "")
+
+	assert.NoError(t, err)
+}
+
 // TestService_Deploy_RollbackOnPostSwitchCrash verifies that if the new container crashes
 // during the post-switch stabilization window, traffic is automatically rolled back to the
 // old container: the old container is restored as tracked, the proxy cache is re-invalidated,
@@ -4491,6 +4539,55 @@ func TestService_ReconcileRemovedRoute_IsIdempotentWhenNoContainerExists(t *test
 	assert.Contains(t, report.Warnings, "no active route container found for removed route")
 }
 
+func TestService_PreviewRemovedRouteCleanup_ReportsRuntimeStateWithoutMutation(t *testing.T) {
+	ctx := testContext()
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, mocks.NewMockEventPublisher(t), nil, Config{}, nil)
+
+	mainContainer := &domain.Container{
+		ID:     "route-container",
+		Name:   "gordon-app.example.com",
+		Status: string(domain.ContainerStatusRunning),
+		Labels: map[string]string{
+			domain.LabelManaged: "true",
+			domain.LabelRoute:   "app.example.com",
+			domain.LabelDomain:  "app.example.com",
+		},
+	}
+	attachment := &domain.Container{
+		ID:     "attachment-container",
+		Name:   "gordon-app-example-com-postgres",
+		Status: string(domain.ContainerStatusRunning),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: "app.example.com",
+		},
+	}
+
+	svc.mu.Lock()
+	svc.containers["app.example.com"] = mainContainer
+	svc.attachments["app.example.com"] = []string{attachment.ID}
+	svc.managedCount = 1
+	svc.mu.Unlock()
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{mainContainer, attachment}, nil).Once()
+
+	report, err := svc.PreviewRemovedRouteCleanup(ctx, "app.example.com")
+	require.NoError(t, err)
+	require.NotNil(t, report)
+
+	require.Len(t, report.OrphanedEntities, 1)
+	assert.Equal(t, "route_container", report.OrphanedEntities[0].Kind)
+	assert.Equal(t, mainContainer.ID, report.OrphanedEntities[0].ID)
+	require.Len(t, report.PreservedAttachments, 1)
+	assert.Equal(t, attachment.ID, report.PreservedAttachments[0].ContainerID)
+	assert.Contains(t, report.Hints, "attachments preserved; remove or purge attachments explicitly if they are no longer needed")
+
+	_, exists := svc.Get(ctx, "app.example.com")
+	assert.True(t, exists, "preview should not clear route tracking")
+}
+
 func TestService_ReconcileRemovedRoute_CanonicalizesDomainBeforeCleanup(t *testing.T) {
 	ctx := testContext()
 	runtime := mocks.NewMockContainerRuntime(t)
@@ -4659,7 +4756,7 @@ func TestService_CleanupOrphanedAttachments_StopRemovesContainerButPreservesData
 	runtime := mocks.NewMockContainerRuntime(t)
 	logWriter := mocks.NewMockContainerLogWriter(t)
 	svc := NewService(runtime, nil, mocks.NewMockEventPublisher(t), logWriter, Config{}, nil)
-	orphan := &domain.Container{
+	running := &domain.Container{
 		ID:     "postgres-1",
 		Name:   "gordon-app-example-com-postgres",
 		Image:  "postgres:16",
@@ -4671,20 +4768,35 @@ func TestService_CleanupOrphanedAttachments_StopRemovesContainerButPreservesData
 			domain.LabelImage:      "postgres:16",
 		},
 	}
+	stopped := &domain.Container{
+		ID:     "redis-1",
+		Name:   "gordon-app-example-com-redis",
+		Image:  "redis:7",
+		Status: string(domain.ContainerStatusExited),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: "app.example.com",
+			domain.LabelImage:      "redis:7",
+		},
+	}
 	svc.mu.Lock()
-	svc.attachments["app.example.com"] = []string{orphan.ID}
+	svc.attachments["app.example.com"] = []string{running.ID, stopped.ID}
 	svc.mu.Unlock()
 
-	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{orphan}, nil).Once()
-	logWriter.EXPECT().StopLogging(orphan.ID).Return(nil).Once()
-	runtime.EXPECT().StopContainer(mock.Anything, orphan.ID).Return(nil).Once()
-	runtime.EXPECT().RemoveContainer(mock.Anything, orphan.ID, true).Return(nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{running, stopped}, nil).Once()
+	logWriter.EXPECT().StopLogging(running.ID).Return(nil).Once()
+	runtime.EXPECT().StopContainer(mock.Anything, running.ID).Return(nil).Once()
+	runtime.EXPECT().RemoveContainer(mock.Anything, running.ID, true).Return(nil).Once()
+	logWriter.EXPECT().StopLogging(stopped.ID).Return(nil).Once()
+	runtime.EXPECT().RemoveContainer(mock.Anything, stopped.ID, true).Return(nil).Once()
 
 	report, err := svc.CleanupOrphanedAttachments(ctx, "", true)
 	require.NoError(t, err)
 	require.NotNil(t, report)
-	require.Len(t, report.RemovedContainers, 1)
-	assert.Equal(t, orphan.ID, report.RemovedContainers[0].ID)
+	require.Len(t, report.RemovedContainers, 2)
+	assert.Equal(t, running.ID, report.RemovedContainers[0].ID)
+	assert.Equal(t, stopped.ID, report.RemovedContainers[1].ID)
 	assert.Contains(t, report.Hints, "attachment volumes and data were preserved")
 
 	svc.mu.RLock()
@@ -4693,7 +4805,7 @@ func TestService_CleanupOrphanedAttachments_StopRemovesContainerButPreservesData
 	assert.Empty(t, ids)
 }
 
-func TestService_ListOrphanedAttachments_IgnoresStoppedAttachments(t *testing.T) {
+func TestService_ListOrphanedAttachments_IncludesStoppedAttachments(t *testing.T) {
 	ctx := testContext()
 	runtime := mocks.NewMockContainerRuntime(t)
 	svc := NewService(runtime, nil, mocks.NewMockEventPublisher(t), nil, Config{}, nil)
@@ -4713,7 +4825,9 @@ func TestService_ListOrphanedAttachments_IgnoresStoppedAttachments(t *testing.T)
 
 	orphans, err := svc.ListOrphanedAttachments(ctx)
 	require.NoError(t, err)
-	assert.Empty(t, orphans)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, stopped.ID, orphans[0].ContainerID)
+	assert.Equal(t, string(domain.ContainerStatusExited), orphans[0].Status)
 }
 
 func TestService_ListOrphanedAttachments_IncludesOwnerAndHonorsGroupConfig(t *testing.T) {

--- a/internal/usecase/publictls/renewal.go
+++ b/internal/usecase/publictls/renewal.go
@@ -68,8 +68,9 @@ func (s *Service) StartRenewalLoop(ctx context.Context, interval time.Duration) 
 
 		log := zerowrap.FromCtx(loopCtx)
 
-		// Startup and reload paths reconcile routes; the periodic loop only renews
-		// due certificates to avoid repeated zone lookups and ACME ordering work.
+		// Startup and reload paths perform an immediate reconcile; the loop still
+		// renews due certificates right away so already-managed certs do not wait
+		// an extra interval before renewal.
 		if err := s.renewDueCertificates(loopCtx, time.Now()); err != nil {
 			log.Warn().Err(err).Msg("failed to renew due public TLS certificates")
 		}
@@ -79,6 +80,9 @@ func (s *Service) StartRenewalLoop(ctx context.Context, interval time.Duration) 
 			case <-loopCtx.Done():
 				return
 			case <-ticker.C:
+				if err := s.Reconcile(loopCtx); err != nil {
+					log.Warn().Err(err).Msg("failed to reconcile public TLS certificates")
+				}
 				if err := s.renewDueCertificates(loopCtx, time.Now()); err != nil {
 					log.Warn().Err(err).Msg("failed to renew due public TLS certificates")
 				}

--- a/internal/usecase/publictls/renewal_test.go
+++ b/internal/usecase/publictls/renewal_test.go
@@ -115,6 +115,48 @@ func TestRenewalLoopStops(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "renewal loop should stop after context cancel")
 }
 
+func TestRenewalLoop_ReconcilesMissingCertificatesOnTick(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := Config{
+		Enabled:   true,
+		Email:     "admin@example.com",
+		Challenge: "http-01",
+		HTTPPort:  8088,
+		TLSPort:   8443,
+	}
+
+	routes := &fakeRoutes{routes: []domain.Route{{Domain: "app.example.com"}}}
+	issuer, recorder := newMockPublicCertificateIssuer(t, nil, nil)
+	store, _ := newMockCertificateStore(t)
+
+	svc := NewService(cfg, ServiceDeps{
+		Config:     cfg,
+		Routes:     routes,
+		Issuer:     issuer,
+		Store:      store,
+		Challenges: NewHTTP01Challenges(),
+		Effective: EffectiveChallenge{
+			ConfiguredMode: domain.ACMEChallengeHTTP01,
+			Mode:           domain.ACMEChallengeHTTP01,
+			TokenSource:    domain.ACMETokenSourceNone,
+			Reason:         "http-01 challenge selected",
+		},
+	})
+
+	require.NoError(t, svc.Load(ctx))
+	done := svc.StartRenewalLoop(ctx, 10*time.Millisecond)
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(recorder.Orders()) > 0
+	}, 5*time.Second, 10*time.Millisecond, "renewal loop should retry missing certificate obtains")
+}
+
 // ---------------------------------------------------------------------------
 // RenewDueCertificates
 // ---------------------------------------------------------------------------

--- a/internal/usecase/publictls/service.go
+++ b/internal/usecase/publictls/service.go
@@ -38,6 +38,7 @@ const defaultObtainBatchSize = 1
 // Service manages public TLS certificates via ACME.
 type Service struct {
 	mu           sync.RWMutex
+	reconcileMu  sync.Mutex
 	cfg          Config
 	deps         ServiceDeps
 	log          zerowrap.Logger
@@ -131,6 +132,10 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		log.Debug().Msg("acme disabled, skipping reconcile")
 		return nil
 	}
+
+	s.reconcileMu.Lock()
+	defer s.reconcileMu.Unlock()
+
 	log.Debug().Msg("starting certificate reconciliation")
 
 	if s.deps.Store == nil {

--- a/internal/usecase/publictls/service_test.go
+++ b/internal/usecase/publictls/service_test.go
@@ -663,8 +663,12 @@ func TestServiceReconcile_SerializesConcurrentRuns(t *testing.T) {
 		t.Fatal("first reconcile did not start certificate obtain")
 	}
 
-	go func() { errCh <- svc.Reconcile(ctx) }()
-	time.Sleep(50 * time.Millisecond)
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		errCh <- svc.Reconcile(ctx)
+	}()
+	<-secondStarted
 	close(releaseObtain)
 
 	require.NoError(t, <-errCh)

--- a/internal/usecase/publictls/service_test.go
+++ b/internal/usecase/publictls/service_test.go
@@ -617,6 +617,61 @@ func TestServiceReconcileObtainsMissingHTTP01Cert(t *testing.T) {
 	assert.NotEmpty(t, stored[0].Certificate.Certificate)
 }
 
+func TestServiceReconcile_SerializesConcurrentRuns(t *testing.T) {
+	ctx := context.Background()
+	routes := &fakeRoutes{routes: []domain.Route{{Domain: "app.example.com"}}}
+	obtainStarted := make(chan struct{}, 2)
+	releaseObtain := make(chan struct{})
+
+	issuer, recorder := newMockPublicCertificateIssuer(t, func(_ context.Context, order out.CertificateOrder) (*out.StoredCertificate, error) {
+		obtainStarted <- struct{}{}
+		<-releaseObtain
+		return defaultStoredCert(order)
+	}, nil)
+	store, _ := newMockCertificateStore(t)
+
+	cfg := Config{
+		Enabled:   true,
+		Email:     "admin@example.com",
+		Challenge: "http-01",
+		HTTPPort:  8088,
+		TLSPort:   8443,
+	}
+
+	svc := NewService(cfg, ServiceDeps{
+		Config:     cfg,
+		Routes:     routes,
+		Issuer:     issuer,
+		Store:      store,
+		Challenges: NewHTTP01Challenges(),
+		Effective: EffectiveChallenge{
+			ConfiguredMode: domain.ACMEChallengeHTTP01,
+			Mode:           domain.ACMEChallengeHTTP01,
+			TokenSource:    domain.ACMETokenSourceNone,
+			Reason:         "http-01 challenge selected",
+		},
+	})
+
+	require.NoError(t, svc.Load(ctx))
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- svc.Reconcile(ctx) }()
+
+	select {
+	case <-obtainStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first reconcile did not start certificate obtain")
+	}
+
+	go func() { errCh <- svc.Reconcile(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	close(releaseObtain)
+
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+	assert.Len(t, recorder.Orders(), 1)
+}
+
 func TestServiceReconcileResolvesMissingEffectiveChallenge(t *testing.T) {
 	ctx := context.Background()
 	routes := &fakeRoutes{routes: []domain.Route{{Domain: "app.example.com"}}}


### PR DESCRIPTION
## Summary
- fix the confirmed v2.31 release blockers across remote resolution, route cleanup, reload wiring, public TLS renewal, and restarting-container handling
- tighten route cleanup diagnosis/inference with a dedicated cleanup preview path and safer permission behavior
- update the release docs/config examples and add regression coverage for the release-readiness fixes

## Verification
- rtk golangci-lint run ./...
- rtk go test ./...
- coderabbit review --agent --base main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route cleanup preview to identify orphaned containers/volumes before removal
  * Rollback renamed to "pin" for route version control
  * Public ACME TLS support and DNS resolver settings
  * Optional dedicated HTTP access log (JSON) and managed container restart policy
  * Improved remote inference for CLI commands

* **Configuration Changes**
  * Default HTTP proxy port examples updated to 8088; TLS port documented as 8443
  * TLS guidance: Gordon can terminate TLS via internal CA; reverse proxies optional

* **Documentation**
  * Expanded installation, upgrade, CLI, and troubleshooting docs updated and clarified

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bnema/gordon/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->