### PR TITLE
fix(container): clean up interrupted deploy candidates

### DIFF
--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -77,9 +77,10 @@ const (
 	// readinessRecoveryWindow is an additional grace window used when a container
 	// is briefly not running at the end of readiness delay. This avoids false
 	// negatives during short startup flaps.
-	readinessRecoveryWindow = 30 * time.Second
-	internalPullMaxAttempts = 3
-	deployFailureLogLimit   = 20
+	readinessRecoveryWindow       = 30 * time.Second
+	failedContainerCleanupTimeout = 30 * time.Second
+	internalPullMaxAttempts       = 3
+	deployFailureLogLimit         = 20
 )
 
 // Service implements the ContainerService interface.
@@ -1963,11 +1964,14 @@ func (s *Service) UpdateAttachments(attachments map[string][]string) {
 
 // cleanupFailedContainer stops and removes a container that failed to start properly.
 func (s *Service) cleanupFailedContainer(ctx context.Context, containerID string) {
-	log := zerowrap.FromCtx(ctx)
-	if err := s.runtime.StopContainer(ctx, containerID); err != nil {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failedContainerCleanupTimeout)
+	defer cancel()
+
+	log := zerowrap.FromCtx(cleanupCtx)
+	if err := s.runtime.StopContainer(cleanupCtx, containerID); err != nil {
 		log.Warn().Err(err).Str(zerowrap.FieldEntityID, containerID).Msg("failed to stop container after failure")
 	}
-	if err := s.runtime.RemoveContainer(ctx, containerID, true); err != nil {
+	if err := s.runtime.RemoveContainer(cleanupCtx, containerID, true); err != nil {
 		log.Warn().Err(err).Str(zerowrap.FieldEntityID, containerID).Msg("failed to remove container after failure")
 	}
 }
@@ -2631,11 +2635,11 @@ func (s *Service) cleanupOrphanedContainers(ctx context.Context, domainName stri
 
 	for _, c := range allContainers {
 		if (c.Name == expectedName || c.Name == expectedNewName || c.Name == expectedNextName) && c.ID != skipContainerID {
-			// Skip any container that is still active in the runtime, including
-			// restart backoff, regardless of name — a temp container may be
-			// serving traffic while the new container stabilizes, or may be from
-			// a concurrent deploy.
-			if c.Status == "running" || c.Status == "restarting" {
+			// Without a selected active container, preserve anything that may still
+			// be serving traffic. When an active container is selected, other active
+			// temp-name containers are stale candidates left by interrupted deploys.
+			isActive := c.Status == "running" || c.Status == "restarting"
+			if isActive && (skipContainerID == "" || c.Name == expectedName) {
 				log.Debug().
 					Str(zerowrap.FieldEntityID, c.ID).
 					Str("container_name", c.Name).

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -610,6 +610,51 @@ func TestService_Deploy_ReadinessFailureReturnsDeployFailureWithLogs(t *testing.
 	assert.ErrorContains(t, deployErr.Err, "last status: starting")
 }
 
+func TestService_Deploy_RequestCancellationStillCleansUpFailedCandidate(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+	svc := NewService(runtime, envLoader, eventBus, nil, testMinDelayConfig(), nil)
+
+	svc.containers["test.example.com"] = &domain.Container{
+		ID:     "old-container",
+		Name:   "gordon-test.example.com",
+		Status: "running",
+	}
+	route := domain.Route{Domain: "test.example.com", Image: "myapp:v2"}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil)
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{"myapp:v2"}, nil)
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, "myapp:v2").Return([]int{8080}, nil)
+	runtime.EXPECT().GetImageLabels(mock.Anything, "myapp:v2").Return(nil, nil)
+	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
+	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:v2").Return([]string{}, nil)
+
+	candidate := &domain.Container{ID: "candidate", Name: "gordon-test.example.com-new", Status: "created"}
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.Anything).Return(candidate, nil)
+
+	ctx, cancel := context.WithCancel(testContext())
+	runtime.EXPECT().StartContainer(mock.Anything, candidate.ID).Run(func(context.Context, string) {
+		cancel()
+	}).Return(nil)
+	runtime.EXPECT().IsContainerRunning(mock.Anything, candidate.ID).Return(true, nil).Once()
+
+	activeCleanupContext := mock.MatchedBy(func(ctx context.Context) bool {
+		_, hasDeadline := ctx.Deadline()
+		return ctx.Err() == nil && hasDeadline
+	})
+	runtime.EXPECT().StopContainer(activeCleanupContext, candidate.ID).Return(nil).Once()
+	runtime.EXPECT().RemoveContainer(activeCleanupContext, candidate.ID, true).Return(nil).Once()
+
+	result, err := svc.Deploy(ctx, route)
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+	tracked, exists := svc.Get(testContext(), route.Domain)
+	require.True(t, exists)
+	assert.Equal(t, "old-container", tracked.ID)
+}
+
 func TestService_Deploy_StrictHealthModeWithoutHealthcheckReturnsHint(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
@@ -2492,7 +2537,7 @@ func TestService_Deploy_OrphanCleanupRemovesTrueOrphans(t *testing.T) {
 	assert.Equal(t, "new-container", tracked.ID)
 }
 
-func TestService_Deploy_OrphanCleanupRemovesStaleNewContainer(t *testing.T) {
+func TestService_Deploy_OrphanCleanupRemovesRunningStaleCandidate(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 	envLoader := mocks.NewMockEnvLoader(t)
 	eventBus := mocks.NewMockEventPublisher(t)
@@ -2503,7 +2548,8 @@ func TestService_Deploy_OrphanCleanupRemovesStaleNewContainer(t *testing.T) {
 	svc.SetProxyCacheInvalidator(cacheInvalidator)
 	ctx := testContext()
 
-	// Tracked canonical container exists, but stale -new container should be removed.
+	// The tracked canonical container is active. A candidate left running by an
+	// interrupted request must be removed before its temporary name is reused.
 	svc.containers["test.example.com"] = &domain.Container{
 		ID:     "tracked-container-123",
 		Name:   "gordon-test.example.com",
@@ -2524,7 +2570,7 @@ func TestService_Deploy_OrphanCleanupRemovesStaleNewContainer(t *testing.T) {
 		{
 			ID:     "stale-new-container",
 			Name:   "gordon-test.example.com-new",
-			Status: "exited",
+			Status: "running",
 		},
 	}, nil)
 	runtime.EXPECT().StopContainer(mock.Anything, "stale-new-container").Return(nil).Once()


### PR DESCRIPTION
## Summary

- run readiness-failure cleanup with a detached 30-second lifecycle context
- remove stale running `-new` and `-next` deployment candidates before reusing their names
- preserve the selected active container during recovery
- cover canceled readiness cleanup and subsequent stale-candidate recovery

## Verification

- `go test ./...`
- `golangci-lint run ./...`

Closes #222

@coderabbitai ignore