### PR TITLE
fix: preserve legacy attachment volumes during recreation

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -42,9 +42,10 @@ var (
 	ErrNetworkExists   = errors.New("network already exists")
 
 	// Volume errors
-	ErrVolumeNotFound          = errors.New("volume not found")
-	ErrVolumeExists            = errors.New("volume already exists")
-	ErrVolumeBackupUnavailable = errors.New("volume backup service unavailable")
+	ErrVolumeNotFound            = errors.New("volume not found")
+	ErrVolumeExists              = errors.New("volume already exists")
+	ErrVolumeBackupUnavailable   = errors.New("volume backup service unavailable")
+	ErrVolumeOwnershipUnverified = errors.New("volume ownership cannot be verified")
 
 	// Preview errors
 	ErrPreviewNotFound = errors.New("preview not found")

--- a/internal/usecase/container/service.go
+++ b/internal/usecase/container/service.go
@@ -607,7 +607,7 @@ func (s *Service) prepareDeployResources(ctx context.Context, route domain.Route
 	}
 	envHash := hashEnvironment(envVars)
 
-	volumes, err := s.setupVolumes(ctx, route.Domain, actualImageRef)
+	volumes, err := s.setupVolumes(ctx, route.Domain, actualImageRef, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2513,13 +2513,16 @@ func (s *Service) loadEnvironment(ctx context.Context, preResolved []string, dom
 	return mergeEnvironmentVariables(dockerfileEnvVars, userEnvVars), nil
 }
 
-func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string) (map[string]string, error) {
+func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string, preferredVolumes map[string]namedVolumeMount) (map[string]string, error) {
 	s.mu.RLock()
 	cfg := s.config
 	s.mu.RUnlock()
 
 	log := zerowrap.FromCtx(ctx)
-	volumes := make(map[string]string)
+	volumes, err := s.validatePreferredVolumes(ctx, preferredVolumes)
+	if err != nil {
+		return nil, err
+	}
 
 	if !cfg.VolumeAutoCreate {
 		return volumes, nil
@@ -2532,6 +2535,10 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 	}
 
 	for _, path := range volumePaths {
+		if _, preferred := volumes[path]; preferred {
+			continue
+		}
+
 		name := generateVolumeName(cfg.VolumePrefix, domainName, path)
 		legacyName := legacyVolumeName(cfg.VolumePrefix, domainName, path)
 		legacyExists, err := s.runtime.VolumeExists(ctx, legacyName)
@@ -2539,11 +2546,12 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 			log.WrapErrWithFields(err, "failed to check legacy volume", map[string]any{"volume": legacyName})
 			continue
 		}
+		legacyOwnership := legacyVolumeOwnershipUnverified
 		if legacyExists {
-			owned, ownershipErr := s.legacyVolumeOwnedByDomain(ctx, legacyName, domainName)
-			if ownershipErr != nil {
-				log.Warn().Err(ownershipErr).Str("volume", legacyName).Msg("could not verify legacy volume ownership; using stable volume name")
-			} else if owned {
+			legacyOwnership, err = s.legacyVolumeOwnership(ctx, legacyName, domainName)
+			if err != nil {
+				log.Warn().Err(err).Str("volume", legacyName).Msg("could not verify legacy volume ownership; using stable volume name")
+			} else if legacyOwnership == legacyVolumeOwnershipOwned {
 				volumes[path] = legacyName
 				continue
 			}
@@ -2556,6 +2564,11 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 		}
 
 		if !exists {
+			if legacyExists && legacyOwnership != legacyVolumeOwnershipForeign {
+				// No verified mount may mean the owning container was already removed;
+				// it does not prove that the preserved volume belongs elsewhere.
+				return nil, fmt.Errorf("legacy volume %q exists but its ownership cannot be verified; refusing to create a replacement volume: %w", legacyName, domain.ErrVolumeOwnershipUnverified)
+			}
 			if err := s.runtime.CreateVolume(ctx, name); err != nil {
 				log.WrapErrWithFields(err, "failed to create volume", map[string]any{"volume": name})
 				continue
@@ -2566,6 +2579,24 @@ func (s *Service) setupVolumes(ctx context.Context, domainName, imageRef string)
 		volumes[path] = name
 	}
 
+	return volumes, nil
+}
+
+func (s *Service) validatePreferredVolumes(ctx context.Context, preferredVolumes map[string]namedVolumeMount) (map[string]string, error) {
+	volumes := make(map[string]string)
+	for path, preferred := range preferredVolumes {
+		if preferred.Name == "" {
+			continue
+		}
+		exists, err := s.runtime.VolumeExists(ctx, preferred.Name)
+		if err != nil {
+			return nil, fmt.Errorf("check previously mounted volume %q: %w", preferred.Name, err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("previously mounted volume %q no longer exists: %w", preferred.Name, domain.ErrVolumeNotFound)
+		}
+		volumes[path] = preferred.Name
+	}
 	return volumes, nil
 }
 
@@ -2922,8 +2953,9 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	if err != nil {
 		return err
 	}
+	preferredVolumes := namedVolumeMounts(existingContainer)
 
-	if existingContainer != nil {
+	if existingContainer != nil && existingContainer.Name == containerName {
 		shouldSkip, err := s.handleRunningAttachment(ctx, existingContainer, containerName, serviceImage)
 		if err != nil {
 			return err
@@ -2931,19 +2963,16 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 		if shouldSkip {
 			return nil
 		}
-		if existingContainer.Status == string(domain.ContainerStatusRunning) {
-			existingContainer = nil
-		}
-	}
-
-	if err := s.removeStoppedAttachment(ctx, existingContainer, containerName); err != nil {
-		return err
 	}
 
 	log.Info().Str(zerowrap.FieldService, serviceImage).Msg("deploying attached service")
 
-	config, err := s.buildAttachmentContainerConfig(ctx, ownerDomain, serviceName, serviceImage, containerName, networkName)
+	config, err := s.buildAttachmentContainerConfig(ctx, ownerDomain, serviceName, serviceImage, containerName, networkName, preferredVolumes)
 	if err != nil {
+		return err
+	}
+
+	if err := s.removeAttachmentForReplacement(ctx, existingContainer, containerName); err != nil {
 		return err
 	}
 
@@ -2979,7 +3008,7 @@ func (s *Service) deployAttachedService(ctx context.Context, ownerDomain, servic
 	return nil
 }
 
-func (s *Service) buildAttachmentContainerConfig(ctx context.Context, ownerDomain, serviceName, serviceImage, containerName, networkName string) (*domain.ContainerConfig, error) {
+func (s *Service) buildAttachmentContainerConfig(ctx context.Context, ownerDomain, serviceName, serviceImage, containerName, networkName string, preferredVolumes map[string]namedVolumeMount) (*domain.ContainerConfig, error) {
 	imageRef, err := s.buildValidatedImageRef(ctx, serviceImage)
 	if err != nil {
 		return nil, err
@@ -2990,7 +3019,7 @@ func (s *Service) buildAttachmentContainerConfig(ctx context.Context, ownerDomai
 	}
 
 	exposedPorts := s.attachmentExposedPorts(ctx, actualImageRef)
-	volumes, err := s.attachmentVolumes(ctx, containerName, actualImageRef)
+	volumes, readOnlyVolumes, err := s.attachmentVolumes(ctx, containerName, actualImageRef, preferredVolumes)
 	if err != nil {
 		return nil, err
 	}
@@ -3004,14 +3033,15 @@ func (s *Service) buildAttachmentContainerConfig(ctx context.Context, ownerDomai
 	s.mu.RUnlock()
 
 	config := &domain.ContainerConfig{
-		Image:       actualImageRef,
-		Name:        containerName,
-		Hostname:    serviceName,
-		Aliases:     []string{serviceName},
-		Ports:       exposedPorts,
-		Env:         envVars,
-		Volumes:     volumes,
-		NetworkMode: networkName,
+		Image:           actualImageRef,
+		Name:            containerName,
+		Hostname:        serviceName,
+		Aliases:         []string{serviceName},
+		Ports:           exposedPorts,
+		Env:             envVars,
+		Volumes:         volumes,
+		ReadOnlyVolumes: readOnlyVolumes,
+		NetworkMode:     networkName,
 		Labels: map[string]string{
 			domain.LabelManaged:    "true",
 			domain.LabelAttachment: "true",
@@ -3038,12 +3068,37 @@ func (s *Service) attachmentExposedPorts(ctx context.Context, imageRef string) [
 	return exposedPorts
 }
 
-func (s *Service) attachmentVolumes(ctx context.Context, containerName, imageRef string) (map[string]string, error) {
-	volumes, err := s.setupVolumes(ctx, containerName, imageRef)
+func (s *Service) attachmentVolumes(ctx context.Context, containerName, imageRef string, preferredVolumes map[string]namedVolumeMount) (map[string]string, map[string]string, error) {
+	volumes, err := s.setupVolumes(ctx, containerName, imageRef, preferredVolumes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to setup volumes for attachment %s with image %s: %w", containerName, imageRef, err)
+		return nil, nil, fmt.Errorf("failed to setup volumes for attachment %s with image %s: %w", containerName, imageRef, err)
 	}
-	return volumes, nil
+	readOnlyVolumes := make(map[string]string)
+	for path, preferred := range preferredVolumes {
+		if preferred.ReadOnly && volumes[path] == preferred.Name {
+			delete(volumes, path)
+			readOnlyVolumes[path] = preferred.Name
+		}
+	}
+	return volumes, readOnlyVolumes, nil
+}
+
+type namedVolumeMount struct {
+	Name     string
+	ReadOnly bool
+}
+
+func namedVolumeMounts(container *domain.Container) map[string]namedVolumeMount {
+	volumes := make(map[string]namedVolumeMount)
+	if container == nil {
+		return volumes
+	}
+	for _, mount := range container.VolumeMounts {
+		if mount.Type == "volume" && mount.Name != "" && mount.Destination != "" {
+			volumes[mount.Destination] = namedVolumeMount{Name: mount.Name, ReadOnly: mount.ReadOnly}
+		}
+	}
+	return volumes
 }
 
 func (s *Service) attachmentEnv(ctx context.Context, containerName, imageRef string) ([]string, error) {
@@ -3102,25 +3157,24 @@ func (s *Service) handleRunningAttachment(ctx context.Context, existing *domain.
 		log.Info().Str("container_name", containerName).Msg("attachment env changed, recreating")
 	}
 
-	if err := s.runtime.StopContainer(ctx, existing.ID); err != nil {
-		return false, log.WrapErr(err, "failed to stop attachment for drift update")
-	}
-	if err := s.runtime.RemoveContainer(ctx, existing.ID, true); err != nil {
-		return false, log.WrapErr(err, "failed to remove attachment for drift update")
-	}
-
 	return false, nil
 }
 
-func (s *Service) removeStoppedAttachment(ctx context.Context, existing *domain.Container, containerName string) error {
+func (s *Service) removeAttachmentForReplacement(ctx context.Context, existing *domain.Container, containerName string) error {
 	if existing == nil {
 		return nil
 	}
 
 	log := zerowrap.FromCtx(ctx)
-	log.Info().Str("container_name", containerName).Msg("removing stopped attachment container")
+	if existing.Status == string(domain.ContainerStatusRunning) {
+		log.Info().Str("container_name", containerName).Msg("stopping attachment container for replacement")
+		if err := s.runtime.StopContainer(ctx, existing.ID); err != nil {
+			return log.WrapErr(err, "failed to stop attachment for replacement")
+		}
+	}
+	log.Info().Str("container_name", containerName).Msg("removing attachment container for replacement")
 	if err := s.runtime.RemoveContainer(ctx, existing.ID, true); err != nil {
-		return log.WrapErr(err, "failed to remove existing attachment container")
+		return log.WrapErr(err, "failed to remove attachment for replacement")
 	}
 
 	return nil
@@ -3147,14 +3201,7 @@ func (s *Service) resolveExistingAttachment(ctx context.Context, ownerDomain, se
 		return nil, err
 	}
 	log.Info().Str("container_name", containerNameLegacy).Msg("found attachment with legacy naming, will be replaced")
-	if err := s.runtime.StopContainer(ctx, existingContainer.ID); err != nil {
-		return nil, log.WrapErr(err, "failed to stop legacy attachment container")
-	}
-	if err := s.runtime.RemoveContainer(ctx, existingContainer.ID, true); err != nil {
-		return nil, log.WrapErr(err, "failed to remove legacy attachment container")
-	}
-
-	return nil, nil
+	return existingContainer, nil
 }
 
 func validateAttachmentOwnership(container *domain.Container, ownerDomain, containerName string) error {
@@ -3226,23 +3273,48 @@ func legacyVolumeName(prefix, domainName, volumePath string) string {
 		strings.ReplaceAll(strings.Trim(volumePath, "/"), "/", "-"))
 }
 
-func (s *Service) legacyVolumeOwnedByDomain(ctx context.Context, volumeName, domainName string) (bool, error) {
+type legacyVolumeOwnership uint8
+
+const (
+	legacyVolumeOwnershipUnverified legacyVolumeOwnership = iota
+	legacyVolumeOwnershipOwned
+	legacyVolumeOwnershipForeign
+)
+
+func (s *Service) legacyVolumeOwnership(ctx context.Context, volumeName, domainName string) (legacyVolumeOwnership, error) {
 	containers, err := s.runtime.ListContainers(ctx, true)
 	if err != nil {
-		return false, fmt.Errorf("list containers for legacy volume ownership: %w", err)
+		return legacyVolumeOwnershipUnverified, fmt.Errorf("list containers for legacy volume ownership: %w", err)
 	}
+	ownerFound := false
+	foreignFound := false
 	for _, container := range containers {
-		if container.Labels[domain.LabelManaged] != "true" ||
-			(container.Labels[domain.LabelRoute] != domainName && container.Labels[domain.LabelDomain] != domainName) {
+		if container.Labels[domain.LabelManaged] != "true" || !containerMountsVolume(container, volumeName) {
 			continue
 		}
-		for _, mount := range container.VolumeMounts {
-			if mount.Name == volumeName || mount.Source == volumeName {
-				return true, nil
-			}
+		if container.Name == domainName || container.Labels[domain.LabelRoute] == domainName || container.Labels[domain.LabelDomain] == domainName {
+			ownerFound = true
+		} else {
+			foreignFound = true
 		}
 	}
-	return false, nil
+	switch {
+	case ownerFound && !foreignFound:
+		return legacyVolumeOwnershipOwned, nil
+	case foreignFound && !ownerFound:
+		return legacyVolumeOwnershipForeign, nil
+	default:
+		return legacyVolumeOwnershipUnverified, nil
+	}
+}
+
+func containerMountsVolume(container *domain.Container, volumeName string) bool {
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == volumeName || mount.Source == volumeName {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeEnvironmentVariables(dockerfileEnv, userEnv []string) []string {

--- a/internal/usecase/container/service_test.go
+++ b/internal/usecase/container/service_test.go
@@ -1799,7 +1799,7 @@ func TestService_SetupVolumes_ReusesLegacyVolume(t *testing.T) {
 		VolumeMounts: []domain.ContainerVolumeMount{{Name: legacyName}},
 	}}, nil)
 
-	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest")
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"/data": legacyName}, volumes)
@@ -1820,10 +1820,91 @@ func TestService_SetupVolumes_DoesNotReuseCollidingLegacyVolume(t *testing.T) {
 	}}, nil)
 	runtime.EXPECT().VolumeExists(mock.Anything, stableName).Return(true, nil)
 
-	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest")
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"/data": stableName}, volumes)
+}
+
+func TestService_SetupVolumes_CreatesStableVolumeWhenLegacyVolumeIsForeign(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: true, VolumePrefix: "gordon"}, nil)
+	legacyName := legacyVolumeName("gordon", "app.example.com", "/data")
+	stableName := generateVolumeName("gordon", "app.example.com", "/data")
+
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{{
+		Labels:       map[string]string{domain.LabelManaged: "true", domain.LabelRoute: "other.example.com"},
+		VolumeMounts: []domain.ContainerVolumeMount{{Name: legacyName}},
+	}}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, stableName).Return(false, nil).Once()
+	runtime.EXPECT().CreateVolume(mock.Anything, stableName).Return(nil).Once()
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"/data": stableName}, volumes)
+}
+
+func TestService_SetupVolumes_PreservesPreferredVolumesWhenAutoCreateDisabled(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: false}, nil)
+	preferred := map[string]namedVolumeMount{
+		"/data": {Name: "existing-data"},
+	}
+
+	runtime.EXPECT().VolumeExists(mock.Anything, "existing-data").Return(true, nil).Once()
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", preferred)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"/data": "existing-data"}, volumes)
+}
+
+func TestService_SetupVolumes_RejectsUnverifiedLegacyVolumeWithoutStableReplacement(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: true, VolumePrefix: "gordon"}, nil)
+	legacyName := legacyVolumeName("gordon", "app.example.com", "/data")
+	stableName := generateVolumeName("gordon", "app.example.com", "/data")
+
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, stableName).Return(false, nil).Once()
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", nil)
+
+	require.ErrorContains(t, err, "refusing to create a replacement")
+	require.ErrorIs(t, err, domain.ErrVolumeOwnershipUnverified)
+	assert.Empty(t, volumes)
+}
+
+func TestService_SetupVolumes_RejectsLegacyVolumeSharedWithForeignWorkload(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	svc := NewService(runtime, nil, nil, nil, Config{VolumeAutoCreate: true, VolumePrefix: "gordon"}, nil)
+	legacyName := legacyVolumeName("gordon", "app.example.com", "/data")
+	stableName := generateVolumeName("gordon", "app.example.com", "/data")
+	mount := []domain.ContainerVolumeMount{{Name: legacyName}}
+
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, "myapp:latest").Return([]string{"/data"}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyName).Return(true, nil).Once()
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{
+		{
+			Labels:       map[string]string{domain.LabelManaged: "true", domain.LabelRoute: "app.example.com"},
+			VolumeMounts: mount,
+		},
+		{
+			Labels:       map[string]string{domain.LabelManaged: "true", domain.LabelRoute: "other.example.com"},
+			VolumeMounts: mount,
+		},
+	}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, stableName).Return(false, nil).Once()
+
+	volumes, err := svc.setupVolumes(testContext(), "app.example.com", "myapp:latest", nil)
+
+	require.ErrorIs(t, err, domain.ErrVolumeOwnershipUnverified)
+	assert.Empty(t, volumes)
 }
 
 func TestValidateAttachmentOwnership(t *testing.T) {
@@ -4372,6 +4453,201 @@ func TestService_WaitForAttachmentReady_FallsBackToDelay(t *testing.T) {
 
 	err := svc.waitForAttachmentReady(ctx, containerID, containerConfig)
 	assert.NoError(t, err)
+}
+
+func TestDeployAttachedService_ReusesVerifiedLegacyVolumeFromStoppedAttachment(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	config.VolumeAutoCreate = true
+	config.VolumePrefix = "gordon"
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+	ctx := testContext()
+
+	ownerDomain := "app.example.com"
+	serviceImage := "postgres:16"
+	networkName := "gordon-net"
+	containerName := fmt.Sprintf("gordon-%s-postgres", domain.SanitizeDomainForContainer(ownerDomain))
+	volumePath := "/var/lib/postgresql"
+	legacyVolume := legacyVolumeName(config.VolumePrefix, containerName, volumePath)
+	existing := &domain.Container{
+		ID:     "stopped-postgres",
+		Name:   containerName,
+		Status: string(domain.ContainerStatusExited),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: ownerDomain,
+		},
+		VolumeMounts: []domain.ContainerVolumeMount{{
+			Name:        legacyVolume,
+			Type:        "volume",
+			Destination: volumePath,
+			ReadOnly:    true,
+		}},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{existing}, nil).Once()
+	runtime.EXPECT().RemoveContainer(mock.Anything, existing.ID, true).Return(nil).Once()
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{serviceImage}, nil).Once()
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, serviceImage).Return([]int{}, nil).Once()
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, serviceImage).Return([]string{volumePath}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyVolume).Return(true, nil).Once()
+	envLoader.EXPECT().LoadEnv(mock.Anything, containerName).Return([]string{}, nil).Once()
+	runtime.EXPECT().InspectImageEnv(mock.Anything, serviceImage).Return([]string{}, nil).Once()
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.AnythingOfType("*domain.ContainerConfig")).
+		Run(func(_ context.Context, cfg *domain.ContainerConfig) {
+			assert.NotContains(t, cfg.Volumes, volumePath)
+			assert.Equal(t, map[string]string{volumePath: legacyVolume}, cfg.ReadOnlyVolumes)
+		}).
+		Return(&domain.Container{ID: "new-postgres", Name: containerName}, nil).Once()
+	runtime.EXPECT().StartContainer(mock.Anything, "new-postgres").Return(nil).Once()
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-postgres").Return(true, nil).Times(2)
+	runtime.EXPECT().GetContainerHealthStatus(mock.Anything, "new-postgres").Return("", false, nil).Once()
+
+	require.NoError(t, svc.deployAttachedService(ctx, ownerDomain, serviceImage, networkName))
+}
+
+func TestDeployAttachedService_KeepsStoppedAttachmentWhenVolumeValidationFails(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	config.VolumeAutoCreate = true
+	config.VolumePrefix = "gordon"
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+
+	ownerDomain := "app.example.com"
+	serviceImage := "postgres:16"
+	containerName := fmt.Sprintf("gordon-%s-postgres", domain.SanitizeDomainForContainer(ownerDomain))
+	existing := &domain.Container{
+		ID:     "stopped-postgres",
+		Name:   containerName,
+		Status: string(domain.ContainerStatusExited),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: ownerDomain,
+		},
+		VolumeMounts: []domain.ContainerVolumeMount{{
+			Name:        "missing-data",
+			Type:        "volume",
+			Destination: "/var/lib/postgresql",
+		}},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{existing}, nil).Once()
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{serviceImage}, nil).Once()
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, serviceImage).Return([]int{}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, "missing-data").Return(false, nil).Once()
+
+	err := svc.deployAttachedService(testContext(), ownerDomain, serviceImage, "gordon-net")
+
+	require.ErrorContains(t, err, "previously mounted volume")
+	require.ErrorIs(t, err, domain.ErrVolumeNotFound)
+}
+
+func TestDeployAttachedService_KeepsRunningAttachmentWhenVolumeValidationFails(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	config.VolumeAutoCreate = true
+	config.VolumePrefix = "gordon"
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+
+	ownerDomain := "app.example.com"
+	serviceImage := "postgres:16"
+	containerName := fmt.Sprintf("gordon-%s-postgres", domain.SanitizeDomainForContainer(ownerDomain))
+	existing := &domain.Container{
+		ID:     "running-postgres",
+		Name:   containerName,
+		Status: string(domain.ContainerStatusRunning),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: ownerDomain,
+			domain.LabelImage:      "postgres:15",
+			domain.LabelEnvHash:    hashEnvironment(nil),
+		},
+		VolumeMounts: []domain.ContainerVolumeMount{{
+			Name:        "missing-data",
+			Type:        "volume",
+			Destination: "/var/lib/postgresql",
+		}},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{existing}, nil).Once()
+	envLoader.EXPECT().LoadEnv(mock.Anything, containerName).Return([]string{}, nil).Once()
+	runtime.EXPECT().InspectImageEnv(mock.Anything, serviceImage).Return([]string{}, nil).Once()
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{serviceImage}, nil).Once()
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, serviceImage).Return([]int{}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, "missing-data").Return(false, nil).Once()
+
+	err := svc.deployAttachedService(testContext(), ownerDomain, serviceImage, "gordon-net")
+
+	require.ErrorContains(t, err, "previously mounted volume")
+	require.ErrorIs(t, err, domain.ErrVolumeNotFound)
+}
+
+func TestDeployAttachedService_ReusesVolumeFromLegacyNamedAttachment(t *testing.T) {
+	runtime := mocks.NewMockContainerRuntime(t)
+	envLoader := mocks.NewMockEnvLoader(t)
+	eventBus := mocks.NewMockEventPublisher(t)
+
+	config := testMinDelayConfig()
+	config.VolumeAutoCreate = true
+	config.VolumePrefix = "gordon"
+	svc := NewService(runtime, envLoader, eventBus, nil, config, nil)
+	ctx := testContext()
+
+	ownerDomain := "app.example.com"
+	serviceImage := "postgres:16"
+	serviceName := "postgres"
+	networkName := "gordon-net"
+	containerName := fmt.Sprintf("gordon-%s-%s", domain.SanitizeDomainForContainer(ownerDomain), serviceName)
+	legacyContainerName := fmt.Sprintf("gordon-%s-%s", domain.SanitizeDomainForContainerLegacy(ownerDomain), serviceName)
+	volumePath := "/var/lib/postgresql"
+	legacyVolume := legacyVolumeName(config.VolumePrefix, legacyContainerName, volumePath)
+	existing := &domain.Container{
+		ID:     "legacy-postgres",
+		Name:   legacyContainerName,
+		Status: string(domain.ContainerStatusRunning),
+		Labels: map[string]string{
+			domain.LabelManaged:    "true",
+			domain.LabelAttachment: "true",
+			domain.LabelAttachedTo: ownerDomain,
+		},
+		VolumeMounts: []domain.ContainerVolumeMount{{
+			Name:        legacyVolume,
+			Type:        "volume",
+			Destination: volumePath,
+		}},
+	}
+
+	runtime.EXPECT().ListContainers(mock.Anything, true).Return([]*domain.Container{existing}, nil).Times(2)
+	runtime.EXPECT().StopContainer(mock.Anything, existing.ID).Return(nil).Once()
+	runtime.EXPECT().RemoveContainer(mock.Anything, existing.ID, true).Return(nil).Once()
+	runtime.EXPECT().ListImages(mock.Anything).Return([]string{serviceImage}, nil).Once()
+	runtime.EXPECT().GetImageExposedPorts(mock.Anything, serviceImage).Return([]int{}, nil).Once()
+	runtime.EXPECT().InspectImageVolumes(mock.Anything, serviceImage).Return([]string{volumePath}, nil).Once()
+	runtime.EXPECT().VolumeExists(mock.Anything, legacyVolume).Return(true, nil).Once()
+	envLoader.EXPECT().LoadEnv(mock.Anything, containerName).Return([]string{}, nil).Once()
+	runtime.EXPECT().InspectImageEnv(mock.Anything, serviceImage).Return([]string{}, nil).Once()
+	runtime.EXPECT().CreateContainer(mock.Anything, mock.AnythingOfType("*domain.ContainerConfig")).
+		Run(func(_ context.Context, cfg *domain.ContainerConfig) {
+			assert.Equal(t, map[string]string{volumePath: legacyVolume}, cfg.Volumes)
+		}).
+		Return(&domain.Container{ID: "new-postgres", Name: containerName}, nil).Once()
+	runtime.EXPECT().StartContainer(mock.Anything, "new-postgres").Return(nil).Once()
+	runtime.EXPECT().IsContainerRunning(mock.Anything, "new-postgres").Return(true, nil).Times(2)
+	runtime.EXPECT().GetContainerHealthStatus(mock.Anything, "new-postgres").Return("", false, nil).Once()
+
+	require.NoError(t, svc.deployAttachedService(ctx, ownerDomain, serviceImage, networkName))
 }
 
 func TestDeployAttachedService_SetsAliasOnContainerConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- carry verified named-volume mounts across attachment recreation before removing the old container
- preserve existing mounts even when automatic volume creation is disabled
- validate replacement image, environment, and volumes before stopping or removing the current attachment
- preserve writable and read-only mount semantics for current and legacy attachment names
- fail closed instead of creating an empty stable volume when legacy ownership is unverified
- create a stable replacement only when the colliding legacy volume is positively identified as foreign

## Why

Gordon v2.31 can remove a stopped attachment container before legacy-volume ownership is checked. The ownership check then cannot verify the preserved volume and silently creates a new empty volume, making stateful services appear reset after a reboot or redeploy.

## Verification

- `go test ./... -count=1`
- `go build ./...`
- Go 1.27-compatible `golangci-lint run ./...` — 0 issues

## Regression coverage

- stopped current-name attachment reuses its verified legacy volume
- legacy-name attachment carries its volume into the replacement container
- read-only mounts retain read-only semantics
- existing mounts survive with `volumes.auto_create = false`
- replacement validation failures leave stopped and running attachments intact
- unverified legacy ownership aborts deployment
- verified foreign ownership permits stable-volume creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preferred existing volumes can now be reused when setting up attachments.
  * Read-only and read-write volume mounts are preserved during attachment redeployment.
  * Legacy attachments and verified legacy volumes are supported in the standard replacement flow.

* **Bug Fixes**
  * Prevented replacement when legacy volume ownership cannot be verified.
  * Improved cleanup sequencing to avoid removing attachments or volumes after validation failures.
  * Preserved existing volume names and attachment states during redeployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->