### PR TITLE
fix(logging): redact secret-bearing log values

### DIFF
--- a/internal/adapters/in/http/middleware/accesslog.go
+++ b/internal/adapters/in/http/middleware/accesslog.go
@@ -66,7 +66,7 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 				BytesSent:  rw.BytesWritten(),
 				DurationMS: durationMS,
 				UserAgent:  r.UserAgent(),
-				Referer:    r.Referer(),
+				Referer:    sanitizeLoggedReferer(r.Referer()),
 				RequestID:  requestID,
 				Proto:      r.Proto,
 			}
@@ -87,6 +87,21 @@ func AccessLogger(writer out.AccessLogWriter, excludeHealthChecks bool, log zero
 	}
 }
 
+func sanitizeLoggedReferer(referer string) string {
+	if referer == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(referer)
+	if err != nil {
+		return "[INVALID_REFERER]"
+	}
+	parsed.User = nil
+	parsed.RawQuery = sanitizeLoggedQuery(parsed.RawQuery)
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
 func sanitizeLoggedQuery(rawQuery string) string {
 	if rawQuery == "" {
 		return ""
@@ -101,7 +116,10 @@ func sanitizeLoggedQuery(rawQuery string) string {
 		key, _, found := strings.Cut(part, "=")
 		decodedKey, err := url.QueryUnescape(key)
 		if err != nil {
-			decodedKey = key
+			if found {
+				parts[i] = key + "=[REDACTED]"
+			}
+			continue
 		}
 
 		if !isSensitiveQueryKey(decodedKey) {

--- a/internal/adapters/in/http/middleware/accesslog_test.go
+++ b/internal/adapters/in/http/middleware/accesslog_test.go
@@ -81,6 +81,56 @@ func TestAccessLogger_RedactsSensitiveQueryParams(t *testing.T) {
 	assert.Equal(t, "code=[REDACTED]&state=ok&token=[REDACTED]&api_key=[REDACTED]&session_id=[REDACTED]", mock.entries[0].Query)
 }
 
+func TestAccessLogger_RedactsSensitiveReferers(t *testing.T) {
+	tests := []struct {
+		name    string
+		referer string
+		want    string
+	}{
+		{
+			name:    "query params",
+			referer: "https://idp.example.com/callback?code=secret-code&state=ok&token=secret-token",
+			want:    "https://idp.example.com/callback?code=[REDACTED]&state=ok&token=[REDACTED]",
+		},
+		{
+			name:    "fragment removed",
+			referer: "https://idp.example.com/callback?state=ok#access_token=secret-token",
+			want:    "https://idp.example.com/callback?state=ok",
+		},
+		{
+			name:    "userinfo removed",
+			referer: "https://user:secret-password@idp.example.com/callback?code=secret-code",
+			want:    "https://idp.example.com/callback?code=[REDACTED]",
+		},
+		{
+			name:    "malformed query key redacted conservatively",
+			referer: "https://idp.example.com/callback?token%ZZ=secret-token&state=ok",
+			want:    "https://idp.example.com/callback?token%ZZ=[REDACTED]&state=ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockAccessLogWriter{}
+			log := testLogger()
+
+			handler := AccessLogger(mock, false, log, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/target", nil)
+			req.Header.Set("Referer", tt.referer)
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, req)
+
+			require.Len(t, mock.entries, 1)
+			assert.Equal(t, tt.want, mock.entries[0].Referer)
+			assert.NotContains(t, mock.entries[0].Referer, "secret")
+		})
+	}
+}
+
 func TestAccessLogger_RequestIDReused(t *testing.T) {
 	mock := &mockAccessLogWriter{}
 	log := testLogger()

--- a/internal/adapters/in/http/middleware/logging.go
+++ b/internal/adapters/in/http/middleware/logging.go
@@ -134,7 +134,7 @@ func RequestLogger(log zerowrap.Logger, trustedNets ...[]*net.IPNet) func(http.H
 				Str("query", sanitizeLoggedQuery(r.URL.RawQuery)).
 				Str(zerowrap.FieldHost, r.Host).
 				Str("user_agent", r.UserAgent()).
-				Str("referer", r.Referer()).
+				Str("referer", sanitizeLoggedReferer(r.Referer())).
 				Str(zerowrap.FieldClientIP, clientIP).
 				Int(zerowrap.FieldStatus, rw.StatusCode()).
 				Int("bytes", rw.BytesWritten()).

--- a/internal/adapters/in/http/middleware/logging_test.go
+++ b/internal/adapters/in/http/middleware/logging_test.go
@@ -1,12 +1,73 @@
 package middleware
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRequestLogger_RedactsSensitiveReferers(t *testing.T) {
+	tests := []struct {
+		name        string
+		referer     string
+		wantReferer string
+	}{
+		{
+			name:        "query params",
+			referer:     "https://idp.example.com/callback?code=secret-code&state=ok&token=secret-token",
+			wantReferer: "https://idp.example.com/callback?code=[REDACTED]&state=ok&token=[REDACTED]",
+		},
+		{
+			name:        "fragment removed",
+			referer:     "https://idp.example.com/callback?state=ok#access_token=secret-token",
+			wantReferer: "https://idp.example.com/callback?state=ok",
+		},
+		{
+			name:        "userinfo removed",
+			referer:     "https://user:secret-password@idp.example.com/callback?code=secret-code",
+			wantReferer: "https://idp.example.com/callback?code=[REDACTED]",
+		},
+		{
+			name:        "malformed query key redacted conservatively",
+			referer:     "https://idp.example.com/callback?token%ZZ=secret-token&state=ok",
+			wantReferer: "https://idp.example.com/callback?token%ZZ=[REDACTED]&state=ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			log := zerowrap.New(zerowrap.Config{Level: "info", Format: "json", Output: &logs})
+
+			handler := RequestLogger(log)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/target?token=direct-secret", nil)
+			req.Header.Set("Referer", tt.referer)
+			rw := httptest.NewRecorder()
+
+			handler.ServeHTTP(rw, req)
+
+			logOutput := logs.String()
+			require.NotEmpty(t, logOutput)
+			var entry map[string]any
+			require.NoError(t, json.Unmarshal(logs.Bytes(), &entry))
+			assert.Equal(t, "token=[REDACTED]", entry["query"])
+			assert.Equal(t, tt.wantReferer, entry["referer"])
+			assert.NotContains(t, logOutput, "direct-secret")
+			assert.NotContains(t, logOutput, "secret-code")
+			assert.NotContains(t, logOutput, "secret-token")
+			assert.NotContains(t, logOutput, "secret-password")
+		})
+	}
+}
 
 func TestPanicRecovery_RethrowsReverseProxyAbort(t *testing.T) {
 	log := testLogger()

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -1427,7 +1428,10 @@ func (r *Runtime) InspectImageEnv(ctx context.Context, imageRef string) ([]strin
 	}
 
 	if len(envVars) > 0 {
-		log.Debug().Strs("env_vars", envVars).Msg("found ENV directives in image")
+		log.Debug().
+			Int(zerowrap.FieldCount, len(envVars)).
+			Strs("env_keys", imageEnvKeys(envVars)).
+			Msg("found ENV directives in image")
 	} else {
 		log.Debug().Msg("no ENV directives found in image")
 	}
@@ -1436,6 +1440,20 @@ func (r *Runtime) InspectImageEnv(ctx context.Context, imageRef string) ([]strin
 }
 
 // GetImageLabels returns the labels defined on an image.
+func imageEnvKeys(envVars []string) []string {
+	keys := make([]string, 0, len(envVars))
+	for _, envVar := range envVars {
+		key, _, ok := strings.Cut(envVar, "=")
+		if !ok || key == "" {
+			keys = append(keys, "[malformed]")
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func (r *Runtime) GetImageLabels(ctx context.Context, imageRef string) (map[string]string, error) {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "adapter",
@@ -1492,9 +1510,7 @@ func (r *Runtime) CreateNetwork(ctx context.Context, name string, config domain.
 		driver = "bridge"
 	}
 	labels := make(map[string]string, len(config.Labels)+1)
-	for key, value := range config.Labels {
-		labels[key] = value
-	}
+	maps.Copy(labels, config.Labels)
 	labels[domain.LabelManaged] = "true"
 
 	createOptions := network.CreateOptions{

--- a/internal/adapters/out/docker/runtime_test.go
+++ b/internal/adapters/out/docker/runtime_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 
 	"github.com/bnema/zerowrap"
-	"github.com/docker/docker/client"
-
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/adapters/out/docker/runtime_test.go
+++ b/internal/adapters/out/docker/runtime_test.go
@@ -1,13 +1,61 @@
 package docker
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/bnema/zerowrap"
+	"github.com/docker/docker/client"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRuntime_InspectImageEnv_RedactsValuesInDebugLog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/images/")
+		assert.Contains(t, r.URL.Path, "/json")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Config": {
+				"Env": ["API_KEY=super-secret-key", "DATABASE_URL=postgres://user:pass@example/db", "PORT=8080", "MALFORMED_SECRET_VALUE", "=empty-key-secret"]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	cli, err := client.NewClientWithOpts(client.WithHost("tcp://"+host), client.WithVersion("1.41"), client.WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+	runtime := NewRuntimeWithClient(cli)
+
+	var logs bytes.Buffer
+	log := zerowrap.New(zerowrap.Config{Level: "debug", Format: "json", Output: &logs})
+	ctx := zerowrap.WithCtx(context.Background(), log)
+
+	envVars, err := runtime.InspectImageEnv(ctx, "example/app:latest")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"API_KEY=super-secret-key", "DATABASE_URL=postgres://user:pass@example/db", "PORT=8080", "MALFORMED_SECRET_VALUE", "=empty-key-secret"}, envVars)
+
+	logOutput := logs.String()
+	assert.Contains(t, logOutput, "env_keys")
+	assert.Contains(t, logOutput, "API_KEY")
+	assert.Contains(t, logOutput, "DATABASE_URL")
+	assert.Contains(t, logOutput, "PORT")
+	assert.Contains(t, logOutput, "[malformed]")
+	assert.NotContains(t, logOutput, "super-secret-key")
+	assert.NotContains(t, logOutput, "postgres://user:pass@example/db")
+	assert.NotContains(t, logOutput, "MALFORMED_SECRET_VALUE")
+	assert.NotContains(t, logOutput, "empty-key-secret")
+	assert.NotContains(t, logOutput, "API_KEY=super-secret-key")
+}
 
 func TestWaitForVolumeArchiveContainerIgnoresNilErrorBeforeStatus(t *testing.T) {
 	statusCh := make(chan container.WaitResponse, 1)

--- a/internal/adapters/out/envloader/file.go
+++ b/internal/adapters/out/envloader/file.go
@@ -99,7 +99,6 @@ func (l *FileLoader) LoadEnv(ctx context.Context, domain string) ([]string, erro
 		if len(parts) != 2 {
 			log.Warn().
 				Int("line", lineNum).
-				Str("content", line).
 				Msg("invalid env file line format, skipping")
 			continue
 		}
@@ -118,10 +117,14 @@ func (l *FileLoader) LoadEnv(ctx context.Context, domain string) ([]string, erro
 		// Resolve secrets if value contains secret syntax
 		resolvedValue, err := l.resolveSecrets(ctx, value)
 		if err != nil {
-			return nil, log.WrapErrWithFields(err, "failed to resolve secret", map[string]any{
-				"key":  key,
-				"line": lineNum,
-			})
+			return nil, log.WrapErrWithFields(
+				fmt.Errorf("key %s on line %d: %w", key, lineNum, err),
+				"failed to resolve secret",
+				map[string]any{
+					"key":  key,
+					"line": lineNum,
+				},
+			)
 		}
 
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, resolvedValue))
@@ -210,14 +213,14 @@ func (l *FileLoader) resolveSecrets(ctx context.Context, value string) (string, 
 
 		end := strings.Index(result[start:], "}")
 		if end == -1 {
-			return "", fmt.Errorf("unclosed secret syntax in value: %s", value)
+			return "", fmt.Errorf("unclosed secret syntax")
 		}
 		end += start
 
 		secretRef := result[start+2 : end]
 		parts := strings.SplitN(secretRef, ":", 2)
 		if len(parts) != 2 {
-			return "", fmt.Errorf("invalid secret syntax: expected 'provider:path', got '%s'", secretRef)
+			return "", fmt.Errorf("invalid secret syntax: expected 'provider:path'")
 		}
 
 		providerName := parts[0]
@@ -230,7 +233,7 @@ func (l *FileLoader) resolveSecrets(ctx context.Context, value string) (string, 
 
 		secretValue, err := provider.GetSecret(ctx, secretPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to get secret from provider %s: %w", providerName, err)
+			return "", fmt.Errorf("failed to get secret from provider %s", providerName)
 		}
 
 		// Replace the secret reference with the actual value

--- a/internal/adapters/out/envloader/file_test.go
+++ b/internal/adapters/out/envloader/file_test.go
@@ -1,7 +1,9 @@
 package envloader
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -200,6 +202,84 @@ ALSO_VALID=another
 		assert.Len(t, envVars, 2)
 		assert.Contains(t, envVars, "VALID=value")
 		assert.Contains(t, envVars, "ALSO_VALID=another")
+	})
+}
+
+func TestFileLoader_LoadEnv_RedactsSecretBearingDiagnostics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("invalid line warning omits raw line content", func(t *testing.T) {
+		var logs bytes.Buffer
+		log := zerowrap.New(zerowrap.Config{Level: "warn", Format: "json", Output: &logs})
+		loader, err := NewFileLoader(t.TempDir(), log)
+		require.NoError(t, err)
+		ctx := zerowrap.WithCtx(ctx, log)
+
+		envFile, err := loader.getEnvFilePath("app.example.com")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(envFile, []byte("valid line leaks super-secret-token\nVALID=value\n"), 0600))
+
+		envVars, err := loader.LoadEnv(ctx, "app.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"VALID=value"}, envVars)
+		assert.NotContains(t, logs.String(), "super-secret-token")
+		assert.NotContains(t, logs.String(), "valid line leaks")
+		assert.Contains(t, logs.String(), "line")
+	})
+
+	t.Run("secret resolution error omits unclosed raw value", func(t *testing.T) {
+		log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+		loader, err := NewFileLoader(t.TempDir(), log)
+		require.NoError(t, err)
+
+		envFile, err := loader.getEnvFilePath("app.example.com")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(envFile, []byte("DATABASE_URL=postgres://user:${pass:db-password-super-secret\n"), 0600))
+
+		_, err = loader.LoadEnv(ctx, "app.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve secret")
+		assert.Contains(t, err.Error(), "DATABASE_URL")
+		assert.NotContains(t, err.Error(), "postgres://user")
+		assert.NotContains(t, err.Error(), "db-password-super-secret")
+	})
+
+	t.Run("secret resolution error omits malformed closed secret ref", func(t *testing.T) {
+		log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+		loader, err := NewFileLoader(t.TempDir(), log)
+		require.NoError(t, err)
+
+		envFile, err := loader.getEnvFilePath("app.example.com")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(envFile, []byte("TOKEN=${db-password-super-secret}\n"), 0600))
+
+		_, err = loader.LoadEnv(ctx, "app.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve secret")
+		assert.Contains(t, err.Error(), "TOKEN")
+		assert.NotContains(t, err.Error(), "db-password-super-secret")
+	})
+
+	t.Run("secret resolution error omits provider error details", func(t *testing.T) {
+		log := zerowrap.New(zerowrap.Config{Level: "fatal"})
+		loader, err := NewFileLoader(t.TempDir(), log)
+		require.NoError(t, err)
+
+		mockPass := mocks.NewMockSecretProvider(t)
+		mockPass.EXPECT().Name().Return("pass")
+		mockPass.EXPECT().GetSecret(ctx, "db-password-super-secret").Return("", errors.New("backend leaked db-password-super-secret"))
+		loader.RegisterSecretProvider(mockPass)
+
+		envFile, err := loader.getEnvFilePath("app.example.com")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(envFile, []byte("TOKEN=${pass:db-password-super-secret}\n"), 0600))
+
+		_, err = loader.LoadEnv(ctx, "app.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve secret")
+		assert.Contains(t, err.Error(), "TOKEN")
+		assert.Contains(t, err.Error(), "provider pass")
+		assert.NotContains(t, err.Error(), "db-password-super-secret")
 	})
 }
 


### PR DESCRIPTION
## Summary
- remove raw env-file line/value details from env-loader diagnostics
- log Docker image ENV metadata as counts and key names only
- sanitize Referer logging across request and access logs, including query secrets, userinfo, fragments, and malformed query keys

## Verification
- go test ./...
- golangci-lint run ./...
- wrap-up review: clean re-review

## Notes
- CodeRabbit review attempted against origin/main but was rate-limited before producing findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* HTTP access logs now redact sensitive data from referer headers, including user credentials and query tokens
* Debug logs and error messages no longer expose secret values during environment configuration processing
* Improved security by sanitizing URLs and query parameters across all logging output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->