### PR TITLE
fix(proxy): handle client-aborted streaming requests

### DIFF
--- a/internal/adapters/in/http/middleware/logging.go
+++ b/internal/adapters/in/http/middleware/logging.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -163,6 +164,10 @@ func PanicRecovery(log zerowrap.Logger) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if err := recover(); err != nil {
+					if isAbortHandlerPanic(err) {
+						panic(http.ErrAbortHandler)
+					}
+
 					log.Error().
 						Str(zerowrap.FieldLayer, "adapter").
 						Str(zerowrap.FieldAdapter, "http").
@@ -181,6 +186,11 @@ func PanicRecovery(log zerowrap.Logger) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isAbortHandlerPanic(v any) bool {
+	err, ok := v.(error)
+	return ok && errors.Is(err, http.ErrAbortHandler)
 }
 
 // CORS middleware adds permissive CORS headers.

--- a/internal/adapters/in/http/middleware/logging_test.go
+++ b/internal/adapters/in/http/middleware/logging_test.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanicRecovery_RethrowsReverseProxyAbort(t *testing.T) {
+	log := testLogger()
+
+	handler := PanicRecovery(log)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	rw := httptest.NewRecorder()
+
+	assert.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(rw, req)
+	})
+	assert.NotEqual(t, http.StatusInternalServerError, rw.Code)
+}

--- a/internal/adapters/in/http/proxy/forwarder.go
+++ b/internal/adapters/in/http/proxy/forwarder.go
@@ -2,6 +2,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -102,16 +103,15 @@ func (h *Handler) forwardToTarget(w http.ResponseWriter, r *http.Request, target
 		transport:     transport,
 		incomingReq:   r,
 		trustedNets:   h.trustedNets,
-		errorHandler: func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
-			var maxBytesErr *http.MaxBytesError
-			if errors.As(proxyErr, &maxBytesErr) {
-				log.Warn().Err(proxyErr).Str("target", targetURL.String()).Msg("proxy error: request body too large")
-				proxyError(w, "Request Entity Too Large", http.StatusRequestEntityTooLarge)
-				return
-			}
-			log.Error().Err(proxyErr).Str("target", targetURL.String()).Msg("proxy error: connection failed")
-			proxyError(w, "Service Unavailable", http.StatusServiceUnavailable)
-		},
+		errorHandler: newProxyErrorHandler(
+			log.WithField("target", targetURL.String()),
+			proxyErrorHandlerConfig{
+				requestTooLargeLog:  "proxy error: request body too large",
+				clientDisconnectLog: "proxy request canceled by client",
+				upstreamErrorLog:    "proxy error: connection failed",
+				upstreamErrorBody:   "Service Unavailable",
+			},
+		),
 		modifyResponse: modifyResponse(maxResponseSize),
 	})
 
@@ -152,16 +152,15 @@ func (h *Handler) forwardToRegistry(w http.ResponseWriter, r *http.Request, regi
 			pr.Out.Host = targetURL.Host
 		},
 		Transport: h.registryTransport,
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
-			var maxBytesErr *http.MaxBytesError
-			if errors.As(proxyErr, &maxBytesErr) {
-				log.Warn().Err(proxyErr).Int("registry_port", registryPort).Msg("registry proxy error: request body too large")
-				proxyError(w, "Request Entity Too Large", http.StatusRequestEntityTooLarge)
-				return
-			}
-			log.Error().Err(proxyErr).Int("registry_port", registryPort).Msg("registry proxy error")
-			proxyError(w, "Registry Unavailable", http.StatusServiceUnavailable)
-		},
+		ErrorHandler: newProxyErrorHandler(
+			log.WithField("registry_port", registryPort),
+			proxyErrorHandlerConfig{
+				requestTooLargeLog:  "registry proxy error: request body too large",
+				clientDisconnectLog: "registry proxy request canceled by client",
+				upstreamErrorLog:    "registry proxy error",
+				upstreamErrorBody:   "Registry Unavailable",
+			},
+		),
 		// Strip browser-oriented security headers from upstream registry responses
 		// to avoid conflicts with Gordon's own headers on browser-facing routes.
 		ModifyResponse: func(resp *http.Response) error {
@@ -179,6 +178,34 @@ func (h *Handler) forwardToRegistry(w http.ResponseWriter, r *http.Request, regi
 
 	log.Debug().Str("target", targetURL.String()).Msg("proxying request to registry")
 	proxy.ServeHTTP(w, r)
+}
+
+type proxyErrorHandlerConfig struct {
+	requestTooLargeLog  string
+	clientDisconnectLog string
+	upstreamErrorLog    string
+	upstreamErrorBody   string
+}
+
+func newProxyErrorHandler(log zerowrap.Logger, cfg proxyErrorHandlerConfig) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, _ *http.Request, proxyErr error) {
+		switch {
+		case isRequestBodyTooLargeError(proxyErr):
+			log.Warn().Err(proxyErr).Msg(cfg.requestTooLargeLog)
+			proxyError(w, "Request Entity Too Large", http.StatusRequestEntityTooLarge)
+		case isClientDisconnectError(proxyErr):
+			log.Debug().Err(proxyErr).Msg(cfg.clientDisconnectLog)
+			clientClosedRequest(w)
+		default:
+			log.Error().Err(proxyErr).Msg(cfg.upstreamErrorLog)
+			proxyError(w, cfg.upstreamErrorBody, http.StatusServiceUnavailable)
+		}
+	}
+}
+
+func isRequestBodyTooLargeError(err error) bool {
+	_, ok := errors.AsType[*http.MaxBytesError](err)
+	return ok
 }
 
 type reverseProxyOptions struct {
@@ -305,10 +332,25 @@ func (l *limitedReadCloser) Close() error {
 	return l.ReadCloser.Close()
 }
 
+const statusClientClosedRequest = 499
+
+func isClientDisconnectError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, http.ErrAbortHandler)
+}
+
+func clientClosedRequest(w http.ResponseWriter) {
+	setProxyGeneratedResponseHeaders(w)
+	w.WriteHeader(statusClientClosedRequest)
+}
+
 // proxyError writes an error response with security headers appropriate for
 // proxy-generated error pages.
 func proxyError(w http.ResponseWriter, msg string, code int) {
+	setProxyGeneratedResponseHeaders(w)
+	http.Error(w, msg, code)
+}
+
+func setProxyGeneratedResponseHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
 	w.Header().Set("Cache-Control", "no-store")
-	http.Error(w, msg, code)
 }

--- a/internal/adapters/in/http/proxy/forwarder_test.go
+++ b/internal/adapters/in/http/proxy/forwarder_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,12 @@ import (
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	"github.com/bnema/gordon/internal/domain"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
 
 func TestForwardToTarget_H2CEndToEnd(t *testing.T) {
 	var h2cProtos http.Protocols
@@ -183,6 +190,35 @@ func TestForwardToTarget_RouteHostPreservedForManagedTarget(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "app.example.com", receivedHost)
 	assert.Equal(t, "app.example.com", receivedForwardedHost)
+}
+
+func TestForwardToTarget_ContextCanceled_Returns499(t *testing.T) {
+	proxySvc := inmocks.NewMockProxyService(t)
+
+	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+	proxySvc.EXPECT().IsRegistryDomain("app.example.com").Return(false)
+	proxySvc.EXPECT().GetTarget(mock.Anything, "app.example.com").Return(&domain.ProxyTarget{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		ContainerID: "c-sse",
+		Scheme:      "http",
+	}, nil)
+	proxySvc.EXPECT().TrackInFlight("c-sse").Return(func() {})
+
+	handler := NewHandler(proxySvc, nil, zerowrap.Default())
+	handler.appTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://app.example.com/api/notifications/sent-events", nil)
+	req.Host = "app.example.com"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, statusClientClosedRequest, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	assert.Equal(t, "default-src 'none'; frame-ancestors 'none'", w.Header().Get("Content-Security-Policy"))
+	assert.Empty(t, w.Body.String())
 }
 
 func TestForwardToTarget_BackendDown_Returns503(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat client-canceled reverse proxy requests as client disconnects instead of upstream failures.
- Preserve real upstream failures as 503 responses while returning 499 for canceled proxy requests.
- Let `http.ErrAbortHandler` panics escape Gordon panic recovery so Go suppresses benign streaming abort logs.

## Test Plan
- [x] `go test ./internal/adapters/in/http/proxy ./internal/adapters/in/http/middleware`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of aborted reverse proxy requests to prevent incorrect error logging and 500 responses.
  * Added client disconnection detection for proxied requests, responding with appropriate status code instead of treating as service failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->