### PR TITLE
fix(security): remediate codex security scan findings

### DIFF
--- a/.github/actions/deploy/README.md
+++ b/.github/actions/deploy/README.md
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Deploy to Gordon
         uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
@@ -53,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Deploy to Gordon
         id: deploy
@@ -151,6 +155,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
@@ -175,6 +180,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
@@ -188,6 +195,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
       - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com

--- a/.github/actions/deploy/README.md
+++ b/.github/actions/deploy/README.md
@@ -27,10 +27,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Deploy to Gordon
-        uses: bnema/gordon/.github/actions/deploy@main
+        uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
           username: ${{ secrets.GORDON_USERNAME }}
@@ -52,11 +52,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Deploy to Gordon
         id: deploy
-        uses: bnema/gordon/.github/actions/deploy@main
+        uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
           username: ${{ secrets.GORDON_USERNAME }}
@@ -148,11 +148,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: bnema/gordon/.github/actions/deploy@main
+      - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
           username: ${{ secrets.GORDON_USERNAME }}
@@ -174,8 +174,8 @@ jobs:
   deploy-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: bnema/gordon/.github/actions/deploy@main
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
           username: ${{ secrets.GORDON_USERNAME }}
@@ -187,8 +187,8 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: bnema/gordon/.github/actions/deploy@main
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: bnema/gordon/.github/actions/deploy@271c36a4cc32fabd91b20f93cd006bdd2a01b181
         with:
           registry: registry.mydomain.com
           username: ${{ secrets.GORDON_USERNAME }}

--- a/.github/actions/deploy/README.md
+++ b/.github/actions/deploy/README.md
@@ -64,9 +64,6 @@ jobs:
           image: myapp                    # Custom image name
           dockerfile: ./docker/Dockerfile # Custom Dockerfile path
           context: .                      # Build context
-          build-args: |                   # Build arguments
-            NODE_ENV=production
-            API_URL=https://api.example.com
           platforms: linux/amd64,linux/arm64  # Multi-platform
           push-latest: 'true'             # Also push :latest
 
@@ -88,7 +85,6 @@ jobs:
 | `tag` | Override image tag | No | Git tag or short SHA |
 | `dockerfile` | Path to Dockerfile | No | `./Dockerfile` |
 | `context` | Build context path | No | `.` |
-| `build-args` | Build arguments (one per line) | No | - |
 | `platforms` | Target platforms | No | - |
 | `push-latest` | Also push with `:latest` tag | No | `true` |
 | `cache-from` | Cache source | No | `type=gha` |
@@ -204,15 +200,7 @@ jobs:
 
 ### Build with Secrets (BuildKit)
 
-```yaml
-- uses: bnema/gordon/.github/actions/deploy@main
-  with:
-    registry: registry.mydomain.com
-    username: ${{ secrets.GORDON_USERNAME }}
-    password: ${{ secrets.GORDON_TOKEN }}
-    build-args: |
-      NPM_TOKEN=${{ secrets.NPM_TOKEN }}
-```
+The deploy action intentionally does not accept build arguments because CI secrets passed as build arguments can remain in image metadata or layers. For secret-bearing builds, use `docker/build-push-action` with its BuildKit `secrets` input, reference the secret with `RUN --mount=type=secret` in the Dockerfile, and pin every action to a reviewed commit SHA.
 
 ## Troubleshooting
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -32,10 +32,6 @@ inputs:
     description: 'Build context path (defaults to .)'
     required: false
     default: '.'
-  build-args:
-    description: 'Build arguments (one per line, KEY=value format)'
-    required: false
-    default: ''
   platforms:
     description: 'Target platforms (e.g., linux/amd64,linux/arm64)'
     required: false
@@ -69,25 +65,31 @@ runs:
   steps:
     - name: Validate inputs
       shell: bash
+      env:
+        INPUT_DOCKERFILE: ${{ inputs.dockerfile }}
       run: |
-        if [[ ! -f "${{ inputs.dockerfile }}" ]]; then
-          echo "::error::Dockerfile not found at ${{ inputs.dockerfile }}"
+        if [[ ! -f "${INPUT_DOCKERFILE}" ]]; then
+          echo "::error::Dockerfile not found at ${INPUT_DOCKERFILE}"
           exit 1
         fi
 
     - name: Extract metadata
       id: meta
       shell: bash
+      env:
+        INPUT_IMAGE: ${{ inputs.image }}
+        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
         # Determine image name
-        IMAGE_NAME="${{ inputs.image }}"
+        IMAGE_NAME="${INPUT_IMAGE}"
         if [[ -z "$IMAGE_NAME" ]]; then
           IMAGE_NAME="${GITHUB_REPOSITORY#*/}"
         fi
 
         # Extract tag from ref (or override)
-        if [[ -n "${{ inputs.tag }}" ]]; then
-          TAG="${{ inputs.tag }}"
+        if [[ -n "${INPUT_TAG}" ]]; then
+          TAG="${INPUT_TAG}"
         elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
           TAG="${GITHUB_REF#refs/tags/}"
         else
@@ -95,23 +97,21 @@ runs:
         fi
 
         # Full image reference
-        FULL_IMAGE="${{ inputs.registry }}/${IMAGE_NAME}:${TAG}"
+        FULL_IMAGE="${INPUT_REGISTRY}/${IMAGE_NAME}:${TAG}"
 
-        echo "image=${FULL_IMAGE}" >> $GITHUB_OUTPUT
-        echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
-        echo "tag=${TAG}" >> $GITHUB_OUTPUT
-        echo "registry=${{ inputs.registry }}" >> $GITHUB_OUTPUT
+        printf 'image=%s\nimage_name=%s\ntag=%s\nregistry=%s\n' \
+          "${FULL_IMAGE}" "${IMAGE_NAME}" "${TAG}" "${INPUT_REGISTRY}" >> "${GITHUB_OUTPUT}"
 
         echo "Building: ${FULL_IMAGE}"
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to Gordon registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
@@ -120,16 +120,21 @@ runs:
     - name: Build tags
       id: tags
       shell: bash
+      env:
+        META_IMAGE: ${{ steps.meta.outputs.image }}
+        META_IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+        INPUT_REGISTRY: ${{ inputs.registry }}
+        INPUT_PUSH_LATEST: ${{ inputs.push-latest }}
       run: |
-        TAGS="${{ steps.meta.outputs.image }}"
-        if [[ "${{ inputs.push-latest }}" == "true" ]]; then
-          TAGS="${TAGS}"$'\n'"${{ inputs.registry }}/${{ steps.meta.outputs.image_name }}:latest"
+        TAGS="${META_IMAGE}"
+        if [[ "${INPUT_PUSH_LATEST}" == "true" ]]; then
+          TAGS="${TAGS}"$'\n'"${INPUT_REGISTRY}/${META_IMAGE_NAME}:latest"
         fi
         printf "tags<<EOF\n%s\nEOF\n" "$TAGS" >> "$GITHUB_OUTPUT"
 
     - name: Build and push
       id: push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       env:
         DOCKER_BUILD_SUMMARY: false
       with:
@@ -137,7 +142,6 @@ runs:
         file: ${{ inputs.dockerfile }}
         push: true
         tags: ${{ steps.tags.outputs.tags }}
-        build-args: ${{ inputs.build-args }}
         platforms: ${{ inputs.platforms }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
@@ -145,13 +149,17 @@ runs:
 
     - name: Summary
       shell: bash
+      env:
+        META_IMAGE: ${{ steps.meta.outputs.image }}
+        META_TAG: ${{ steps.meta.outputs.tag }}
+        PUSH_DIGEST: ${{ steps.push.outputs.digest }}
       run: |
-        echo "## Gordon Deploy Summary" >> $GITHUB_STEP_SUMMARY
+        echo "## Gordon Deploy Summary" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Image | \`${{ steps.meta.outputs.image }}\` |" >> $GITHUB_STEP_SUMMARY
-        echo "| Tag | \`${{ steps.meta.outputs.tag }}\` |" >> $GITHUB_STEP_SUMMARY
-        echo "| Digest | \`${{ steps.push.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
+        printf '| Image | `%s` |\n' "$META_IMAGE" >> "$GITHUB_STEP_SUMMARY"
+        printf '| Tag | `%s` |\n' "$META_TAG" >> "$GITHUB_STEP_SUMMARY"
+        printf '| Digest | `%s` |\n' "$PUSH_DIGEST" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Container deployed to Gordon registry and will be automatically deployed." >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -81,22 +81,45 @@ runs:
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_REGISTRY: ${{ inputs.registry }}
       run: |
-        # Determine image name
-        IMAGE_NAME="${INPUT_IMAGE}"
-        if [[ -z "$IMAGE_NAME" ]]; then
-          IMAGE_NAME="${GITHUB_REPOSITORY#*/}"
-        fi
+        reject_line_breaks() {
+          [[ "$2" != *$'\n'* && "$2" != *$'\r'* ]] || {
+            echo "::error::$1 must not contain line breaks"
+            exit 1
+          }
+        }
+        reject_line_breaks "registry" "$INPUT_REGISTRY"
+        reject_line_breaks "image" "$INPUT_IMAGE"
+        reject_line_breaks "tag" "$INPUT_TAG"
 
-        # Extract tag from ref (or override)
+        IMAGE_NAME="${INPUT_IMAGE:-${GITHUB_REPOSITORY#*/}}"
         if [[ -n "${INPUT_TAG}" ]]; then
           TAG="${INPUT_TAG}"
         elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
           TAG="${GITHUB_REF#refs/tags/}"
         else
-          TAG="$(echo "$GITHUB_SHA" | head -c 7)"
+          TAG="${GITHUB_SHA:0:7}"
         fi
 
-        # Full image reference
+        [[ "$INPUT_REGISTRY" =~ ^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$ ]] || {
+          echo "::error::registry must be a hostname with an optional port"
+          exit 1
+        }
+        if [[ "$INPUT_REGISTRY" =~ :([0-9]+)$ ]]; then
+          PORT="${BASH_REMATCH[1]}"
+          [[ "$PORT" != 0* && $((10#$PORT)) -ge 1 && $((10#$PORT)) -le 65535 ]] || {
+            echo "::error::registry port must be between 1 and 65535 without leading zeros"
+            exit 1
+          }
+        fi
+        [[ "$IMAGE_NAME" =~ ^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$ ]] || {
+          echo "::error::image contains invalid Docker repository components"
+          exit 1
+        }
+        [[ "$TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || {
+          echo "::error::tag is not a valid Docker tag"
+          exit 1
+        }
+
         FULL_IMAGE="${INPUT_REGISTRY}/${IMAGE_NAME}:${TAG}"
 
         printf 'image=%s\nimage_name=%s\ntag=%s\nregistry=%s\n' \
@@ -130,7 +153,11 @@ runs:
         if [[ "${INPUT_PUSH_LATEST}" == "true" ]]; then
           TAGS="${TAGS}"$'\n'"${INPUT_REGISTRY}/${META_IMAGE_NAME}:latest"
         fi
-        printf "tags<<EOF\n%s\nEOF\n" "$TAGS" >> "$GITHUB_OUTPUT"
+        DELIMITER="gordon_$(openssl rand -hex 16)"
+        while grep -Fqx "$DELIMITER" <<< "$TAGS"; do
+          DELIMITER="gordon_$(openssl rand -hex 16)"
+        done
+        printf 'tags<<%s\n%s\n%s\n' "$DELIMITER" "$TAGS" "$DELIMITER" >> "$GITHUB_OUTPUT"
 
     - name: Build and push
       id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: stable
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/docs/deployment/github-actions.md
+++ b/docs/deployment/github-actions.md
@@ -138,11 +138,15 @@ jobs:
       - name: Build and Deploy
         env:
           GORDON_TOKEN: ${{ secrets.GORDON_TOKEN }}
+          GORDON_REMOTE: ${{ secrets.GORDON_REMOTE }}
+          DEPLOY_TAG: ${{ inputs.tag }}
         run: |
-          gordon push --build \
-            --remote ${{ secrets.GORDON_REMOTE }} \
-            ${{ github.event.inputs.tag && format('--tag {0}', github.event.inputs.tag) || '' }} \
-            --no-confirm
+          args=(push --build --remote "$GORDON_REMOTE" --no-confirm)
+          if [[ -n "$DEPLOY_TAG" ]]; then
+            [[ "$DEPLOY_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || exit 1
+            args+=(--tag "$DEPLOY_TAG")
+          fi
+          gordon "${args[@]}"
 ```
 
 #### Monorepo

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -147,21 +147,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Registry
-        run: |
-          echo "${{ secrets.GORDON_TOKEN }}" | \
-          docker login -u ${{ secrets.GORDON_USERNAME }} --password-stdin ${{ secrets.GORDON_REGISTRY }}
+        env:
+          GORDON_TOKEN: ${{ secrets.GORDON_TOKEN }}
+          GORDON_USERNAME: ${{ secrets.GORDON_USERNAME }}
+          GORDON_REGISTRY: ${{ secrets.GORDON_REGISTRY }}
+        run: printf '%s' "$GORDON_TOKEN" | docker login -u "$GORDON_USERNAME" --password-stdin "$GORDON_REGISTRY"
 
       - name: Rollback
+        env:
+          GORDON_REGISTRY: ${{ secrets.GORDON_REGISTRY }}
+          VERSION: ${{ inputs.version }}
         run: |
-          docker pull ${{ secrets.GORDON_REGISTRY }}/myapp:${{ github.event.inputs.version }}
-          docker tag ${{ secrets.GORDON_REGISTRY }}/myapp:${{ github.event.inputs.version }} \
-                     ${{ secrets.GORDON_REGISTRY }}/myapp:latest
-          docker push ${{ secrets.GORDON_REGISTRY }}/myapp:latest
+          [[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || exit 1
+          docker pull "$GORDON_REGISTRY/myapp:$VERSION"
+          docker tag "$GORDON_REGISTRY/myapp:$VERSION" "$GORDON_REGISTRY/myapp:latest"
+          docker push "$GORDON_REGISTRY/myapp:latest"
 
       - name: Summary
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          echo "## Rollback Complete" >> $GITHUB_STEP_SUMMARY
-          echo "Rolled back to version: ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Rollback Complete" >> "$GITHUB_STEP_SUMMARY"
+          printf 'Rolled back to version: %s\n' "$VERSION" >> "$GITHUB_STEP_SUMMARY"
 ```
 
 ### Rollback Script

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -159,9 +159,17 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           [[ "$VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || exit 1
-          docker pull "$GORDON_REGISTRY/myapp:$VERSION"
-          docker tag "$GORDON_REGISTRY/myapp:$VERSION" "$GORDON_REGISTRY/myapp:latest"
-          docker push "$GORDON_REGISTRY/myapp:latest"
+          REPOSITORY="$GORDON_REGISTRY/myapp"
+          SOURCE_IMAGE="$REPOSITORY:$VERSION"
+          LATEST_IMAGE="$REPOSITORY:latest"
+          SOURCE_DIGEST="$(docker buildx imagetools inspect "$SOURCE_IMAGE" --format '{{json .Manifest}}' | jq -er '.digest')"
+          IMMUTABLE_IMAGE="$REPOSITORY@$SOURCE_DIGEST"
+          docker buildx imagetools create --tag "$LATEST_IMAGE" "$IMMUTABLE_IMAGE"
+          LATEST_DIGEST="$(docker buildx imagetools inspect "$LATEST_IMAGE" --format '{{json .Manifest}}' | jq -er '.digest')"
+          [[ "$LATEST_DIGEST" == "$SOURCE_DIGEST" ]] || {
+            echo "rollback verification failed: latest resolved to $LATEST_DIGEST, expected $SOURCE_DIGEST" >&2
+            exit 1
+          }
 
       - name: Summary
         env:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,8 @@ Manual archive installation requires downloading the matching `checksums.txt` re
 
 **Linux (x86_64)**
 ```bash
-wget https://github.com/bnema/gordon/releases/latest/download/gordon_linux_amd64.tar.gz
+wget https://github.com/bnema/gordon/releases/latest/download/{gordon_linux_amd64.tar.gz,checksums.txt}
+grep ' gordon_linux_amd64.tar.gz$' checksums.txt | sha256sum --check --strict
 tar -xzf gordon_linux_amd64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
@@ -41,7 +42,8 @@ sudo mv gordon /usr/local/bin/
 
 **Linux (ARM64)** - for Raspberry Pi 4, AWS Graviton, Oracle Ampere, etc.
 ```bash
-wget https://github.com/bnema/gordon/releases/latest/download/gordon_linux_arm64.tar.gz
+wget https://github.com/bnema/gordon/releases/latest/download/{gordon_linux_arm64.tar.gz,checksums.txt}
+grep ' gordon_linux_arm64.tar.gz$' checksums.txt | sha256sum --check --strict
 tar -xzf gordon_linux_arm64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
@@ -49,7 +51,8 @@ sudo mv gordon /usr/local/bin/
 
 **macOS (Apple Silicon)**
 ```bash
-curl -LO https://github.com/bnema/gordon/releases/latest/download/gordon_darwin_arm64.tar.gz
+curl -LO https://github.com/bnema/gordon/releases/latest/download/{gordon_darwin_arm64.tar.gz,checksums.txt}
+grep ' gordon_darwin_arm64.tar.gz$' checksums.txt | shasum -a 256 --check
 tar -xzf gordon_darwin_arm64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
@@ -57,7 +60,8 @@ sudo mv gordon /usr/local/bin/
 
 **macOS (Intel)**
 ```bash
-curl -LO https://github.com/bnema/gordon/releases/latest/download/gordon_darwin_amd64.tar.gz
+curl -LO https://github.com/bnema/gordon/releases/latest/download/{gordon_darwin_amd64.tar.gz,checksums.txt}
+grep ' gordon_darwin_amd64.tar.gz$' checksums.txt | shasum -a 256 --check
 tar -xzf gordon_darwin_amd64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,12 +15,21 @@ Detailed installation guide for production environments.
 ### Quick Install (Recommended)
 
 ```bash
-curl -fsSL https://gordon.bnema.dev/install | bash
+(
+  set -euo pipefail
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL --output "$installer" https://gordon.bnema.dev/install
+  less "$installer"
+  bash "$installer"
+)
 ```
 
-This script automatically detects your OS (Linux/macOS) and architecture (amd64/arm64), downloads the appropriate binary from GitHub releases, and installs it to `/usr/local/bin`.
+Download and inspect the installer before executing it. The installer verifies the release archive checksum before installation and automatically detects your OS (Linux/macOS) and architecture (amd64/arm64), downloads the appropriate binary from GitHub releases, and installs it to `/usr/local/bin`.
 
 ### Manual Installation
+
+Manual archive installation requires downloading the matching `checksums.txt` release asset and verifying the archive's SHA-256 checksum before extraction. The checksum-verifying installer above is recommended.
 
 **Linux (x86_64)**
 ```bash
@@ -74,8 +83,9 @@ sudo mv gordon /usr/local/bin/
 ### Docker
 
 ```bash
-# Install Docker
-curl -fsSL https://get.docker.com | sh
+# Install Docker from your distribution's signed package repository.
+sudo apt update
+sudo apt install docker.io
 
 # Add user to docker group
 sudo usermod -aG docker $USER

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,11 @@ Detailed installation guide for production environments.
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
   curl -fsSL --output "$installer" https://gordon.bnema.dev/install
-  less "$installer"
+  if command -v less >/dev/null 2>&1; then
+    less "$installer"
+  else
+    cat "$installer"
+  fi
   bash "$installer"
 )
 ```
@@ -32,42 +36,47 @@ Download and inspect the installer before executing it. The installer verifies t
 Manual archive installation requires downloading the matching `checksums.txt` release asset and verifying the archive's SHA-256 checksum before extraction. The checksum-verifying installer above is recommended.
 
 **Linux (x86_64)**
+
 ```bash
 wget https://github.com/bnema/gordon/releases/latest/download/{gordon_linux_amd64.tar.gz,checksums.txt}
-grep ' gordon_linux_amd64.tar.gz$' checksums.txt | sha256sum --check --strict
+grep -E '^[[:xdigit:]]{64} ([* ]?)gordon_linux_amd64\.tar\.gz$' checksums.txt | sha256sum --check --strict
 tar -xzf gordon_linux_amd64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
 ```
 
 **Linux (ARM64)** - for Raspberry Pi 4, AWS Graviton, Oracle Ampere, etc.
+
 ```bash
 wget https://github.com/bnema/gordon/releases/latest/download/{gordon_linux_arm64.tar.gz,checksums.txt}
-grep ' gordon_linux_arm64.tar.gz$' checksums.txt | sha256sum --check --strict
+grep -E '^[[:xdigit:]]{64} ([* ]?)gordon_linux_arm64\.tar\.gz$' checksums.txt | sha256sum --check --strict
 tar -xzf gordon_linux_arm64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
 ```
 
 **macOS (Apple Silicon)**
+
 ```bash
 curl -LO https://github.com/bnema/gordon/releases/latest/download/{gordon_darwin_arm64.tar.gz,checksums.txt}
-grep ' gordon_darwin_arm64.tar.gz$' checksums.txt | shasum -a 256 --check
+grep -E '^[[:xdigit:]]{64} ([* ]?)gordon_darwin_arm64\.tar\.gz$' checksums.txt | shasum -a 256 --check
 tar -xzf gordon_darwin_arm64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
 ```
 
 **macOS (Intel)**
+
 ```bash
 curl -LO https://github.com/bnema/gordon/releases/latest/download/{gordon_darwin_amd64.tar.gz,checksums.txt}
-grep ' gordon_darwin_amd64.tar.gz$' checksums.txt | shasum -a 256 --check
+grep -E '^[[:xdigit:]]{64} ([* ]?)gordon_darwin_amd64\.tar\.gz$' checksums.txt | shasum -a 256 --check
 tar -xzf gordon_darwin_amd64.tar.gz
 chmod +x gordon
 sudo mv gordon /usr/local/bin/
 ```
 
 Verify installation:
+
 ```bash
 gordon version
 ```

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -207,6 +207,7 @@ available while Gordon is running.`,
 // newAuthLoginCmd creates the login command for remote authentication.
 func newAuthLoginCmd() *cobra.Command {
 	var tokenFile string
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -228,13 +229,14 @@ Examples:
 				if err != nil {
 					return fmt.Errorf("read token: %w", err)
 				}
-				return runAuthLoginWithToken(cmd.Context(), token, cmd.OutOrStdout())
+				return runAuthLoginWithToken(cmd.Context(), token, cmd.OutOrStdout(), jsonOut)
 			}
-			return runAuthLoginVerify(cmd.Context(), cmd.OutOrStdout())
+			return runAuthLoginVerify(cmd.Context(), cmd.OutOrStdout(), jsonOut)
 		},
 	}
 
 	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
 }
@@ -251,7 +253,7 @@ func resolveRequiredRemote(flagToken string) (*remote.ResolvedRemote, error) {
 	return resolved, nil
 }
 
-func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) error {
+func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer, jsonOut bool) error {
 	token = strings.TrimSpace(token)
 	if token == "" {
 		return fmt.Errorf("token cannot be empty")
@@ -268,19 +270,26 @@ func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) err
 	defer cancel()
 	verified := true
 	if _, err := client.GetStatus(verifyCtx); err != nil {
-		_ = cliWriteLine(out, styles.RenderWarning(fmt.Sprintf("Token verification failed: %v", err)))
+		if !jsonOut {
+			_ = cliWriteLine(out, styles.RenderWarning(fmt.Sprintf("Token verification failed: %v", err)))
+		}
 		verified = false
 	}
 
 	// Store token — requires a named remote.
 	if resolved.Name == "" {
-		_ = cliWriteLine(out, styles.RenderWarning("Ad-hoc URL: token verified but cannot be stored. Use 'gordon remotes add' to save this remote."))
-		return nil
+		if jsonOut {
+			return writeJSON(out, map[string]any{"remote": resolved.DisplayName(), "stored": false, "verified": verified})
+		}
+		return cliWriteLine(out, styles.RenderWarning("Ad-hoc URL: token verified but cannot be stored. Use 'gordon remotes add' to save this remote."))
 	}
 	if err := remote.UpdateRemoteToken(resolved.Name, token); err != nil {
 		return fmt.Errorf("failed to save token: %w", err)
 	}
 
+	if jsonOut {
+		return writeJSON(out, map[string]any{"remote": resolved.Name, "stored": true, "verified": verified})
+	}
 	_ = cliWriteLine(out, "")
 	_ = cliWriteLine(out, styles.RenderSuccess(fmt.Sprintf("Token stored for remote '%s'", resolved.Name)))
 	if verified {
@@ -289,7 +298,7 @@ func runAuthLoginWithToken(ctx context.Context, token string, out io.Writer) err
 	return nil
 }
 
-func runAuthLoginVerify(ctx context.Context, out io.Writer) error {
+func runAuthLoginVerify(ctx context.Context, out io.Writer, jsonOut bool) error {
 	resolved, err := resolveRequiredRemote(tokenFlag)
 	if err != nil {
 		return err
@@ -307,8 +316,10 @@ func runAuthLoginVerify(ctx context.Context, out io.Writer) error {
 		return fmt.Errorf("authentication failed")
 	}
 
-	_ = cliWriteLine(out, styles.RenderSuccess(fmt.Sprintf("Authenticated to '%s'", resolved.DisplayName())))
-	return nil
+	if jsonOut {
+		return writeJSON(out, map[string]any{"remote": resolved.DisplayName(), "authenticated": true})
+	}
+	return cliWriteLine(out, styles.RenderSuccess(fmt.Sprintf("Authenticated to '%s'", resolved.DisplayName())))
 }
 
 // newAuthShowTokenCmd creates the show-token command.

--- a/internal/adapters/in/cli/auth.go
+++ b/internal/adapters/in/cli/auth.go
@@ -206,31 +206,35 @@ available while Gordon is running.`,
 
 // newAuthLoginCmd creates the login command for remote authentication.
 func newAuthLoginCmd() *cobra.Command {
-	var token string
+	var tokenFile string
 
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with a Gordon server",
 		Long: `Store or verify a token for a Gordon server remote.
 
-With --token: stores the token and verifies it.
-Without --token: verifies the existing stored token still works.
+With --token-file: reads, stores, and verifies a token without exposing it in argv.
+Without --token-file: verifies the existing stored token still works.
 
 Generate a token on the server with: gordon auth token generate
 
 Examples:
-	gordon auth login --token <token>              Store token for active remote
-	gordon auth login --remote prod --token <tok>  Store token for specific remote
+	gordon auth login --token-file ./token         Store token for active remote
+	gordon auth login --remote prod --token-file ./token
 	gordon auth login                              Verify existing token`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if token != "" {
+			if tokenFile != "" {
+				token, err := readProtectedSecretFile(tokenFile)
+				if err != nil {
+					return fmt.Errorf("read token: %w", err)
+				}
 				return runAuthLoginWithToken(cmd.Context(), token, cmd.OutOrStdout())
 			}
 			return runAuthLoginVerify(cmd.Context(), cmd.OutOrStdout())
 		},
 	}
 
-	cmd.Flags().StringVarP(&token, "token", "t", "", "Authentication token to store for the remote")
+	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
 
 	return cmd
 }
@@ -291,7 +295,7 @@ func runAuthLoginVerify(ctx context.Context, out io.Writer) error {
 		return err
 	}
 	if resolved.Token == "" {
-		return fmt.Errorf("no token stored for remote '%s'; use: gordon auth login --token <token>", resolved.DisplayName())
+		return fmt.Errorf("no token stored for remote '%s'; use: gordon auth login --token-file <path>", resolved.DisplayName())
 	}
 
 	client := remote.NewClient(resolved.URL, remoteClientOptions(resolved.Token, resolved.InsecureTLS)...)

--- a/internal/adapters/in/cli/auth_test.go
+++ b/internal/adapters/in/cli/auth_test.go
@@ -39,8 +39,9 @@ func TestRunAuthLoginWithToken_StoresToken(t *testing.T) {
 	t.Cleanup(func() { remoteFlag = origRemote })
 
 	var out bytes.Buffer
-	err := runAuthLoginWithToken(context.Background(), "token123", &out)
+	err := runAuthLoginWithToken(context.Background(), "token123", &out, true)
 	assert.NoError(t, err)
+	assert.JSONEq(t, `{"remote":"prod","stored":true,"verified":false}`, out.String())
 
 	loaded, err := remote.LoadRemotes("")
 	assert.NoError(t, err)

--- a/internal/adapters/in/cli/remotes.go
+++ b/internal/adapters/in/cli/remotes.go
@@ -154,7 +154,7 @@ func remotesListJSON(out io.Writer, remotes map[string]remote.RemoteEntry, names
 
 // newRemotesAddCmd creates the remotes add command.
 func newRemotesAddCmd() *cobra.Command {
-	var token string
+	var tokenFile string
 	var tokenEnv string
 	var insecureTLS bool
 
@@ -165,7 +165,7 @@ func newRemotesAddCmd() *cobra.Command {
 
 Examples:
   gordon remotes add prod https://gordon.mydomain.com
-  gordon remotes add prod https://gordon.mydomain.com --token eyJ...
+  gordon remotes add prod https://gordon.mydomain.com --token-file ./token
   gordon remotes add staging https://staging.mydomain.com --token-env STAGING_TOKEN
   gordon remotes add dev https://dev.internal --insecure`,
 		Args: cobra.ExactArgs(2),
@@ -173,8 +173,14 @@ Examples:
 			name := args[0]
 			url := normalizeURL(args[1])
 
-			// If token-env is provided, use that instead of token
-			finalToken := token
+			var finalToken string
+			if tokenFile != "" {
+				var err error
+				finalToken, err = readProtectedSecretFile(tokenFile)
+				if err != nil {
+					return fmt.Errorf("read token: %w", err)
+				}
+			}
 			if tokenEnv != "" {
 				// Store token_env reference instead of actual token
 				if err := addRemoteWithEnv(name, url, tokenEnv, insecureTLS); err != nil {
@@ -188,15 +194,15 @@ Examples:
 
 			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Remote added: %s -> %s", name, url)))
 
-			if token == "" && tokenEnv == "" {
-				fmt.Println(styles.Theme.Muted.Render("Tip: Add a token with --token or --token-env for authenticated access"))
+			if tokenFile == "" && tokenEnv == "" {
+				fmt.Println(styles.Theme.Muted.Render("Tip: Add a token with --token-file or --token-env for authenticated access"))
 			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&token, "token", "", "Authentication token")
+	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
 	cmd.Flags().StringVar(&tokenEnv, "token-env", "", "Environment variable containing token")
 	cmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Skip TLS certificate verification")
 
@@ -313,8 +319,9 @@ Examples:
 
 // newRemotesSetTokenCmd creates the remotes set-token command.
 func newRemotesSetTokenCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "set-token <name> <token>",
+	var tokenFile string
+	cmd := &cobra.Command{
+		Use:   "set-token <name> --token-file <path>",
 		Short: "Set the token for a remote",
 		Long: `Set or update the authentication token for a saved remote.
 
@@ -326,12 +333,14 @@ This is useful when:
 For servers with password authentication, use 'gordon auth login' instead.
 
 Examples:
-  gordon remotes set-token prod eyJhbGciOiJIUzI1NiIs...
-  gordon remotes set-token staging $(cat token.txt)`,
-		Args: cobra.ExactArgs(2),
+  gordon remotes set-token prod --token-file ./token`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			token := args[1]
+			token, err := readProtectedSecretFile(tokenFile)
+			if err != nil {
+				return fmt.Errorf("read token: %w", err)
+			}
 
 			// Verify remote exists
 			remotes, _, err := remote.ListRemotes()
@@ -352,6 +361,9 @@ Examples:
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
+	_ = cmd.MarkFlagRequired("token-file")
+	return cmd
 }
 
 // normalizeURL ensures the URL has a protocol scheme, defaulting to https.

--- a/internal/adapters/in/cli/remotes.go
+++ b/internal/adapters/in/cli/remotes.go
@@ -157,6 +157,7 @@ func newRemotesAddCmd() *cobra.Command {
 	var tokenFile string
 	var tokenEnv string
 	var insecureTLS bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "add <name> <url>",
@@ -192,12 +193,15 @@ Examples:
 				}
 			}
 
-			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Remote added: %s -> %s", name, url)))
-
-			if tokenFile == "" && tokenEnv == "" {
-				fmt.Println(styles.Theme.Muted.Render("Tip: Add a token with --token-file or --token-env for authenticated access"))
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"name": name, "url": url, "added": true})
 			}
-
+			if err := cliWriteLine(cmd.OutOrStdout(), styles.RenderSuccess(fmt.Sprintf("Remote added: %s -> %s", name, url))); err != nil {
+				return err
+			}
+			if tokenFile == "" && tokenEnv == "" {
+				return cliWriteLine(cmd.OutOrStdout(), styles.Theme.Muted.Render("Tip: Add a token with --token-file or --token-env for authenticated access"))
+			}
 			return nil
 		},
 	}
@@ -205,6 +209,7 @@ Examples:
 	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
 	cmd.Flags().StringVar(&tokenEnv, "token-env", "", "Environment variable containing token")
 	cmd.Flags().BoolVar(&insecureTLS, "insecure", false, "Skip TLS certificate verification")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 
 	return cmd
 }
@@ -320,6 +325,7 @@ Examples:
 // newRemotesSetTokenCmd creates the remotes set-token command.
 func newRemotesSetTokenCmd() *cobra.Command {
 	var tokenFile string
+	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "set-token <name> --token-file <path>",
 		Short: "Set the token for a remote",
@@ -349,19 +355,24 @@ Examples:
 			}
 
 			if _, exists := remotes[name]; !exists {
-				fmt.Println(styles.RenderError(fmt.Sprintf("Remote '%s' not found", name)))
-				return nil
+				if jsonOut {
+					return writeJSON(cmd.OutOrStdout(), map[string]any{"name": name, "updated": false, "error": "remote not found"})
+				}
+				return cliWriteLine(cmd.OutOrStdout(), styles.RenderError(fmt.Sprintf("Remote '%s' not found", name)))
 			}
 
 			if err := remote.UpdateRemoteToken(name, token); err != nil {
 				return fmt.Errorf("failed to update token: %w", err)
 			}
 
-			fmt.Println(styles.RenderSuccess(fmt.Sprintf("Token updated for remote '%s'", name)))
-			return nil
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"name": name, "updated": true})
+			}
+			return cliWriteLine(cmd.OutOrStdout(), styles.RenderSuccess(fmt.Sprintf("Token updated for remote '%s'", name)))
 		},
 	}
 	cmd.Flags().StringVar(&tokenFile, "token-file", "", "Read authentication token from a mode 0600 file")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 	_ = cmd.MarkFlagRequired("token-file")
 	return cmd
 }

--- a/internal/adapters/in/cli/root.go
+++ b/internal/adapters/in/cli/root.go
@@ -38,7 +38,18 @@ const (
 // NewRootCmd creates the root command for Gordon CLI.
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "gordon",
+		Use: "gordon",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if tokenFlag == "" {
+				return nil
+			}
+			token, err := readProtectedSecretFile(tokenFlag)
+			if err != nil {
+				return fmt.Errorf("read remote token: %w", err)
+			}
+			tokenFlag = token
+			return nil
+		},
 		Short: "Gordon - A lightweight container deployment platform",
 		Long: `Gordon is a self-contained container deployment platform that combines
 a Docker registry with automatic container deployment capabilities.
@@ -61,7 +72,7 @@ Commands are organized by where they run:
 
 	// Add persistent flags for remote targeting
 	rootCmd.PersistentFlags().StringVarP(&remoteFlag, "remote", "r", "", "Remote name or URL (e.g., prod, https://gordon.mydomain.com)")
-	rootCmd.PersistentFlags().StringVar(&tokenFlag, "token", "", "Authentication token for remote")
+	rootCmd.PersistentFlags().StringVar(&tokenFlag, "token-file", "", "Read remote authentication token from a mode 0600 file")
 	rootCmd.PersistentFlags().BoolVar(&insecureTLSFlag, "insecure", false, "Skip TLS certificate verification for remote HTTPS endpoints")
 
 	// Server-only commands (must run on the Gordon host)

--- a/internal/adapters/in/cli/secret_input.go
+++ b/internal/adapters/in/cli/secret_input.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func readProtectedSecretFile(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("%s must not be accessible by group or others (use chmod 600)", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "", fmt.Errorf("%s is empty", path)
+	}
+	return value, nil
+}

--- a/internal/adapters/in/cli/secret_input.go
+++ b/internal/adapters/in/cli/secret_input.go
@@ -2,14 +2,28 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 func readProtectedSecretFile(path string) (string, error) {
-	info, err := os.Stat(path)
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("open secret file %s: %w", path, err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return "", fmt.Errorf("open secret file %s: invalid file descriptor", path)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat secret file %s: %w", path, err)
 	}
 	if !info.Mode().IsRegular() {
 		return "", fmt.Errorf("%s is not a regular file", path)
@@ -17,9 +31,9 @@ func readProtectedSecretFile(path string) (string, error) {
 	if info.Mode().Perm()&0o077 != 0 {
 		return "", fmt.Errorf("%s must not be accessible by group or others (use chmod 600)", path)
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read secret file %s: %w", path, err)
 	}
 	value := strings.TrimSpace(string(data))
 	if value == "" {

--- a/internal/adapters/in/cli/secret_input.go
+++ b/internal/adapters/in/cli/secret_input.go
@@ -14,6 +14,10 @@ func readProtectedSecretFile(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open secret file %s: %w", path, err)
 	}
+	if fd < 0 {
+		return "", fmt.Errorf("open secret file %s: invalid file descriptor %d", path, fd)
+	}
+	//nolint:gosec // G115: fd is validated non-negative and originates from unix.Open.
 	file := os.NewFile(uintptr(fd), path)
 	if file == nil {
 		_ = unix.Close(fd)

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -222,32 +222,32 @@ func getKeyPrefix(isLastAttachment, isLastKey bool) string {
 
 // newSecretsSetCmd creates the secrets set command.
 func newSecretsSetCmd() *cobra.Command {
-	var attachment string
+	var attachment, fromFile string
 
 	cmd := &cobra.Command{
-		Use:   "set <domain> <KEY=value>...",
+		Use:   "set <domain> --from-file <path>",
 		Short: "Set secrets for a domain or attachment",
 		Long: `Set one or more secrets for a domain or an attachment container.
 
-Secrets are specified as KEY=value pairs. Multiple secrets can be set at once.
+Secrets are read from a mode 0600 file containing one KEY=value pair per line.
 
 Use --attachment to target an attachment service (e.g., postgres, redis) instead
 of the main domain container.
 
 Examples:
-  gordon secrets set app.mydomain.com DATABASE_URL=postgres://localhost/db
-  gordon secrets set app.mydomain.com API_KEY=secret123 DEBUG=false
-  gordon secrets set app.mydomain.com --attachment postgres POSTGRES_PASSWORD=secret
-  gordon secrets set app.mydomain.com --attachment redis REDIS_PASSWORD=secret`,
-		Args: cobra.MinimumNArgs(2),
+  gordon secrets set app.mydomain.com --from-file ./app.env
+  gordon secrets set app.mydomain.com --attachment postgres --from-file ./postgres.env`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			secretDomain := args[0]
-			pairs := args[1:]
+			content, err := readProtectedSecretFile(fromFile)
+			if err != nil {
+				return fmt.Errorf("read secrets: %w", err)
+			}
 
-			// Parse KEY=value pairs
 			secrets := make(map[string]string)
-			for _, pair := range pairs {
+			for _, pair := range strings.Split(content, "\n") {
 				parts := strings.SplitN(pair, "=", 2)
 				if len(parts) != 2 {
 					return fmt.Errorf("invalid format: %s (expected KEY=value)", pair)
@@ -288,6 +288,8 @@ Examples:
 	}
 
 	cmd.Flags().StringVarP(&attachment, "attachment", "a", "", "Target an attachment service (e.g., postgres, redis)")
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Read KEY=value lines from a mode 0600 file")
+	_ = cmd.MarkFlagRequired("from-file")
 
 	return cmd
 }

--- a/internal/adapters/in/cli/secrets.go
+++ b/internal/adapters/in/cli/secrets.go
@@ -223,6 +223,7 @@ func getKeyPrefix(isLastAttachment, isLastKey bool) string {
 // newSecretsSetCmd creates the secrets set command.
 func newSecretsSetCmd() *cobra.Command {
 	var attachment, fromFile string
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:   "set <domain> --from-file <path>",
@@ -275,20 +276,23 @@ Examples:
 				target = fmt.Sprintf("%s [%s]", secretDomain, attachment)
 			}
 
+			if jsonOut {
+				return writeJSON(cmd.OutOrStdout(), map[string]any{
+					"domain": secretDomain, "attachment": attachment, "count": len(secrets), "updated": true,
+				})
+			}
 			if len(secrets) == 1 {
 				for key := range secrets {
-					fmt.Println(styles.RenderSuccess(fmt.Sprintf("Secret set: %s on %s", key, target)))
+					return cliWriteLine(cmd.OutOrStdout(), styles.RenderSuccess(fmt.Sprintf("Secret set: %s on %s", key, target)))
 				}
-			} else {
-				fmt.Println(styles.RenderSuccess(fmt.Sprintf("Set %d secrets for %s", len(secrets), target)))
 			}
-
-			return nil
+			return cliWriteLine(cmd.OutOrStdout(), styles.RenderSuccess(fmt.Sprintf("Set %d secrets for %s", len(secrets), target)))
 		},
 	}
 
 	cmd.Flags().StringVarP(&attachment, "attachment", "a", "", "Target an attachment service (e.g., postgres, redis)")
 	cmd.Flags().StringVar(&fromFile, "from-file", "", "Read KEY=value lines from a mode 0600 file")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 	_ = cmd.MarkFlagRequired("from-file")
 
 	return cmd

--- a/internal/adapters/in/http/registry/handler.go
+++ b/internal/adapters/in/http/registry/handler.go
@@ -370,6 +370,10 @@ func (h *Handler) handlePutManifest(w http.ResponseWriter, r *http.Request) {
 	digest, err := h.registrySvc.PutManifest(ctx, manifestObj)
 	if err != nil {
 		log.Error().Err(err).Str("name", name).Str("reference", reference).Msg("failed to store manifest")
+		if errors.Is(err, domain.ErrDigestMismatch) || errors.Is(err, domain.ErrInvalidDigest) {
+			h.sendRegistryError(w, http.StatusBadRequest, "DIGEST_INVALID", "manifest digest does not match content")
+			return
+		}
 		h.sendRegistryError(w, http.StatusInternalServerError, "MANIFEST_INVALID", "failed to store manifest")
 		return
 	}
@@ -387,7 +391,7 @@ func (h *Handler) handleGetBlob(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Str("name", name).Str("digest", digest).Msg("GET blob")
 
-	path, err := h.registrySvc.GetBlobPath(ctx, digest)
+	path, err := h.registrySvc.GetBlobPath(ctx, name, digest)
 	if err != nil {
 		log.Warn().Err(err).Str("name", name).Str("digest", digest).Msg("blob not found")
 		h.sendRegistryError(w, http.StatusNotFound, "BLOB_UNKNOWN", "blob not found")

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	"github.com/bnema/gordon/internal/domain"
@@ -204,6 +205,8 @@ func TestHandler_GetBlob_Success(t *testing.T) {
 	registrySvc := inmocks.NewMockRegistryService(t)
 
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
+	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	// Create a temp file for http.ServeFile
 	tmpFile, err := os.CreateTemp("", "blob-*")
@@ -216,28 +219,30 @@ func TestHandler_GetBlob_Success(t *testing.T) {
 
 	registrySvc.EXPECT().GetBlobPath(mock.Anything, "myapp", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(tmpFile.Name(), nil)
 
-	req := httptest.NewRequest("GET", "/v2/myapp/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", nil)
-	rec := httptest.NewRecorder()
+	resp, err := server.Client().Get(server.URL + "/v2/myapp/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, blobContent, rec.Body.Bytes())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, blobContent, body)
 }
 
 func TestHandler_GetBlob_NotFound(t *testing.T) {
 	registrySvc := inmocks.NewMockRegistryService(t)
 
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
+	server := httptest.NewServer(handler)
+	defer server.Close()
 
 	registrySvc.EXPECT().GetBlobPath(mock.Anything, "myapp", "sha256:0000000000000000000000000000000000000000000000000000000000000000").Return("", assert.AnError)
 
-	req := httptest.NewRequest("GET", "/v2/myapp/blobs/sha256:0000000000000000000000000000000000000000000000000000000000000000", nil)
-	rec := httptest.NewRecorder()
+	resp, err := server.Client().Get(server.URL + "/v2/myapp/blobs/sha256:0000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestHandler_BlobRoutes_MethodNotAllowed(t *testing.T) {

--- a/internal/adapters/in/http/registry/handler_test.go
+++ b/internal/adapters/in/http/registry/handler_test.go
@@ -214,7 +214,7 @@ func TestHandler_GetBlob_Success(t *testing.T) {
 	_, err = tmpFile.Write(blobContent)
 	assert.NoError(t, err)
 
-	registrySvc.EXPECT().GetBlobPath(mock.Anything, "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(tmpFile.Name(), nil)
+	registrySvc.EXPECT().GetBlobPath(mock.Anything, "myapp", "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4").Return(tmpFile.Name(), nil)
 
 	req := httptest.NewRequest("GET", "/v2/myapp/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", nil)
 	rec := httptest.NewRecorder()
@@ -230,7 +230,7 @@ func TestHandler_GetBlob_NotFound(t *testing.T) {
 
 	handler := NewHandler(registrySvc, testLogger(), DefaultMaxBlobChunkSize)
 
-	registrySvc.EXPECT().GetBlobPath(mock.Anything, "sha256:0000000000000000000000000000000000000000000000000000000000000000").Return("", assert.AnError)
+	registrySvc.EXPECT().GetBlobPath(mock.Anything, "myapp", "sha256:0000000000000000000000000000000000000000000000000000000000000000").Return("", assert.AnError)
 
 	req := httptest.NewRequest("GET", "/v2/myapp/blobs/sha256:0000000000000000000000000000000000000000000000000000000000000000", nil)
 	rec := httptest.NewRecorder()

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1736,11 +1737,11 @@ type boundedBuffer struct {
 func (w *boundedBuffer) Write(p []byte) (int, error) {
 	remaining := w.limit - w.Len()
 	if remaining <= 0 {
-		return 0, fmt.Errorf("container exec output exceeds %d bytes", w.limit)
+		return 0, fmt.Errorf("%w: limit is %d bytes", domain.ErrExecOutputExceeded, w.limit)
 	}
 	if len(p) > remaining {
 		_, _ = w.Buffer.Write(p[:remaining])
-		return remaining, fmt.Errorf("container exec output exceeds %d bytes", w.limit)
+		return remaining, fmt.Errorf("%w: limit is %d bytes", domain.ErrExecOutputExceeded, w.limit)
 	}
 	return w.Buffer.Write(p)
 }
@@ -1748,9 +1749,28 @@ func (w *boundedBuffer) Write(p []byte) (int, error) {
 func parseExecOutput(reader io.Reader) ([]byte, []byte, error) {
 	stdout := boundedBuffer{limit: maxExecOutputSize}
 	stderr := boundedBuffer{limit: maxExecOutputSize}
+	buffers := map[byte]*boundedBuffer{1: &stdout, 2: &stderr}
+	var header [8]byte
 
-	if _, err := stdcopy.StdCopy(&stdout, &stderr, reader); err != nil {
-		return nil, nil, err
+	for {
+		if _, err := io.ReadFull(reader, header[:]); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, nil, fmt.Errorf("read Docker exec frame header: %w", err)
+		}
+		output, ok := buffers[header[0]]
+		if !ok {
+			return nil, nil, fmt.Errorf("invalid Docker exec stream %d", header[0])
+		}
+		payloadSize := int64(binary.BigEndian.Uint32(header[4:]))
+		remaining := int64(output.limit - output.Len())
+		if payloadSize > remaining {
+			return nil, nil, fmt.Errorf("%w: frame is %d bytes with %d bytes remaining", domain.ErrExecOutputExceeded, payloadSize, remaining)
+		}
+		if _, err := io.CopyN(output, reader, payloadSize); err != nil {
+			return nil, nil, fmt.Errorf("read Docker exec frame payload: %w", err)
+		}
 	}
 
 	return stdout.Bytes(), stderr.Bytes(), nil

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -525,6 +525,7 @@ func (r *Runtime) GetContainerLogs(ctx context.Context, containerID string, foll
 		ShowStderr: true,
 		Follow:     follow,
 		Timestamps: true,
+		Tail:       "10000",
 	})
 	if err != nil {
 		return nil, log.WrapErr(err, "failed to get container logs")
@@ -747,6 +748,7 @@ func (r *Runtime) PruneImages(ctx context.Context, danglingOnly bool) (runtimepk
 	log := zerowrap.FromCtx(ctx)
 
 	pruneFilters := filters.NewArgs()
+	pruneFilters.Add("label", domain.LabelManaged+"=true")
 	if danglingOnly {
 		pruneFilters.Add("dangling", "true")
 	}
@@ -1724,9 +1726,28 @@ func (r *Runtime) ExecInContainer(ctx context.Context, containerID string, cmd [
 	}, nil
 }
 
+const maxExecOutputSize = 8 << 20 // 8 MiB per stream
+
+type boundedBuffer struct {
+	bytes.Buffer
+	limit int
+}
+
+func (w *boundedBuffer) Write(p []byte) (int, error) {
+	remaining := w.limit - w.Len()
+	if remaining <= 0 {
+		return 0, fmt.Errorf("container exec output exceeds %d bytes", w.limit)
+	}
+	if len(p) > remaining {
+		_, _ = w.Buffer.Write(p[:remaining])
+		return remaining, fmt.Errorf("container exec output exceeds %d bytes", w.limit)
+	}
+	return w.Buffer.Write(p)
+}
+
 func parseExecOutput(reader io.Reader) ([]byte, []byte, error) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	stdout := boundedBuffer{limit: maxExecOutputSize}
+	stderr := boundedBuffer{limit: maxExecOutputSize}
 
 	if _, err := stdcopy.StdCopy(&stdout, &stderr, reader); err != nil {
 		return nil, nil, err

--- a/internal/adapters/out/docker/runtime_exec_test.go
+++ b/internal/adapters/out/docker/runtime_exec_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func TestParseExecOutput_SplitsStdoutAndStderr(t *testing.T) {
@@ -21,6 +23,18 @@ func TestParseExecOutput_SplitsStdoutAndStderr(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello\n"), stdout)
 	assert.Equal(t, []byte("warn\n"), stderr)
+}
+
+func TestParseExecOutput_RejectsOversizedFrameBeforeReadingPayload(t *testing.T) {
+	var header [8]byte
+	header[0] = 1
+	binary.BigEndian.PutUint32(header[4:], maxExecOutputSize+1)
+
+	stdout, stderr, err := parseExecOutput(bytes.NewReader(header[:]))
+
+	assert.ErrorIs(t, err, domain.ErrExecOutputExceeded)
+	assert.Nil(t, stdout)
+	assert.Nil(t, stderr)
 }
 
 func TestRuntime_ExecInContainer_RejectsEmptyCommand(t *testing.T) {

--- a/internal/adapters/out/ratelimit/memory.go
+++ b/internal/adapters/out/ratelimit/memory.go
@@ -17,8 +17,18 @@ var _ out.RateLimiter = (*MemoryStore)(nil)
 
 // MemoryStore is an in-memory rate limiter implementation using golang.org/x/time/rate.
 // Each unique key gets its own independent rate limiter.
+type limiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+const (
+	maxLimiterEntries = 10000
+	limiterIdleTTL    = 10 * time.Minute
+)
+
 type MemoryStore struct {
-	limiters map[string]*rate.Limiter
+	limiters map[string]limiterEntry
 	mu       sync.RWMutex
 	rps      float64
 	burst    int
@@ -28,7 +38,7 @@ type MemoryStore struct {
 // NewMemoryStore creates a new in-memory rate limiter store.
 func NewMemoryStore(rps float64, burst int, log zerowrap.Logger) *MemoryStore {
 	return &MemoryStore{
-		limiters: make(map[string]*rate.Limiter),
+		limiters: make(map[string]limiterEntry),
 		rps:      rps,
 		burst:    burst,
 		log:      log,
@@ -48,23 +58,43 @@ func (s *MemoryStore) AllowN(_ context.Context, key string, n int) bool {
 
 // getLimiter returns the rate limiter for the given key, creating one if it doesn't exist.
 func (s *MemoryStore) getLimiter(key string) *rate.Limiter {
-	s.mu.RLock()
-	limiter, exists := s.limiters[key]
-	s.mu.RUnlock()
-
-	if exists {
-		return limiter
-	}
-
+	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Double-check after acquiring write lock
-	if limiter, exists = s.limiters[key]; exists {
-		return limiter
+	if entry, exists := s.limiters[key]; exists {
+		entry.lastSeen = now
+		s.limiters[key] = entry
+		return entry.limiter
 	}
 
-	limiter = rate.NewLimiter(rate.Limit(s.rps), s.burst)
-	s.limiters[key] = limiter
+	s.evictExpiredOrOldest(now)
+	limiter := rate.NewLimiter(rate.Limit(s.rps), s.burst)
+	s.limiters[key] = limiterEntry{limiter: limiter, lastSeen: now}
 	return limiter
+}
+
+func (s *MemoryStore) evictExpiredOrOldest(now time.Time) {
+	for key, entry := range s.limiters {
+		if now.Sub(entry.lastSeen) > limiterIdleTTL {
+			delete(s.limiters, key)
+		}
+	}
+	if len(s.limiters) < maxLimiterEntries {
+		return
+	}
+
+	var oldestKey string
+	var oldest time.Time
+	found := false
+	for key, entry := range s.limiters {
+		if !found || entry.lastSeen.Before(oldest) {
+			oldestKey = key
+			oldest = entry.lastSeen
+			found = true
+		}
+	}
+	if found {
+		delete(s.limiters, oldestKey)
+	}
 }

--- a/internal/adapters/out/ratelimit/memory.go
+++ b/internal/adapters/out/ratelimit/memory.go
@@ -2,6 +2,7 @@
 package ratelimit
 
 import (
+	"container/list"
 	"context"
 	"sync"
 	"time"
@@ -18,6 +19,7 @@ var _ out.RateLimiter = (*MemoryStore)(nil)
 // MemoryStore is an in-memory rate limiter implementation using golang.org/x/time/rate.
 // Each unique key gets its own independent rate limiter.
 type limiterEntry struct {
+	key      string
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
@@ -28,8 +30,9 @@ const (
 )
 
 type MemoryStore struct {
-	limiters map[string]limiterEntry
-	mu       sync.RWMutex
+	limiters map[string]*list.Element
+	lru      *list.List
+	mu       sync.Mutex
 	rps      float64
 	burst    int
 	log      zerowrap.Logger
@@ -38,7 +41,8 @@ type MemoryStore struct {
 // NewMemoryStore creates a new in-memory rate limiter store.
 func NewMemoryStore(rps float64, burst int, log zerowrap.Logger) *MemoryStore {
 	return &MemoryStore{
-		limiters: make(map[string]limiterEntry),
+		limiters: make(map[string]*list.Element),
+		lru:      list.New(),
 		rps:      rps,
 		burst:    burst,
 		log:      log,
@@ -62,39 +66,40 @@ func (s *MemoryStore) getLimiter(key string) *rate.Limiter {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if entry, exists := s.limiters[key]; exists {
+	if element, exists := s.limiters[key]; exists {
+		entry := element.Value.(*limiterEntry)
 		entry.lastSeen = now
-		s.limiters[key] = entry
+		s.lru.MoveToFront(element)
 		return entry.limiter
 	}
 
 	s.evictExpiredOrOldest(now)
 	limiter := rate.NewLimiter(rate.Limit(s.rps), s.burst)
-	s.limiters[key] = limiterEntry{limiter: limiter, lastSeen: now}
+	entry := &limiterEntry{key: key, limiter: limiter, lastSeen: now}
+	s.limiters[key] = s.lru.PushFront(entry)
 	return limiter
 }
 
 func (s *MemoryStore) evictExpiredOrOldest(now time.Time) {
-	for key, entry := range s.limiters {
-		if now.Sub(entry.lastSeen) > limiterIdleTTL {
-			delete(s.limiters, key)
+	for element := s.lru.Back(); element != nil; {
+		entry := element.Value.(*limiterEntry)
+		if now.Sub(entry.lastSeen) <= limiterIdleTTL {
+			break
 		}
+		previous := element.Prev()
+		s.removeElement(element)
+		element = previous
 	}
-	if len(s.limiters) < maxLimiterEntries {
+	if len(s.limiters) >= maxLimiterEntries {
+		s.removeElement(s.lru.Back())
+	}
+}
+
+func (s *MemoryStore) removeElement(element *list.Element) {
+	if element == nil {
 		return
 	}
-
-	var oldestKey string
-	var oldest time.Time
-	found := false
-	for key, entry := range s.limiters {
-		if !found || entry.lastSeen.Before(oldest) {
-			oldestKey = key
-			oldest = entry.lastSeen
-			found = true
-		}
-	}
-	if found {
-		delete(s.limiters, oldestKey)
-	}
+	entry := element.Value.(*limiterEntry)
+	delete(s.limiters, entry.key)
+	s.lru.Remove(element)
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -84,6 +84,7 @@ import (
 	"github.com/bnema/gordon/internal/usecase/proxy"
 	"github.com/bnema/gordon/internal/usecase/publictls"
 	registrySvc "github.com/bnema/gordon/internal/usecase/registry"
+	"github.com/bnema/gordon/internal/usecase/registrystate"
 	secretsSvc "github.com/bnema/gordon/internal/usecase/secrets"
 	servicecfg "github.com/bnema/gordon/internal/usecase/services"
 	"github.com/bnema/gordon/internal/usecase/traffic"
@@ -747,9 +748,9 @@ func (si *serviceInit) initRuntimeAndProxy() error {
 		return err
 	}
 
-	registryMutationMu := &sync.RWMutex{}
-	si.svc.registrySvc = registrySvc.NewService(si.svc.blobStorage, si.svc.manifestStorage, si.svc.eventBus, registryMutationMu)
-	si.svc.imageSvc = images.NewService(si.svc.runtime, si.svc.manifestStorage, si.svc.blobStorage, si.log, registryMutationMu)
+	registryState := registrystate.New()
+	si.svc.registrySvc = registrySvc.NewService(si.svc.blobStorage, si.svc.manifestStorage, si.svc.eventBus, registryState)
+	si.svc.imageSvc = images.NewService(si.svc.runtime, si.svc.manifestStorage, si.svc.blobStorage, si.log, registryState)
 	si.svc.volumeSvc = volumesSvc.NewService(si.svc.runtime)
 
 	injectTelemetryMetrics(si.cfg, si.svc, si.log)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -747,8 +747,9 @@ func (si *serviceInit) initRuntimeAndProxy() error {
 		return err
 	}
 
-	si.svc.registrySvc = registrySvc.NewService(si.svc.blobStorage, si.svc.manifestStorage, si.svc.eventBus)
-	si.svc.imageSvc = images.NewService(si.svc.runtime, si.svc.manifestStorage, si.svc.blobStorage, si.log)
+	registryMutationMu := &sync.RWMutex{}
+	si.svc.registrySvc = registrySvc.NewService(si.svc.blobStorage, si.svc.manifestStorage, si.svc.eventBus, registryMutationMu)
+	si.svc.imageSvc = images.NewService(si.svc.runtime, si.svc.manifestStorage, si.svc.blobStorage, si.log, registryMutationMu)
 	si.svc.volumeSvc = volumesSvc.NewService(si.svc.runtime)
 
 	injectTelemetryMetrics(si.cfg, si.svc, si.log)

--- a/internal/boundaries/in/mocks/mock_registry_service.go
+++ b/internal/boundaries/in/mocks/mock_registry_service.go
@@ -438,8 +438,8 @@ func (_c *MockRegistryService_GetBlob_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // GetBlobPath provides a mock function for the type MockRegistryService
-func (_mock *MockRegistryService) GetBlobPath(ctx context.Context, digest string) (string, error) {
-	ret := _mock.Called(ctx, digest)
+func (_mock *MockRegistryService) GetBlobPath(ctx context.Context, name string, digest string) (string, error) {
+	ret := _mock.Called(ctx, name, digest)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBlobPath")
@@ -447,16 +447,16 @@ func (_mock *MockRegistryService) GetBlobPath(ctx context.Context, digest string
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
-		return returnFunc(ctx, digest)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return returnFunc(ctx, name, digest)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) string); ok {
-		r0 = returnFunc(ctx, digest)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = returnFunc(ctx, name, digest)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, digest)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, name, digest)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -470,12 +470,13 @@ type MockRegistryService_GetBlobPath_Call struct {
 
 // GetBlobPath is a helper method to define mock.On call
 //   - ctx context.Context
+//   - name string
 //   - digest string
-func (_e *MockRegistryService_Expecter) GetBlobPath(ctx any, digest any) *MockRegistryService_GetBlobPath_Call {
-	return &MockRegistryService_GetBlobPath_Call{Call: _e.mock.On("GetBlobPath", ctx, digest)}
+func (_e *MockRegistryService_Expecter) GetBlobPath(ctx any, name any, digest any) *MockRegistryService_GetBlobPath_Call {
+	return &MockRegistryService_GetBlobPath_Call{Call: _e.mock.On("GetBlobPath", ctx, name, digest)}
 }
 
-func (_c *MockRegistryService_GetBlobPath_Call) Run(run func(ctx context.Context, digest string)) *MockRegistryService_GetBlobPath_Call {
+func (_c *MockRegistryService_GetBlobPath_Call) Run(run func(ctx context.Context, name string, digest string)) *MockRegistryService_GetBlobPath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -485,9 +486,14 @@ func (_c *MockRegistryService_GetBlobPath_Call) Run(run func(ctx context.Context
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -498,7 +504,7 @@ func (_c *MockRegistryService_GetBlobPath_Call) Return(s string, err error) *Moc
 	return _c
 }
 
-func (_c *MockRegistryService_GetBlobPath_Call) RunAndReturn(run func(ctx context.Context, digest string) (string, error)) *MockRegistryService_GetBlobPath_Call {
+func (_c *MockRegistryService_GetBlobPath_Call) RunAndReturn(run func(ctx context.Context, name string, digest string) (string, error)) *MockRegistryService_GetBlobPath_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/in/registry.go
+++ b/internal/boundaries/in/registry.go
@@ -16,7 +16,7 @@ type RegistryService interface {
 
 	// Blob operations
 	GetBlob(ctx context.Context, digest string) (io.ReadCloser, error)
-	GetBlobPath(ctx context.Context, digest string) (string, error)
+	GetBlobPath(ctx context.Context, name, digest string) (string, error)
 	PutBlob(ctx context.Context, digest string, data io.Reader, size int64) error
 	BlobExists(ctx context.Context, digest string) bool
 

--- a/internal/domain/auth.go
+++ b/internal/domain/auth.go
@@ -35,6 +35,7 @@ type TokenClaims struct {
 	IssuedAt    int64    `json:"iat"`
 	ExpiresAt   int64    `json:"exp,omitempty"` // 0 means never expires
 	Issuer      string   `json:"iss"`
+	TokenType   string   `json:"token_type"`
 	IsEphemeral bool     `json:"-"` // true when token was issued by /auth/token (not stored)
 }
 
@@ -257,17 +258,12 @@ func ScopesGrantRegistryAccess(grantedScopes []string, repoName, action string) 
 	return false
 }
 
-// ScopesGrantAdminAccess reports whether any of the granted scope strings
-// authorise the given action on the named admin resource.
-// It handles the wildcard shorthand ("*") as well as full admin scope format
-// (admin:resource:actions).
+// ScopesGrantAdminAccess reports whether an explicit admin scope authorises
+// the given action on the named admin resource. Untyped shorthand scopes such
+// as "*" are registry-only and never grant administrative access.
 func ScopesGrantAdminAccess(grantedScopes []string, resource, action string) bool {
 	for _, raw := range grantedScopes {
 		scopeStr := strings.TrimSpace(raw)
-		if scopeStr == ScopeActionAll {
-			return true
-		}
-
 		adminScope, err := ParseAdminScope(scopeStr)
 		if err != nil {
 			continue

--- a/internal/domain/auth_test.go
+++ b/internal/domain/auth_test.go
@@ -443,11 +443,11 @@ func TestScopesGrantAdminAccess(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "wildcard shorthand grants any admin access",
+			name:     "wildcard shorthand does not grant admin access",
 			granted:  []string{"*"},
 			resource: "routes",
 			action:   "read",
-			want:     true,
+			want:     false,
 		},
 		{
 			name:     "exact admin scope grants matching resource and action",

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -28,13 +28,14 @@ var (
 	ErrNoTargetAvailable  = errors.New("no target available for route")
 
 	// Registry errors
-	ErrManifestNotFound = errors.New("manifest not found")
-	ErrBlobNotFound     = errors.New("blob not found")
-	ErrUploadNotFound   = errors.New("upload not found")
-	ErrInvalidDigest    = errors.New("invalid digest")
-	ErrDigestMismatch   = errors.New("digest mismatch")
-	ErrUnauthorized     = errors.New("unauthorized")
-	ErrBlobSizeExceeded = errors.New("blob size exceeds maximum")
+	ErrManifestNotFound   = errors.New("manifest not found")
+	ErrBlobNotFound       = errors.New("blob not found")
+	ErrUploadNotFound     = errors.New("upload not found")
+	ErrInvalidDigest      = errors.New("invalid digest")
+	ErrDigestMismatch     = errors.New("digest mismatch")
+	ErrUnauthorized       = errors.New("unauthorized")
+	ErrBlobSizeExceeded   = errors.New("blob size exceeds maximum")
+	ErrExecOutputExceeded = errors.New("container exec output exceeds maximum")
 
 	// Network errors
 	ErrNetworkNotFound = errors.New("network not found")
@@ -58,11 +59,13 @@ var (
 	ErrRouteConflict        = errors.New("route conflicts with existing configuration")
 
 	// Environment errors
-	ErrEnvFileNotFound      = errors.New("environment file not found")
-	ErrSecretNotFound       = errors.New("secret not found")
-	ErrSecretsAlreadyExist  = errors.New("secrets already exist")
-	ErrProviderNotFound     = errors.New("secret provider not found")
-	ErrInvalidContainerName = errors.New("invalid container name")
+	ErrEnvFileNotFound             = errors.New("environment file not found")
+	ErrSecretNotFound              = errors.New("secret not found")
+	ErrSecretsAlreadyExist         = errors.New("secrets already exist")
+	ErrProviderNotFound            = errors.New("secret provider not found")
+	ErrInvalidContainerName        = errors.New("invalid container name")
+	ErrAttachmentOwnershipMismatch = errors.New("attachment ownership mismatch")
+	ErrReadinessLogSizeExceeded    = errors.New("readiness log exceeds maximum")
 
 	// Authentication errors
 	ErrInvalidToken       = errors.New("invalid token")

--- a/internal/domain/sanitize.go
+++ b/internal/domain/sanitize.go
@@ -1,6 +1,10 @@
 package domain
 
-import "strings"
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
 
 // SanitizeDomainForContainer makes a domain safe for container naming.
 // It uses distinct replacements to avoid collisions between domains like
@@ -17,6 +21,12 @@ func SanitizeDomainForContainer(domain string) string {
 	result = strings.ReplaceAll(result, ":", "-_")
 	result = strings.ReplaceAll(result, "/", "--")
 	return result
+}
+
+// StableResourceName returns a Docker-safe, collision-resistant name fragment.
+func StableResourceName(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%s-%x", SanitizeDomainForContainer(value), digest[:6])
 }
 
 // SanitizeDomainForContainerLegacy uses the OLD (buggy) sanitization that replaces

--- a/internal/usecase/auth/service.go
+++ b/internal/usecase/auth/service.go
@@ -200,6 +200,9 @@ func buildTokenClaims(claims jwt.MapClaims) *domain.TokenClaims {
 			}
 		}
 	}
+	if tokenType, ok := claims["token_type"].(string); ok {
+		tokenClaims.TokenType = tokenType
+	}
 
 	return tokenClaims
 }
@@ -238,6 +241,9 @@ func ensureTokenNotExpired(tokenClaims *domain.TokenClaims, log zerowrap.Logger)
 // 2. Have lifetime ≤ MaxAccessTokenLifetime
 // 3. Be recently issued (within MaxAccessTokenLifetime) to prevent replay attacks
 func (s *Service) isEphemeralAccessToken(claims *domain.TokenClaims) bool {
+	if claims.TokenType != "access" {
+		return false // Only tokens minted by GenerateAccessToken may bypass the store
+	}
 	if claims.ExpiresAt <= 0 {
 		return false // Never-expiring tokens require store validation
 	}
@@ -289,12 +295,13 @@ func (s *Service) GenerateToken(ctx context.Context, subject string, scopes []st
 
 	// Build JWT claims
 	claims := jwt.MapClaims{
-		"jti":    tokenID,
-		"sub":    subject,
-		"iss":    TokenIssuer,
-		"iat":    now.Unix(),
-		"nbf":    now.Unix(), // SECURITY: Not-before claim for clock skew protection
-		"scopes": scopes,
+		"jti":        tokenID,
+		"sub":        subject,
+		"iss":        TokenIssuer,
+		"iat":        now.Unix(),
+		"nbf":        now.Unix(), // SECURITY: Not-before claim for clock skew protection
+		"scopes":     scopes,
+		"token_type": "stored",
 	}
 
 	// Set expiry if specified
@@ -349,13 +356,14 @@ func (s *Service) GenerateAccessToken(ctx context.Context, subject string, scope
 	now := time.Now().UTC()
 
 	claims := jwt.MapClaims{
-		"jti":    tokenID,
-		"sub":    subject,
-		"iss":    TokenIssuer,
-		"iat":    now.Unix(),
-		"nbf":    now.Unix(), // SECURITY: Not-before claim for clock skew protection
-		"scopes": scopes,
-		"exp":    now.Add(expiry).Unix(),
+		"jti":        tokenID,
+		"sub":        subject,
+		"iss":        TokenIssuer,
+		"iat":        now.Unix(),
+		"nbf":        now.Unix(), // SECURITY: Not-before claim for clock skew protection
+		"scopes":     scopes,
+		"exp":        now.Add(expiry).Unix(),
+		"token_type": "access",
 	}
 
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/usecase/auth/service.go
+++ b/internal/usecase/auth/service.go
@@ -515,13 +515,14 @@ func (s *Service) ExtendToken(ctx context.Context, tokenString string) (string, 
 	newExpiresAt := now.Add(tokenExtensionTTL)
 
 	newClaims := jwt.MapClaims{
-		"jti":    tokenClaims.ID, // Reuse existing JTI to avoid invalidating concurrent requests
-		"sub":    tokenClaims.Subject,
-		"iss":    TokenIssuer,
-		"iat":    now.Unix(), // Update to current time (token is being re-issued)
-		"nbf":    now.Unix(), // SECURITY: not-before matches issuance time
-		"scopes": tokenClaims.Scopes,
-		"exp":    newExpiresAt.Unix(),
+		"jti":        tokenClaims.ID, // Reuse existing JTI to avoid invalidating concurrent requests
+		"sub":        tokenClaims.Subject,
+		"iss":        TokenIssuer,
+		"iat":        now.Unix(), // Update to current time (token is being re-issued)
+		"nbf":        now.Unix(), // SECURITY: not-before matches issuance time
+		"scopes":     tokenClaims.Scopes,
+		"exp":        newExpiresAt.Unix(),
+		"token_type": "stored",
 	}
 
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, newClaims)

--- a/internal/usecase/auth/service_test.go
+++ b/internal/usecase/auth/service_test.go
@@ -939,6 +939,20 @@ func TestIsEphemeralAccessTokenRejectsFutureIat(t *testing.T) {
 	}
 }
 
+func TestIsEphemeralAccessTokenRequiresExplicitTokenType(t *testing.T) {
+	svc, _ := newTestAuthService(t)
+	now := time.Now().UTC()
+
+	claims := &domain.TokenClaims{
+		IssuedAt:  now.Unix(),
+		ExpiresAt: now.Add(5 * time.Minute).Unix(),
+	}
+
+	assert.False(t, svc.isEphemeralAccessToken(claims))
+	claims.TokenType = "access"
+	assert.True(t, svc.isEphemeralAccessToken(claims))
+}
+
 func TestExtendTokenSkipsServiceToken(t *testing.T) {
 	tokenStore := mocks.NewMockTokenStore(t)
 

--- a/internal/usecase/auth/service_test.go
+++ b/internal/usecase/auth/service_test.go
@@ -802,6 +802,7 @@ func TestExtendTokenSlidesExpiry(t *testing.T) {
 	expectedExpiry := time.Now().Add(24 * time.Hour)
 	actualExpiry := time.Unix(claims.ExpiresAt, 0)
 	assert.WithinDuration(t, expectedExpiry, actualExpiry, 5*time.Minute, "expiry should be ~24h from now")
+	assert.Equal(t, "stored", claims.TokenType)
 }
 
 func TestExtendTokenDebounce(t *testing.T) {

--- a/internal/usecase/auto/preview/handler.go
+++ b/internal/usecase/auto/preview/handler.go
@@ -79,11 +79,10 @@ func (h *AutoPreviewHandler) Handle(ctx context.Context, event domain.Event) err
 		// semaphore prevents a push burst from creating an unbounded goroutine backlog.
 		select {
 		case h.jobs <- struct{}{}:
+		case <-ctx.Done():
+			return fmt.Errorf("schedule preview %s for %s: %w", previewName, baseRoute.Domain, ctx.Err())
 		case <-h.serviceCtx.Done():
 			return h.serviceCtx.Err()
-		default:
-			log.Warn().Str("preview", previewName).Str("base_route", baseRoute.Domain).Msg("preview worker queue is full, skipping event")
-			continue
 		}
 		go func(baseRoute baseRouteInfo, previewDomain string) {
 			defer func() { <-h.jobs }()

--- a/internal/usecase/auto/preview/handler.go
+++ b/internal/usecase/auto/preview/handler.go
@@ -16,6 +16,7 @@ type AutoPreviewHandler struct {
 	serviceCtx     context.Context
 	config         auto.AutoConfigProvider
 	previewService *Service
+	jobs           chan struct{}
 }
 
 func NewAutoPreviewHandler(
@@ -27,6 +28,7 @@ func NewAutoPreviewHandler(
 		serviceCtx:     serviceCtx,
 		config:         config,
 		previewService: previewService,
+		jobs:           make(chan struct{}, 16),
 	}
 }
 
@@ -73,8 +75,18 @@ func (h *AutoPreviewHandler) Handle(ctx context.Context, event domain.Event) err
 			continue
 		}
 
-		// Launch async — volume cloning may exceed event bus timeout
+		// Launch async — volume cloning may exceed event bus timeout. The bounded
+		// semaphore prevents a push burst from creating an unbounded goroutine backlog.
+		select {
+		case h.jobs <- struct{}{}:
+		case <-h.serviceCtx.Done():
+			return h.serviceCtx.Err()
+		default:
+			log.Warn().Str("preview", previewName).Str("base_route", baseRoute.Domain).Msg("preview worker queue is full, skipping event")
+			continue
+		}
 		go func(baseRoute baseRouteInfo, previewDomain string) {
+			defer func() { <-h.jobs }()
 			if err := h.previewService.CreatePreview(h.serviceCtx, CreatePreviewRequest{
 				Name:          previewName,
 				Domain:        previewDomain,

--- a/internal/usecase/auto/preview/service.go
+++ b/internal/usecase/auto/preview/service.go
@@ -339,6 +339,7 @@ func (s *Service) cloneBaseRouteVolumes(ctx context.Context, baseRoute, previewD
 
 	log := zerowrap.FromCtx(ctx)
 	basePrefix := prefix + "-" + domain.StableResourceName(baseRoute) + "-"
+	legacyBasePrefix := prefix + "-" + strings.ReplaceAll(baseRoute, ".", "-") + "-"
 
 	vols, err := s.volumeCloner.ListVolumes(ctx)
 	if err != nil {
@@ -347,7 +348,7 @@ func (s *Service) cloneBaseRouteVolumes(ctx context.Context, baseRoute, previewD
 
 	var sourceVols []string
 	for _, v := range vols {
-		if strings.HasPrefix(v.Name, basePrefix) {
+		if strings.HasPrefix(v.Name, basePrefix) || strings.HasPrefix(v.Name, legacyBasePrefix) {
 			sourceVols = append(sourceVols, v.Name)
 		}
 	}
@@ -358,6 +359,9 @@ func (s *Service) cloneBaseRouteVolumes(ctx context.Context, baseRoute, previewD
 
 	namer := func(sourceVolName string) string {
 		pathSuffix := strings.TrimPrefix(sourceVolName, basePrefix)
+		if pathSuffix == sourceVolName {
+			pathSuffix = strings.TrimPrefix(sourceVolName, legacyBasePrefix)
+		}
 		return generateVolumeName(prefix, previewDomain, pathSuffix)
 	}
 

--- a/internal/usecase/auto/preview/service.go
+++ b/internal/usecase/auto/preview/service.go
@@ -92,7 +92,17 @@ func (s *Service) Load(ctx context.Context) error {
 
 func (s *Service) Add(ctx context.Context, p domain.PreviewRoute) error {
 	s.mu.Lock()
-	s.previews = append(s.previews, p)
+	replaced := false
+	for i := range s.previews {
+		if s.previews[i].Domain == p.Domain {
+			s.previews[i] = p
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		s.previews = append(s.previews, p)
+	}
 	cp := make([]domain.PreviewRoute, len(s.previews))
 	copy(cp, s.previews)
 	s.mu.Unlock()
@@ -102,7 +112,7 @@ func (s *Service) Add(ctx context.Context, p domain.PreviewRoute) error {
 func (s *Service) Update(ctx context.Context, p domain.PreviewRoute) error {
 	s.mu.Lock()
 	for i := range s.previews {
-		if s.previews[i].Name == p.Name {
+		if s.previews[i].Domain == p.Domain {
 			s.previews[i] = p
 			cp := make([]domain.PreviewRoute, len(s.previews))
 			copy(cp, s.previews)
@@ -313,8 +323,8 @@ func (s *Service) qualifyImage(image string) string {
 func generateVolumeName(prefix, domainName, volumePath string) string {
 	return fmt.Sprintf("%s-%s-%s",
 		prefix,
-		strings.ReplaceAll(domainName, ".", "-"),
-		strings.ReplaceAll(strings.Trim(volumePath, "/"), "/", "-"))
+		domain.StableResourceName(domainName),
+		domain.StableResourceName(strings.Trim(volumePath, "/")))
 }
 
 func (s *Service) cloneBaseRouteVolumes(ctx context.Context, baseRoute, previewDomain string) ([]string, error) {
@@ -328,7 +338,7 @@ func (s *Service) cloneBaseRouteVolumes(ctx context.Context, baseRoute, previewD
 	}
 
 	log := zerowrap.FromCtx(ctx)
-	basePrefix := prefix + "-" + strings.ReplaceAll(baseRoute, ".", "-") + "-"
+	basePrefix := prefix + "-" + domain.StableResourceName(baseRoute) + "-"
 
 	vols, err := s.volumeCloner.ListVolumes(ctx)
 	if err != nil {
@@ -370,11 +380,11 @@ type CreatePreviewRequest struct {
 
 // CreatePreview orchestrates the full preview creation: lock, clone volumes, start containers, register.
 func (s *Service) CreatePreview(ctx context.Context, req CreatePreviewRequest) error {
-	lock := s.AcquireNameLock(req.Name)
+	lock := s.AcquireNameLock(req.Domain)
 	lock.Lock()
 	defer func() {
 		lock.Unlock()
-		s.ReleaseNameLock(req.Name)
+		s.ReleaseNameLock(req.Domain)
 	}()
 
 	log := zerowrap.FromCtx(ctx)

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -211,7 +211,7 @@ func (s *Service) acquireDomainDeployLock(ctx context.Context, domain string) (f
 
 // buildContainerConfig constructs the container configuration for deployment.
 func (s *Service) deploymentContainerName(containerDomain string, existing *domain.Container) string {
-	canonicalName := fmt.Sprintf("gordon-%s", containerDomain)
+	canonicalName := managedContainerName(containerDomain)
 	if existing == nil {
 		return canonicalName
 	}
@@ -517,7 +517,7 @@ func (s *Service) resolveExistingContainer(ctx context.Context, domainName strin
 
 	// Slow path: query runtime for running containers
 	log := zerowrap.FromCtx(ctx)
-	canonicalName := fmt.Sprintf("gordon-%s", domainName)
+	canonicalName := managedContainerName(domainName)
 	candidateNames := map[string]bool{
 		canonicalName:           true,
 		canonicalName + "-new":  true,
@@ -1333,7 +1333,7 @@ func isManagedRouteContainerForDomain(c *domain.Container, domainName string) bo
 	if c.Labels[domain.LabelAttachment] == "true" {
 		return false
 	}
-	return c.Labels[domain.LabelRoute] == domainName || c.Labels[domain.LabelDomain] == domainName || c.Name == fmt.Sprintf("gordon-%s", domainName)
+	return c.Labels[domain.LabelRoute] == domainName || c.Labels[domain.LabelDomain] == domainName || c.Name == managedContainerName(domainName)
 }
 
 func isPreservedAttachmentForDomain(c *domain.Container, domainName string) bool {
@@ -1997,7 +1997,7 @@ func (s *Service) cleanupOldContainer(ctx context.Context, old *domain.Container
 	}
 
 	// Rename new container to canonical name
-	canonicalName := fmt.Sprintf("gordon-%s", domainName)
+	canonicalName := managedContainerName(domainName)
 	if err := s.runtime.RenameContainer(ctx, newContainerID, canonicalName); err != nil {
 		log.Warn().Err(err).Str("canonical_name", canonicalName).Msg("failed to rename container to canonical name")
 	}
@@ -2431,14 +2431,10 @@ func (s *Service) pullImage(ctx context.Context, pullRef string, isInternal bool
 		}, isInternal); err != nil {
 			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image")
 		}
-	case cfg.RegistryAuthEnabled:
-		if cfg.ServiceTokenUsername == "" || cfg.ServiceToken == "" {
-			return log.WrapErr(fmt.Errorf("registry service token not configured"), "failed to pull image for registry auth")
-		}
-		if err := s.runtime.PullImageWithAuth(ctx, pullRef, cfg.ServiceTokenUsername, cfg.ServiceToken); err != nil {
-			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image with auth")
-		}
 	default:
+		// Never send Gordon's service credentials to an external registry.
+		// External pulls are anonymous until per-registry credentials have an
+		// explicit trust-boundary-aware configuration path.
 		if err := s.runtime.PullImage(ctx, pullRef); err != nil {
 			return log.WrapErr(fmt.Errorf("%w: %w", domain.ErrImagePullFailed, err), "failed to pull image")
 		}
@@ -2537,6 +2533,16 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 
 	for _, path := range volumePaths {
 		name := generateVolumeName(cfg.VolumePrefix, domainName, path)
+		legacyName := legacyVolumeName(cfg.VolumePrefix, domainName, path)
+		legacyExists, err := s.runtime.VolumeExists(ctx, legacyName)
+		if err != nil {
+			log.WrapErrWithFields(err, "failed to check legacy volume", map[string]any{"volume": legacyName})
+			continue
+		}
+		if legacyExists {
+			volumes[path] = legacyName
+			continue
+		}
 
 		exists, err := s.runtime.VolumeExists(ctx, name)
 		if err != nil {
@@ -2593,7 +2599,7 @@ func (s *Service) generateNetworkName(identifier string) string {
 	cfg := s.config
 	s.mu.RUnlock()
 
-	return fmt.Sprintf("%s-%s", cfg.NetworkPrefix, strings.ReplaceAll(identifier, ".", "-"))
+	return fmt.Sprintf("%s-%s", cfg.NetworkPrefix, domain.StableResourceName(identifier))
 }
 
 func (s *Service) createNetworkIfNeeded(ctx context.Context, networkName string) error {
@@ -2613,7 +2619,11 @@ func (s *Service) createNetworkIfNeeded(ctx context.Context, networkName string)
 		s.mu.RLock()
 		internal := s.config.NetworkInternal
 		s.mu.RUnlock()
-		if err := s.runtime.CreateNetwork(ctx, networkName, domain.NetworkConfig{Driver: "bridge", Internal: internal}); err != nil {
+		if err := s.runtime.CreateNetwork(ctx, networkName, domain.NetworkConfig{
+			Driver:   "bridge",
+			Internal: internal,
+			Labels:   map[string]string{domain.LabelManaged: "true"},
+		}); err != nil {
 			return log.WrapErr(err, "failed to create network")
 		}
 		log.Info().Msg("created network for app isolation")
@@ -2624,7 +2634,7 @@ func (s *Service) createNetworkIfNeeded(ctx context.Context, networkName string)
 
 func (s *Service) cleanupOrphanedContainers(ctx context.Context, domainName string, skipContainerID string) error {
 	log := zerowrap.FromCtx(ctx)
-	expectedName := fmt.Sprintf("gordon-%s", domainName)
+	expectedName := managedContainerName(domainName)
 	expectedNewName := expectedName + "-new"
 	expectedNextName := expectedName + "-next"
 
@@ -2681,7 +2691,7 @@ func (s *Service) cleanupNetworkIfEmpty(ctx context.Context, networkName string)
 	}
 
 	for _, n := range networks {
-		if n.Name == networkName && len(n.Containers) == 0 {
+		if n.Name == networkName && len(n.Containers) == 0 && n.Labels[domain.LabelManaged] == "true" {
 			if err := s.runtime.RemoveNetwork(ctx, networkName); err != nil {
 				return err
 			}
@@ -3125,6 +3135,11 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 		return nil, nil
 	}
 
+	if existingContainer.Labels[domain.LabelManaged] != "true" ||
+		existingContainer.Labels[domain.LabelAttachment] != "true" ||
+		existingContainer.Labels[domain.LabelAttachedTo] != ownerDomain {
+		return nil, fmt.Errorf("legacy attachment name %q is owned by another workload", containerNameLegacy)
+	}
 	log.Info().Str("container_name", containerNameLegacy).Msg("found attachment with legacy naming, will be replaced")
 	if err := s.runtime.StopContainer(ctx, existingContainer.ID); err != nil {
 		return nil, log.WrapErr(err, "failed to stop legacy attachment container")
@@ -3137,6 +3152,10 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 }
 
 // Utility functions
+
+func managedContainerName(domainName string) string {
+	return "gordon-" + domainName
+}
 
 func normalizeImageRef(image string) string {
 	if isDigestRef(image) {
@@ -3179,6 +3198,13 @@ func normalizeImageRef(image string) string {
 }
 
 func generateVolumeName(prefix, domainName, volumePath string) string {
+	return fmt.Sprintf("%s-%s-%s",
+		prefix,
+		domain.StableResourceName(domainName),
+		domain.StableResourceName(strings.Trim(volumePath, "/")))
+}
+
+func legacyVolumeName(prefix, domainName, volumePath string) string {
 	return fmt.Sprintf("%s-%s-%s",
 		prefix,
 		strings.ReplaceAll(domainName, ".", "-"),

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -2540,8 +2540,13 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 			continue
 		}
 		if legacyExists {
-			volumes[path] = legacyName
-			continue
+			owned, ownershipErr := s.legacyVolumeOwnedByDomain(ctx, legacyName, domainName)
+			if ownershipErr != nil {
+				log.Warn().Err(ownershipErr).Str("volume", legacyName).Msg("could not verify legacy volume ownership; using stable volume name")
+			} else if owned {
+				volumes[path] = legacyName
+				continue
+			}
 		}
 
 		exists, err := s.runtime.VolumeExists(ctx, name)
@@ -3126,6 +3131,9 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 	containerName := fmt.Sprintf("gordon-%s-%s", sanitizeName(ownerDomain), serviceName)
 	existingContainer := s.findContainerByName(ctx, containerName)
 	if existingContainer != nil {
+		if err := validateAttachmentOwnership(existingContainer, ownerDomain, containerName); err != nil {
+			return nil, err
+		}
 		return existingContainer, nil
 	}
 
@@ -3135,10 +3143,8 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 		return nil, nil
 	}
 
-	if existingContainer.Labels[domain.LabelManaged] != "true" ||
-		existingContainer.Labels[domain.LabelAttachment] != "true" ||
-		existingContainer.Labels[domain.LabelAttachedTo] != ownerDomain {
-		return nil, fmt.Errorf("legacy attachment name %q is owned by another workload", containerNameLegacy)
+	if err := validateAttachmentOwnership(existingContainer, ownerDomain, containerNameLegacy); err != nil {
+		return nil, err
 	}
 	log.Info().Str("container_name", containerNameLegacy).Msg("found attachment with legacy naming, will be replaced")
 	if err := s.runtime.StopContainer(ctx, existingContainer.ID); err != nil {
@@ -3149,6 +3155,15 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 	}
 
 	return nil, nil
+}
+
+func validateAttachmentOwnership(container *domain.Container, ownerDomain, containerName string) error {
+	if container.Labels[domain.LabelManaged] != "true" ||
+		container.Labels[domain.LabelAttachment] != "true" ||
+		container.Labels[domain.LabelAttachedTo] != ownerDomain {
+		return fmt.Errorf("%w: attachment name %q is owned by another workload", domain.ErrAttachmentOwnershipMismatch, containerName)
+	}
+	return nil
 }
 
 // Utility functions
@@ -3209,6 +3224,25 @@ func legacyVolumeName(prefix, domainName, volumePath string) string {
 		prefix,
 		strings.ReplaceAll(domainName, ".", "-"),
 		strings.ReplaceAll(strings.Trim(volumePath, "/"), "/", "-"))
+}
+
+func (s *Service) legacyVolumeOwnedByDomain(ctx context.Context, volumeName, domainName string) (bool, error) {
+	containers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		return false, fmt.Errorf("list containers for legacy volume ownership: %w", err)
+	}
+	for _, container := range containers {
+		if container.Labels[domain.LabelManaged] != "true" ||
+			(container.Labels[domain.LabelRoute] != domainName && container.Labels[domain.LabelDomain] != domainName) {
+			continue
+		}
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == volumeName || mount.Source == volumeName {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func mergeEnvironmentVariables(dockerfileEnv, userEnv []string) []string {

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -200,16 +200,15 @@ func TestService_GetNetworkForApp_UsesLiveConfigProvider(t *testing.T) {
 		nil, Config{NetworkIsolation: true, NetworkPrefix: "gordon"}, provider,
 	)
 
-	// Should use group network: generateNetworkName produces "gordon-shared-group"
+	// Group and per-domain networks use collision-resistant names.
 	network := svc.getNetworkForApp("app1.example.com")
-	assert.Equal(t, "gordon-shared-group", network)
+	assert.Equal(t, svc.generateNetworkName("shared-group"), network)
 
 	network = svc.getNetworkForApp("app3.example.com")
-	assert.Equal(t, "gordon-shared-group", network)
+	assert.Equal(t, svc.generateNetworkName("shared-group"), network)
 
-	// Domain not in any group gets its own network: "gordon-solo-example-com"
 	network = svc.getNetworkForApp("solo.example.com")
-	assert.Equal(t, "gordon-solo-example-com", network)
+	assert.Equal(t, svc.generateNetworkName("solo.example.com"), network)
 }
 
 func TestService_ManagedContainersMetric_GlobalSeriesOnDeployReplaceAndRemove(t *testing.T) {
@@ -704,7 +703,7 @@ func TestService_Deploy_StrictHealthModeWithoutHealthcheckReturnsHint(t *testing
 	assert.ErrorContains(t, deployErr.Err, "no healthcheck detected")
 }
 
-func TestService_PullImage_UsesServiceTokenForExternalPull(t *testing.T) {
+func TestService_PullImage_DoesNotSendServiceTokenToExternalRegistry(t *testing.T) {
 	runtime := mocks.NewMockContainerRuntime(t)
 
 	config := Config{
@@ -717,28 +716,11 @@ func TestService_PullImage_UsesServiceTokenForExternalPull(t *testing.T) {
 	svc := NewService(runtime, nil, nil, nil, config, nil)
 	ctx := testContext()
 
-	runtime.EXPECT().PullImageWithAuth(mock.Anything, "registry.example.com/myapp:latest", "gordon-service", "service-token").Return(nil)
+	runtime.EXPECT().PullImage(mock.Anything, "registry.example.com/myapp:latest").Return(nil)
 
 	err := svc.pullImage(ctx, "registry.example.com/myapp:latest", false)
 
 	assert.NoError(t, err)
-}
-
-func TestService_PullImage_RequiresServiceTokenForExternalPull(t *testing.T) {
-	runtime := mocks.NewMockContainerRuntime(t)
-
-	config := Config{
-		AllowedRegistries:   []string{"docker.io"},
-		RegistryAuthEnabled: true,
-	}
-
-	svc := NewService(runtime, nil, nil, nil, config, nil)
-	ctx := testContext()
-
-	err := svc.pullImage(ctx, "registry.example.com/myapp:latest", false)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "registry service token not configured")
 }
 
 func TestService_PullImage_InternalRetriesOnConnectionRefused(t *testing.T) {
@@ -1041,13 +1023,17 @@ func TestService_Deploy_WithNetworkIsolation(t *testing.T) {
 	envLoader.EXPECT().LoadEnv(mock.Anything, "test.example.com").Return([]string{}, nil)
 	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
 
-	// Network isolation - should check and create network
-	runtime.EXPECT().NetworkExists(mock.Anything, "gordon-test-example-com").Return(false, nil)
-	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-test-example-com", domain.NetworkConfig{Driver: "bridge"}).Return(nil)
+	// Network isolation - should check and create an owned network.
+	networkName := svc.generateNetworkName("test.example.com")
+	runtime.EXPECT().NetworkExists(mock.Anything, networkName).Return(false, nil)
+	runtime.EXPECT().CreateNetwork(mock.Anything, networkName, domain.NetworkConfig{
+		Driver: "bridge",
+		Labels: map[string]string{domain.LabelManaged: "true"},
+	}).Return(nil)
 
 	container := &domain.Container{ID: "container-123", Status: "created"}
 	runtime.EXPECT().CreateContainer(mock.Anything, mock.MatchedBy(func(cfg *domain.ContainerConfig) bool {
-		return cfg.NetworkMode == "gordon-test-example-com"
+		return cfg.NetworkMode == networkName
 	})).Return(container, nil)
 	runtime.EXPECT().StartContainer(mock.Anything, "container-123").Return(nil)
 
@@ -1100,10 +1086,14 @@ func TestService_Deploy_WithVolumeAutoCreate(t *testing.T) {
 	runtime.EXPECT().InspectImageEnv(mock.Anything, "myapp:latest").Return([]string{}, nil)
 
 	// Volume operations
+	dataVolume := generateVolumeName("gordon", "test.example.com", "/data")
+	configVolume := generateVolumeName("gordon", "test.example.com", "/config")
 	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data", "/config"}, nil)
-	runtime.EXPECT().VolumeExists(mock.Anything, "gordon-test-example-com-data").Return(false, nil)
-	runtime.EXPECT().CreateVolume(mock.Anything, "gordon-test-example-com-data").Return(nil)
-	runtime.EXPECT().VolumeExists(mock.Anything, "gordon-test-example-com-config").Return(true, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyVolumeName("gordon", "test.example.com", "/data")).Return(false, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, dataVolume).Return(false, nil)
+	runtime.EXPECT().CreateVolume(mock.Anything, dataVolume).Return(nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyVolumeName("gordon", "test.example.com", "/config")).Return(false, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, configVolume).Return(true, nil)
 
 	container := &domain.Container{ID: "container-123", Status: "created"}
 	runtime.EXPECT().CreateContainer(mock.Anything, mock.MatchedBy(func(cfg *domain.ContainerConfig) bool {
@@ -1203,10 +1193,11 @@ func TestService_Remove_WithNetworkCleanup(t *testing.T) {
 	}
 
 	runtime.EXPECT().RemoveContainer(mock.Anything, "container-123", true).Return(nil)
+	networkName := svc.generateNetworkName("test.example.com")
 	runtime.EXPECT().ListNetworks(mock.Anything).Return([]*domain.NetworkInfo{
-		{Name: "gordon-test-example-com", Containers: []string{}},
+		{Name: networkName, Containers: []string{}, Labels: map[string]string{domain.LabelManaged: "true"}},
 	}, nil)
-	runtime.EXPECT().RemoveNetwork(mock.Anything, "gordon-test-example-com").Return(nil)
+	runtime.EXPECT().RemoveNetwork(mock.Anything, networkName).Return(nil)
 
 	err := svc.Remove(ctx, "container-123", true)
 
@@ -1777,14 +1768,14 @@ func TestGenerateVolumeName(t *testing.T) {
 			prefix:     "gordon",
 			domain:     "app.example.com",
 			volumePath: "/data",
-			expected:   "gordon-app-example-com-data",
+			expected:   "gordon-app__example__com-28059829b105-data-3a6eb0790f39",
 		},
 		{
 			name:       "nested path",
 			prefix:     "gordon",
 			domain:     "app.example.com",
 			volumePath: "/var/lib/data",
-			expected:   "gordon-app-example-com-var-lib-data",
+			expected:   "gordon-app__example__com-28059829b105-var--lib--data-323f0a44c820",
 		},
 	}
 
@@ -1794,6 +1785,20 @@ func TestGenerateVolumeName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestService_SetupVolumes_ReusesLegacyVolume(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: true, VolumePrefix: "gordon"}, nil)
+	legacyName := legacyVolumeName("gordon", "app.example.com", "/data")
+
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil)
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest")
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"/data": legacyName}, volumes)
 }
 
 func TestMergeEnvironmentVariables(t *testing.T) {
@@ -4480,7 +4485,11 @@ func TestService_CreateNetworkIfNeeded_UsesInternalOptionWhenConfigured(t *testi
 	svc := NewService(runtime, nil, nil, nil, Config{NetworkInternal: true}, nil)
 
 	runtime.EXPECT().NetworkExists(mock.Anything, "gordon-app").Return(false, nil)
-	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-app", domain.NetworkConfig{Driver: "bridge", Internal: true}).Return(nil)
+	runtime.EXPECT().CreateNetwork(mock.Anything, "gordon-app", domain.NetworkConfig{
+		Driver:   "bridge",
+		Internal: true,
+		Labels:   map[string]string{domain.LabelManaged: "true"},
+	}).Return(nil)
 
 	require.NoError(t, svc.createNetworkIfNeeded(testContext(), "gordon-app"))
 }

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1794,11 +1794,48 @@ func TestService_SetupVolumes_ReusesLegacyVolume(t *testing.T) {
 
 	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil)
 	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{{
+		Labels:       map[string]string{domain.LabelManaged: "true", domain.LabelRoute: "app.example.com"},
+		VolumeMounts: []domain.ContainerVolumeMount{{Name: legacyName}},
+	}}, nil)
 
 	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest")
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"/data": legacyName}, volumes)
+}
+
+func TestService_SetupVolumes_DoesNotReuseCollidingLegacyVolume(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: true, VolumePrefix: "gordon"}, nil)
+	legacyName := legacyVolumeName("gordon", "app.example.com", "/data")
+	stableName := generateVolumeName("gordon", "app.example.com", "/data")
+	require.Equal(t, legacyName, legacyVolumeName("gordon", "app-example.com", "/data"))
+
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil)
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{{
+		Labels:       map[string]string{domain.LabelManaged: "true", domain.LabelRoute: "app-example.com"},
+		VolumeMounts: []domain.ContainerVolumeMount{{Name: legacyName}},
+	}}, nil)
+	runtime.EXPECT().VolumeExists(mock.Anything, stableName).Return(true, nil)
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest")
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"/data": stableName}, volumes)
+}
+
+func TestValidateAttachmentOwnership(t *testing.T) {
+	owned := &domain.Container{Labels: map[string]string{
+		domain.LabelManaged: "true", domain.LabelAttachment: "true", domain.LabelAttachedTo: "app.example.com",
+	}}
+	require.NoError(t, validateAttachmentOwnership(owned, "app.example.com", "gordon-app-postgres"))
+
+	foreign := &domain.Container{Labels: map[string]string{
+		domain.LabelManaged: "true", domain.LabelAttachment: "true", domain.LabelAttachedTo: "other.example.com",
+	}}
+	assert.ErrorIs(t, validateAttachmentOwnership(foreign, "app.example.com", "gordon-app-postgres"), domain.ErrAttachmentOwnershipMismatch)
 }
 
 func TestMergeEnvironmentVariables(t *testing.T) {

--- a/internal/usecase/images/service.go
+++ b/internal/usecase/images/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bnema/gordon/internal/boundaries/out"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/registrystate"
 	"github.com/bnema/gordon/pkg/runtime"
 	"github.com/bnema/gordon/pkg/validation"
 )
@@ -25,6 +26,7 @@ type Service struct {
 	blobStorage     out.BlobStorage
 	log             zerowrap.Logger
 	mutationMu      *sync.RWMutex
+	registryState   *registrystate.State
 }
 
 type imageRuntime interface {
@@ -38,18 +40,19 @@ func NewService(
 	manifestStorage out.ManifestStorage,
 	blobStorage out.BlobStorage,
 	log zerowrap.Logger,
-	mutationLocks ...*sync.RWMutex,
+	states ...*registrystate.State,
 ) *Service {
-	mutationMu := &sync.RWMutex{}
-	if len(mutationLocks) > 0 && mutationLocks[0] != nil {
-		mutationMu = mutationLocks[0]
+	registryState := registrystate.New()
+	if len(states) > 0 && states[0] != nil {
+		registryState = states[0]
 	}
 	return &Service{
 		runtime:         rt,
 		manifestStorage: manifestStorage,
 		blobStorage:     blobStorage,
 		log:             log,
-		mutationMu:      mutationMu,
+		mutationMu:      &registryState.MutationMu,
+		registryState:   registryState,
 	}
 }
 
@@ -243,6 +246,10 @@ func (s *Service) PruneRegistry(ctx context.Context, keepLast int) (domain.Image
 		if err := s.collectKeptTagDigests(log, repository, tagInfos, keptTags, referencedDigests); err != nil {
 			return domain.ImagePruneReport{}, err
 		}
+	}
+
+	for digest := range s.registryState.PendingDigests(time.Now().UTC()) {
+		referencedDigests[digest] = struct{}{}
 	}
 
 	blobs, err := s.blobStorage.ListBlobs()

--- a/internal/usecase/images/service.go
+++ b/internal/usecase/images/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bnema/zerowrap"
@@ -23,6 +24,7 @@ type Service struct {
 	manifestStorage out.ManifestStorage
 	blobStorage     out.BlobStorage
 	log             zerowrap.Logger
+	mutationMu      *sync.RWMutex
 }
 
 type imageRuntime interface {
@@ -36,12 +38,18 @@ func NewService(
 	manifestStorage out.ManifestStorage,
 	blobStorage out.BlobStorage,
 	log zerowrap.Logger,
+	mutationLocks ...*sync.RWMutex,
 ) *Service {
+	mutationMu := &sync.RWMutex{}
+	if len(mutationLocks) > 0 && mutationLocks[0] != nil {
+		mutationMu = mutationLocks[0]
+	}
 	return &Service{
 		runtime:         rt,
 		manifestStorage: manifestStorage,
 		blobStorage:     blobStorage,
 		log:             log,
+		mutationMu:      mutationMu,
 	}
 }
 
@@ -194,6 +202,9 @@ func (s *Service) PruneRuntime(ctx context.Context) (domain.ImagePruneReport, er
 // It keeps the "latest" tag when present and keeps keepLast most-recent
 // non-latest tags from tagInfos.
 func (s *Service) PruneRegistry(ctx context.Context, keepLast int) (domain.ImagePruneReport, error) {
+	s.mutationMu.Lock()
+	defer s.mutationMu.Unlock()
+
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldUseCase: "PruneRegistry",

--- a/internal/usecase/images/service_test.go
+++ b/internal/usecase/images/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bnema/gordon/internal/boundaries/out"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/registrystate"
 	pkgruntime "github.com/bnema/gordon/pkg/runtime"
 )
 
@@ -330,6 +331,24 @@ func TestService_PruneRegistry_GarbageCollectsUnreferencedBlobs(t *testing.T) {
 	assert.Equal(t, 1, report.Registry.BlobsRemoved)
 	assert.Equal(t, int64(4096), report.Registry.SpaceReclaimed)
 	assert.Equal(t, []string{"sha256:orphan"}, blobStorage.deletedBlobs)
+}
+
+func TestService_PruneRegistry_PreservesPendingBlob(t *testing.T) {
+	manifestStorage := newFakeManifestStorage()
+	manifestStorage.repositories = []string{"gordon/api"}
+	manifestStorage.tagsByRepo["gordon/api"] = []string{"latest"}
+	manifestStorage.modTimes[manifestRefKey("gordon/api", "latest")] = time.Now().UTC()
+	manifestStorage.manifests[manifestRefKey("gordon/api", "latest")] = mustManifestJSON(t, "sha256:cfg-live", "sha256:layer-live")
+	blobStorage := &fakeBlobStorage{blobs: []string{"sha256:pending"}}
+	state := registrystate.New()
+	state.AddPending("sha256:pending", time.Now().UTC())
+	svc := NewService(&fakeRuntime{}, manifestStorage, blobStorage, zerowrap.Default(), state)
+
+	report, err := svc.PruneRegistry(context.Background(), 1)
+
+	require.NoError(t, err)
+	assert.Zero(t, report.Registry.BlobsRemoved)
+	assert.Empty(t, blobStorage.deletedBlobs)
 }
 
 func TestService_PruneRegistry_PreservesSharedBlobs(t *testing.T) {

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -4,6 +4,9 @@ package registry
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -31,6 +34,7 @@ type Service struct {
 	eventBus         out.EventPublisher
 	metrics          *telemetry.Metrics
 	suppressedImages sync.Map // imageName -> *time.Timer
+	mutationMu       *sync.RWMutex
 }
 
 // SetMetrics sets the telemetry metrics for the registry service.
@@ -43,11 +47,17 @@ func NewService(
 	blobStorage out.BlobStorage,
 	manifestStorage out.ManifestStorage,
 	eventBus out.EventPublisher,
+	mutationLocks ...*sync.RWMutex,
 ) *Service {
+	mutationMu := &sync.RWMutex{}
+	if len(mutationLocks) > 0 && mutationLocks[0] != nil {
+		mutationMu = mutationLocks[0]
+	}
 	return &Service{
 		blobStorage:     blobStorage,
 		manifestStorage: manifestStorage,
 		eventBus:        eventBus,
+		mutationMu:      mutationMu,
 	}
 }
 
@@ -155,6 +165,9 @@ func (s *Service) GetManifest(ctx context.Context, name, reference string) (*dom
 
 // PutManifest stores a manifest and returns the calculated digest.
 func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (string, error) {
+	s.mutationMu.RLock()
+	defer s.mutationMu.RUnlock()
+
 	ctx, span := registryTracer.Start(ctx, "registry.put_manifest",
 		trace.WithAttributes(
 			attribute.String("name", manifest.Name),
@@ -171,8 +184,20 @@ func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (s
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	// Calculate digest
+	// Calculate and verify the digest before mutating storage. A digest-addressed
+	// manifest must match its URL reference or clients could later retrieve
+	// attacker-controlled bytes under a trusted content address.
 	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(manifest.Data))
+	if validation.IsDigest(manifest.Reference) {
+		matches, err := manifestDigestMatches(manifest.Reference, manifest.Data)
+		if err != nil {
+			return "", err
+		}
+		if !matches {
+			return "", fmt.Errorf("%w: manifest content does not match %s", domain.ErrDigestMismatch, manifest.Reference)
+		}
+		digest = manifest.Reference
+	}
 
 	if err := s.manifestStorage.PutManifest(manifest.Name, manifest.Reference, manifest.ContentType, manifest.Data); err != nil {
 		return "", log.WrapErr(err, "failed to store manifest")
@@ -191,7 +216,7 @@ func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (s
 	// Publish image pushed event only for tag references (not digests).
 	// A docker push sends manifests by both digest and tag; firing only on
 	// tag prevents duplicate deploy triggers for the same push.
-	if s.eventBus != nil && !strings.HasPrefix(manifest.Reference, "sha256:") {
+	if s.eventBus != nil && !validation.IsDigest(manifest.Reference) {
 		if s.IsDeployEventSuppressed(manifest.Name) {
 			log.Info().Str("image", manifest.Name).Msg("skipping image.pushed event: CLI deploy intent active")
 		} else {
@@ -245,14 +270,24 @@ func (s *Service) GetBlob(ctx context.Context, digest string) (io.ReadCloser, er
 	return reader, nil
 }
 
-// GetBlobPath returns the filesystem path to a blob for direct serving.
-func (s *Service) GetBlobPath(ctx context.Context, digest string) (string, error) {
+// GetBlobPath returns the filesystem path to a blob only when a manifest in
+// the requested repository references it.
+func (s *Service) GetBlobPath(ctx context.Context, name, digest string) (string, error) {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldUseCase: "GetBlobPath",
+		"name":                name,
 		"digest":              digest,
 	})
 	log := zerowrap.FromCtx(ctx)
+
+	referenced, err := s.repositoryReferencesDigest(name, digest)
+	if err != nil {
+		return "", log.WrapErr(err, "failed to verify blob ownership")
+	}
+	if !referenced {
+		return "", domain.ErrBlobNotFound
+	}
 
 	path, err := s.blobStorage.GetBlobPath(digest)
 	if err != nil {
@@ -262,8 +297,91 @@ func (s *Service) GetBlobPath(ctx context.Context, digest string) (string, error
 	return path, nil
 }
 
+type manifestDescriptor struct {
+	Digest string `json:"digest"`
+}
+
+type manifestReferences struct {
+	Config    manifestDescriptor   `json:"config"`
+	Layers    []manifestDescriptor `json:"layers"`
+	Manifests []manifestDescriptor `json:"manifests"`
+	Blobs     []manifestDescriptor `json:"blobs"`
+	Subject   *manifestDescriptor  `json:"subject"`
+}
+
+func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) {
+	tags, err := s.manifestStorage.ListTags(name)
+	if err != nil {
+		if errors.Is(err, domain.ErrManifestNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	queue := append([]string(nil), tags...)
+	seen := make(map[string]struct{}, len(queue))
+	for len(queue) > 0 {
+		reference := queue[0]
+		queue = queue[1:]
+		if _, ok := seen[reference]; ok {
+			continue
+		}
+		seen[reference] = struct{}{}
+
+		data, _, err := s.manifestStorage.GetManifest(name, reference)
+		if err != nil {
+			return false, err
+		}
+		var refs manifestReferences
+		if err := json.Unmarshal(data, &refs); err != nil {
+			return false, fmt.Errorf("decode manifest %s: %w", reference, err)
+		}
+
+		if refs.Config.Digest == target || descriptorListContains(refs.Layers, target) ||
+			descriptorListContains(refs.Blobs, target) || (refs.Subject != nil && refs.Subject.Digest == target) {
+			return true, nil
+		}
+		for _, child := range refs.Manifests {
+			if child.Digest == target {
+				return true, nil
+			}
+			if child.Digest != "" {
+				queue = append(queue, child.Digest)
+			}
+		}
+	}
+	return false, nil
+}
+
+func descriptorListContains(descriptors []manifestDescriptor, digest string) bool {
+	for _, descriptor := range descriptors {
+		if descriptor.Digest == digest {
+			return true
+		}
+	}
+	return false
+}
+
+func manifestDigestMatches(reference string, data []byte) (bool, error) {
+	algorithm, _, ok := strings.Cut(reference, ":")
+	if !ok {
+		return false, domain.ErrInvalidDigest
+	}
+	switch algorithm {
+	case "sha256":
+		return reference == fmt.Sprintf("sha256:%x", sha256.Sum256(data)), nil
+	case "sha512":
+		return reference == fmt.Sprintf("sha512:%x", sha512.Sum512(data)), nil
+	default:
+		return false, domain.ErrInvalidDigest
+	}
+}
+
 // PutBlob stores a blob with the given digest.
 func (s *Service) PutBlob(ctx context.Context, digest string, data io.Reader, size int64) error {
+	s.mutationMu.RLock()
+	defer s.mutationMu.RUnlock()
+
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldUseCase: "PutBlob",

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -191,7 +191,7 @@ func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (s
 	if validation.IsDigest(manifest.Reference) {
 		matches, err := manifestDigestMatches(manifest.Reference, manifest.Data)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("validate manifest digest: %w", err)
 		}
 		if !matches {
 			return "", fmt.Errorf("%w: manifest content does not match %s", domain.ErrDigestMismatch, manifest.Reference)
@@ -237,6 +237,9 @@ func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (s
 
 // DeleteManifest removes a manifest.
 func (s *Service) DeleteManifest(ctx context.Context, name, reference string) error {
+	s.mutationMu.RLock()
+	defer s.mutationMu.RUnlock()
+
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:   "usecase",
 		zerowrap.FieldUseCase: "DeleteManifest",
@@ -315,7 +318,7 @@ func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) 
 		if errors.Is(err, domain.ErrManifestNotFound) {
 			return false, nil
 		}
-		return false, err
+		return false, fmt.Errorf("list tags for repository %s: %w", name, err)
 	}
 
 	queue := append([]string(nil), tags...)
@@ -330,7 +333,7 @@ func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) 
 
 		data, _, err := s.manifestStorage.GetManifest(name, reference)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("get manifest %s for repository %s: %w", reference, name, err)
 		}
 		var refs manifestReferences
 		if err := json.Unmarshal(data, &refs); err != nil {

--- a/internal/usecase/registry/service.go
+++ b/internal/usecase/registry/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bnema/gordon/internal/adapters/out/telemetry"
 	"github.com/bnema/gordon/internal/boundaries/out"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/registrystate"
 	"github.com/bnema/gordon/pkg/validation"
 )
 
@@ -35,6 +36,7 @@ type Service struct {
 	metrics          *telemetry.Metrics
 	suppressedImages sync.Map // imageName -> *time.Timer
 	mutationMu       *sync.RWMutex
+	registryState    *registrystate.State
 }
 
 // SetMetrics sets the telemetry metrics for the registry service.
@@ -47,17 +49,18 @@ func NewService(
 	blobStorage out.BlobStorage,
 	manifestStorage out.ManifestStorage,
 	eventBus out.EventPublisher,
-	mutationLocks ...*sync.RWMutex,
+	states ...*registrystate.State,
 ) *Service {
-	mutationMu := &sync.RWMutex{}
-	if len(mutationLocks) > 0 && mutationLocks[0] != nil {
-		mutationMu = mutationLocks[0]
+	registryState := registrystate.New()
+	if len(states) > 0 && states[0] != nil {
+		registryState = states[0]
 	}
 	return &Service{
 		blobStorage:     blobStorage,
 		manifestStorage: manifestStorage,
 		eventBus:        eventBus,
-		mutationMu:      mutationMu,
+		mutationMu:      &registryState.MutationMu,
+		registryState:   registryState,
 	}
 }
 
@@ -202,6 +205,7 @@ func (s *Service) PutManifest(ctx context.Context, manifest *domain.Manifest) (s
 	if err := s.manifestStorage.PutManifest(manifest.Name, manifest.Reference, manifest.ContentType, manifest.Data); err != nil {
 		return "", log.WrapErr(err, "failed to store manifest")
 	}
+	s.registryState.MarkPublished(manifestReferencedDigests(manifest.Data))
 
 	// Record push metrics
 	if s.metrics != nil {
@@ -312,6 +316,8 @@ type manifestReferences struct {
 	Subject   *manifestDescriptor  `json:"subject"`
 }
 
+const maxManifestTraversal = 10000
+
 func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) {
 	tags, err := s.manifestStorage.ListTags(name)
 	if err != nil {
@@ -321,6 +327,9 @@ func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) 
 		return false, fmt.Errorf("list tags for repository %s: %w", name, err)
 	}
 
+	if len(tags) > maxManifestTraversal {
+		return false, fmt.Errorf("%w: repository %s exceeds manifest traversal limit", domain.ErrBlobNotFound, name)
+	}
 	queue := append([]string(nil), tags...)
 	seen := make(map[string]struct{}, len(queue))
 	for len(queue) > 0 {
@@ -330,6 +339,9 @@ func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) 
 			continue
 		}
 		seen[reference] = struct{}{}
+		if len(seen) > maxManifestTraversal {
+			return false, fmt.Errorf("%w: repository %s exceeds manifest traversal limit", domain.ErrBlobNotFound, name)
+		}
 
 		data, _, err := s.manifestStorage.GetManifest(name, reference)
 		if err != nil {
@@ -340,20 +352,58 @@ func (s *Service) repositoryReferencesDigest(name, target string) (bool, error) 
 			return false, fmt.Errorf("decode manifest %s: %w", reference, err)
 		}
 
-		if refs.Config.Digest == target || descriptorListContains(refs.Layers, target) ||
-			descriptorListContains(refs.Blobs, target) || (refs.Subject != nil && refs.Subject.Digest == target) {
+		if manifestReferencesTarget(refs, target) {
 			return true, nil
 		}
-		for _, child := range refs.Manifests {
-			if child.Digest == target {
-				return true, nil
-			}
-			if child.Digest != "" {
-				queue = append(queue, child.Digest)
+		nestedManifests := refs.Manifests
+		if refs.Subject != nil && refs.Subject.Digest != "" {
+			nestedManifests = append(append([]manifestDescriptor(nil), refs.Manifests...), *refs.Subject)
+		}
+		if len(seen)+len(queue)+len(nestedManifests) > maxManifestTraversal {
+			return false, fmt.Errorf("%w: repository %s exceeds manifest traversal limit", domain.ErrBlobNotFound, name)
+		}
+		queue = appendManifestDigests(queue, nestedManifests)
+	}
+	return false, nil
+}
+
+func manifestReferencesTarget(refs manifestReferences, target string) bool {
+	return refs.Config.Digest == target ||
+		descriptorListContains(refs.Layers, target) ||
+		descriptorListContains(refs.Manifests, target) ||
+		descriptorListContains(refs.Blobs, target) ||
+		(refs.Subject != nil && refs.Subject.Digest == target)
+}
+
+func appendManifestDigests(queue []string, descriptors []manifestDescriptor) []string {
+	for _, descriptor := range descriptors {
+		if descriptor.Digest != "" {
+			queue = append(queue, descriptor.Digest)
+		}
+	}
+	return queue
+}
+
+func manifestReferencedDigests(data []byte) []string {
+	var refs manifestReferences
+	if json.Unmarshal(data, &refs) != nil {
+		return nil
+	}
+	digests := make([]string, 0, 1+len(refs.Layers)+len(refs.Manifests)+len(refs.Blobs))
+	if refs.Config.Digest != "" {
+		digests = append(digests, refs.Config.Digest)
+	}
+	for _, descriptors := range [][]manifestDescriptor{refs.Layers, refs.Manifests, refs.Blobs} {
+		for _, descriptor := range descriptors {
+			if descriptor.Digest != "" {
+				digests = append(digests, descriptor.Digest)
 			}
 		}
 	}
-	return false, nil
+	if refs.Subject != nil && refs.Subject.Digest != "" {
+		digests = append(digests, refs.Subject.Digest)
+	}
+	return digests
 }
 
 func descriptorListContains(descriptors []manifestDescriptor, digest string) bool {
@@ -396,6 +446,7 @@ func (s *Service) PutBlob(ctx context.Context, digest string, data io.Reader, si
 	if err := s.blobStorage.PutBlob(digest, data, size); err != nil {
 		return log.WrapErr(err, "failed to store blob")
 	}
+	s.registryState.AddPending(digest, time.Now().UTC())
 
 	log.Info().Msg("blob stored")
 	return nil

--- a/internal/usecase/registry/service_test.go
+++ b/internal/usecase/registry/service_test.go
@@ -3,7 +3,9 @@ package registry
 import (
 	"bytes"
 	"context"
+	"crypto/sha512"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -82,6 +84,69 @@ func TestService_PutManifest_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, digest)
 	assert.True(t, strings.HasPrefix(digest, "sha256:"))
+}
+
+func TestService_PutManifest_SHA512DigestDoesNotPublishEvent(t *testing.T) {
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+	svc := NewService(blobStorage, manifestStorage, eventBus)
+	data := []byte(`{"schemaVersion":2}`)
+	reference := fmt.Sprintf("sha512:%x", sha512.Sum512(data))
+	manifest := &domain.Manifest{Name: "myapp", Reference: reference, ContentType: "application/vnd.oci.image.manifest.v1+json", Data: data}
+
+	manifestStorage.EXPECT().PutManifest("myapp", reference, manifest.ContentType, data).Return(nil)
+
+	digest, err := svc.PutManifest(testContext(), manifest)
+
+	require.NoError(t, err)
+	assert.Equal(t, reference, digest)
+}
+
+func TestService_PutManifest_RejectsDigestMismatch(t *testing.T) {
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+	svc := NewService(blobStorage, manifestStorage, eventBus)
+
+	manifest := &domain.Manifest{
+		Name:        "myapp",
+		Reference:   "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		ContentType: "application/vnd.oci.image.manifest.v1+json",
+		Data:        []byte(`{"schemaVersion":2}`),
+	}
+
+	_, err := svc.PutManifest(testContext(), manifest)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrDigestMismatch)
+}
+
+func TestService_GetBlobPath_RequiresRepositoryReference(t *testing.T) {
+	const digest = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	svc := NewService(blobStorage, manifestStorage, nil)
+
+	manifestStorage.EXPECT().ListTags("allowed").Return([]string{"latest"}, nil)
+	manifestStorage.EXPECT().GetManifest("allowed", "latest").Return(
+		[]byte(`{"schemaVersion":2,"layers":[{"digest":"`+digest+`"}]}`),
+		"application/vnd.oci.image.manifest.v1+json", nil,
+	)
+	blobStorage.EXPECT().GetBlobPath(digest).Return("/registry/blob", nil)
+
+	path, err := svc.GetBlobPath(testContext(), "allowed", digest)
+	require.NoError(t, err)
+	assert.Equal(t, "/registry/blob", path)
+
+	manifestStorage.EXPECT().ListTags("denied").Return([]string{"latest"}, nil)
+	manifestStorage.EXPECT().GetManifest("denied", "latest").Return(
+		[]byte(`{"schemaVersion":2,"layers":[]}`),
+		"application/vnd.oci.image.manifest.v1+json", nil,
+	)
+
+	_, err = svc.GetBlobPath(testContext(), "denied", digest)
+	assert.ErrorIs(t, err, domain.ErrBlobNotFound)
 }
 
 func TestService_PutManifest_StorageError(t *testing.T) {

--- a/internal/usecase/registry/service_test.go
+++ b/internal/usecase/registry/service_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/bnema/gordon/internal/boundaries/out/mocks"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/registrystate"
 )
 
 func testContext() context.Context {
@@ -90,8 +92,10 @@ func TestService_PutManifest_SHA512DigestDoesNotPublishEvent(t *testing.T) {
 	blobStorage := mocks.NewMockBlobStorage(t)
 	manifestStorage := mocks.NewMockManifestStorage(t)
 	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(blobStorage, manifestStorage, eventBus)
-	data := []byte(`{"schemaVersion":2}`)
+	state := registrystate.New()
+	state.AddPending("sha256:config", time.Now().UTC())
+	svc := NewService(blobStorage, manifestStorage, eventBus, state)
+	data := []byte(`{"schemaVersion":2,"config":{"digest":"sha256:config"}}`)
 	reference := fmt.Sprintf("sha512:%x", sha512.Sum512(data))
 	manifest := &domain.Manifest{Name: "myapp", Reference: reference, ContentType: "application/vnd.oci.image.manifest.v1+json", Data: data}
 
@@ -101,6 +105,7 @@ func TestService_PutManifest_SHA512DigestDoesNotPublishEvent(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, reference, digest)
+	assert.Empty(t, state.PendingDigests(time.Now().UTC()))
 }
 
 func TestService_PutManifest_RejectsDigestMismatch(t *testing.T) {
@@ -146,6 +151,39 @@ func TestService_GetBlobPath_RequiresRepositoryReference(t *testing.T) {
 	)
 
 	_, err = svc.GetBlobPath(testContext(), "denied", digest)
+	assert.ErrorIs(t, err, domain.ErrBlobNotFound)
+}
+
+func TestService_GetBlobPath_FollowsSubjectManifest(t *testing.T) {
+	const target = "sha256:target"
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	svc := NewService(blobStorage, manifestStorage, nil)
+
+	manifestStorage.EXPECT().ListTags("artifacts").Return([]string{"latest"}, nil)
+	manifestStorage.EXPECT().GetManifest("artifacts", "latest").Return(
+		[]byte(`{"subject":{"digest":"sha256:subject"}}`), "application/vnd.oci.artifact.manifest.v1+json", nil,
+	)
+	manifestStorage.EXPECT().GetManifest("artifacts", "sha256:subject").Return(
+		[]byte(`{"config":{"digest":"`+target+`"}}`), "application/vnd.oci.image.manifest.v1+json", nil,
+	)
+	blobStorage.EXPECT().GetBlobPath(target).Return("/registry/target", nil)
+
+	path, err := svc.GetBlobPath(testContext(), "artifacts", target)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/registry/target", path)
+}
+
+func TestService_GetBlobPath_BoundsManifestTraversal(t *testing.T) {
+	blobStorage := mocks.NewMockBlobStorage(t)
+	manifestStorage := mocks.NewMockManifestStorage(t)
+	svc := NewService(blobStorage, manifestStorage, nil)
+	tags := make([]string, maxManifestTraversal+1)
+	manifestStorage.EXPECT().ListTags("busy").Return(tags, nil)
+
+	_, err := svc.GetBlobPath(testContext(), "busy", "sha256:target")
+
 	assert.ErrorIs(t, err, domain.ErrBlobNotFound)
 }
 

--- a/internal/usecase/registrystate/state.go
+++ b/internal/usecase/registrystate/state.go
@@ -1,0 +1,57 @@
+// Package registrystate coordinates registry mutations and garbage collection.
+package registrystate
+
+import (
+	"sync"
+	"time"
+)
+
+// PendingBlobTTL protects uploaded blobs while clients publish their manifest.
+const PendingBlobTTL = 24 * time.Hour
+
+// State is shared by registry writes and registry garbage collection.
+type State struct {
+	MutationMu sync.RWMutex
+
+	pendingMu sync.Mutex
+	pending   map[string]time.Time
+}
+
+// New creates empty registry coordination state.
+func New() *State {
+	return &State{pending: make(map[string]time.Time)}
+}
+
+// AddPending records a blob that has been uploaded but not yet referenced by a manifest.
+func (s *State) AddPending(digest string, now time.Time) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	if s.pending == nil {
+		s.pending = make(map[string]time.Time)
+	}
+	s.pending[digest] = now
+}
+
+// MarkPublished removes blobs now owned by a published manifest from the pending set.
+func (s *State) MarkPublished(digests []string) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	for _, digest := range digests {
+		delete(s.pending, digest)
+	}
+}
+
+// PendingDigests returns non-expired pending blobs and drops abandoned entries.
+func (s *State) PendingDigests(now time.Time) map[string]struct{} {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	result := make(map[string]struct{}, len(s.pending))
+	for digest, createdAt := range s.pending {
+		if now.Sub(createdAt) > PendingBlobTTL {
+			delete(s.pending, digest)
+			continue
+		}
+		result[digest] = struct{}{}
+	}
+	return result
+}

--- a/internal/usecase/registrystate/state_test.go
+++ b/internal/usecase/registrystate/state_test.go
@@ -1,0 +1,21 @@
+package registrystate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateTracksPublishesAndExpiresPendingBlobs(t *testing.T) {
+	now := time.Now().UTC()
+	state := New()
+	state.AddPending("sha256:published", now)
+	state.AddPending("sha256:pending", now)
+	state.AddPending("sha256:expired", now.Add(-PendingBlobTTL-time.Second))
+
+	state.MarkPublished([]string{"sha256:published"})
+	pending := state.PendingDigests(now)
+
+	assert.Equal(t, map[string]struct{}{"sha256:pending": {}}, pending)
+}

--- a/internal/usecase/services/service.go
+++ b/internal/usecase/services/service.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -532,6 +534,9 @@ func (s *Service) waitLogReadiness(ctx context.Context, containerID string, svc 
 		if err == nil && found {
 			return nil
 		}
+		if errors.Is(err, domain.ErrReadinessLogSizeExceeded) {
+			return err
+		}
 		if err != nil {
 			lastErr = err
 		}
@@ -559,14 +564,41 @@ func (s *Service) logContains(ctx context.Context, containerID, path, contains s
 		return false, err
 	}
 	defer reader.Close()
-	content, err := io.ReadAll(io.LimitReader(reader, maxReadinessLogSize+1))
-	if err != nil {
+	if contains == "" {
+		return true, nil
+	}
+
+	needle := []byte(contains)
+	buffer := make([]byte, 32*1024)
+	carry := make([]byte, 0, len(needle)-1)
+	remaining := maxReadinessLogSize
+	for remaining > 0 {
+		readSize := min(len(buffer), remaining)
+		n, readErr := reader.Read(buffer[:readSize])
+		if n > 0 {
+			window := append(carry, buffer[:n]...)
+			if bytes.Contains(window, needle) {
+				return true, nil
+			}
+			overlap := min(len(needle)-1, len(window))
+			carry = append(carry[:0], window[len(window)-overlap:]...)
+			remaining -= n
+		}
+		if errors.Is(readErr, io.EOF) {
+			return false, nil
+		}
+		if readErr != nil {
+			return false, readErr
+		}
+	}
+
+	var extra [1]byte
+	if _, err := reader.Read(extra[:]); errors.Is(err, io.EOF) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-	if len(content) > maxReadinessLogSize {
-		return false, fmt.Errorf("readiness log exceeds %d bytes", maxReadinessLogSize)
-	}
-	return strings.Contains(string(content), contains), nil
+	return false, fmt.Errorf("%w: limit is %d bytes", domain.ErrReadinessLogSizeExceeded, maxReadinessLogSize)
 }
 
 func normalizeCleanup(cleanup domain.StandaloneServiceCleanup) domain.StandaloneServiceCleanup {

--- a/internal/usecase/services/service.go
+++ b/internal/usecase/services/service.go
@@ -521,7 +521,7 @@ func tcpReadinessAddress(svc domain.StandaloneService) (string, error) {
 }
 
 func (s *Service) waitLogReadiness(ctx context.Context, containerID string, svc domain.StandaloneService) error {
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	var lastErr error
 	for {
@@ -551,15 +551,20 @@ func logReadinessTimeoutError(serviceName string, timeoutErr, lastErr error) err
 	return fmt.Errorf("standalone service %q log readiness timed out: %w", serviceName, timeoutErr)
 }
 
+const maxReadinessLogSize = 1 << 20 // 1 MiB
+
 func (s *Service) logContains(ctx context.Context, containerID, path, contains string) (bool, error) {
 	reader, err := s.runtime.CopyFromContainer(ctx, containerID, path)
 	if err != nil {
 		return false, err
 	}
 	defer reader.Close()
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(io.LimitReader(reader, maxReadinessLogSize+1))
 	if err != nil {
 		return false, err
+	}
+	if len(content) > maxReadinessLogSize {
+		return false, fmt.Errorf("readiness log exceeds %d bytes", maxReadinessLogSize)
 	}
 	return strings.Contains(string(content), contains), nil
 }

--- a/internal/usecase/services/service_test.go
+++ b/internal/usecase/services/service_test.go
@@ -387,6 +387,32 @@ func TestWaitLogReadinessReadsContainerFileUntilTextAppears(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLogContainsStopsAtMatchBeforeSizeLimit(t *testing.T) {
+	runtime := outmocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime)
+	runtime.EXPECT().CopyFromContainer(mock.Anything, "container-1", "/logs/server.log").Return(
+		io.NopCloser(strings.NewReader("ready\n"+strings.Repeat("x", maxReadinessLogSize))), nil,
+	)
+
+	found, err := svc.logContains(context.Background(), "container-1", "/logs/server.log", "ready")
+
+	require.NoError(t, err)
+	assert.True(t, found)
+}
+
+func TestLogContainsReturnsSentinelAtSizeLimit(t *testing.T) {
+	runtime := outmocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime)
+	runtime.EXPECT().CopyFromContainer(mock.Anything, "container-1", "/logs/server.log").Return(
+		io.NopCloser(strings.NewReader(strings.Repeat("x", maxReadinessLogSize+1))), nil,
+	)
+
+	found, err := svc.logContains(context.Background(), "container-1", "/logs/server.log", "ready")
+
+	assert.False(t, found)
+	assert.ErrorIs(t, err, domain.ErrReadinessLogSizeExceeded)
+}
+
 func TestWaitReadinessHonorsContextTimeout(t *testing.T) {
 	svc := sampleService()
 	svc.Readiness = domain.StandaloneServiceReadiness{Type: domain.StandaloneServiceReadinessTCP}


### PR DESCRIPTION
## Summary

- harden registry token classification, authorization scopes, manifest digest verification, and repository-scoped blob access
- prevent credential leakage to external registries and add bounded runtime, preview, and rate-limiter behavior
- make Docker resource ownership and generated names collision-resistant while preserving legacy volumes
- move CLI secret inputs out of argv and harden CI actions, action pins, installer integrity guidance, and workflow shell handling

## Verification

- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...` (0 issues)
- `git diff --check`
- CodeRabbit CLI review, followed by fixes and a second committed-changes review
- codex-security rerun attempted; the plugin retained partial output but aborted when a session event exceeded its 1 MiB safety limit
- both commits are GPG signed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Authentication and secret-management commands now use protected files instead of inline tokens.
  - Token validation and administrative access checks are stricter.
  - External image pulls no longer send service credentials.

- **Bug Fixes**
  - Registry digest mismatches return clearer client errors.
  - Blob access is restricted to repositories that reference the blob.
  - Preview and legacy volume handling is more reliable.

- **Documentation**
  - Installation guides now include checksum verification, safer installer inspection, platform detection, and signed Docker packages.
  - Deployment and rollback examples improve input validation and secret handling.

- **Performance & Reliability**
  - Container logs, command output, and readiness reads have bounded limits.
  - Preview creation is throttled to prevent resource exhaustion.
  - Managed cleanup avoids removing unrelated Docker resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->