### PR TITLE
fix(remote): avoid replaying non-idempotent requests

### DIFF
--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -305,7 +305,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, jsonBody []
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, &requestTransportError{err: err}
+		return nil, &requestTransportError{
+			err: fmt.Errorf("%s %s transport request: %w", method, path, err),
+		}
 	}
 
 	return resp, nil
@@ -394,7 +396,10 @@ func parseErrorResponse(resp *http.Response, body []byte) error {
 }
 
 func isRetryableRequestError(err error) bool {
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+	var transportErr *requestTransportError
+	return errors.As(err, &transportErr) &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
 }
 
 func isIdempotentMethod(method string) bool {

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -266,6 +266,18 @@ func (c *Client) request(ctx context.Context, method, path string, body any) (*h
 	return resp, nil
 }
 
+type requestTransportError struct {
+	err error
+}
+
+func (e *requestTransportError) Error() string {
+	return e.err.Error()
+}
+
+func (e *requestTransportError) Unwrap() error {
+	return e.err
+}
+
 // doRequest builds and executes a single HTTP request to the admin API.
 func (c *Client) doRequest(ctx context.Context, method, path string, jsonBody []byte) (*http.Response, error) {
 	reqURL := c.baseURL + "/admin" + path
@@ -293,7 +305,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, jsonBody []
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, &requestTransportError{err: err}
 	}
 
 	return resp, nil
@@ -333,6 +345,28 @@ func (e *HTTPError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
+// OutcomeUnknownError reports that a non-idempotent request may have completed
+// even though the client did not receive a definitive response.
+type OutcomeUnknownError struct {
+	Method string
+	Path   string
+	Err    error
+}
+
+func (e *OutcomeUnknownError) Error() string {
+	return fmt.Sprintf(
+		"%s %s outcome unknown: request may have completed; inspect current state before retrying: %v",
+		e.Method,
+		e.Path,
+		e.Err,
+	)
+}
+
+// Unwrap returns the transport or HTTP error that made the outcome ambiguous.
+func (e *OutcomeUnknownError) Unwrap() error {
+	return e.Err
+}
+
 func parseErrorResponse(resp *http.Response, body []byte) error {
 	msg := string(body)
 	structured := false
@@ -363,9 +397,19 @@ func isRetryableRequestError(err error) bool {
 	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
+func isIdempotentMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace,
+		http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
 func isRetryableStatus(status int) bool {
-	// Only retry gateway errors; retrying 500 on non-idempotent POSTs
-	// (deploy, restart, reload) can cause duplicate state changes.
+	// Gateway errors can be transient; requestWithRetry separately ensures the
+	// method is safe to replay before attempting another request.
 	return status == 502 || status == 503 || status == 504
 }
 
@@ -376,14 +420,23 @@ func retryDelay(attempt int) time.Duration {
 	return retryBaseDelay * time.Duration(1<<(attempt-1))
 }
 
-// requestWithRetry performs an HTTP request and retries transient failures.
-// Retries occur on transport errors and gateway errors (502, 503, 504).
+// requestWithRetry performs an HTTP request and retries transient failures
+// only when the HTTP method is idempotent. A transient failure from a
+// non-idempotent request is returned as OutcomeUnknownError without replaying it.
 func (c *Client) requestWithRetry(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var lastErr error
+	idempotent := isIdempotentMethod(method)
 
 	for attempt := 1; attempt <= retryMaxAttempts; attempt++ {
 		resp, err := c.request(ctx, method, path, body)
 		if err != nil {
+			if !idempotent {
+				var transportErr *requestTransportError
+				if errors.As(err, &transportErr) {
+					return nil, &OutcomeUnknownError{Method: method, Path: path, Err: err}
+				}
+				return nil, err
+			}
 			lastErr = err
 			if attempt == retryMaxAttempts || !isRetryableRequestError(err) {
 				return nil, err
@@ -396,6 +449,9 @@ func (c *Client) requestWithRetry(ctx context.Context, method, path string, body
 			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 			_ = resp.Body.Close()
 			lastErr = parseErrorResponse(resp, respBody)
+			if !idempotent {
+				return nil, &OutcomeUnknownError{Method: method, Path: path, Err: lastErr}
+			}
 			if attempt == retryMaxAttempts {
 				return nil, lastErr
 			}
@@ -718,7 +774,7 @@ func (c *Client) GetTrafficStatus(ctx context.Context) (*dto.TrafficStatusRespon
 
 // GetStatus returns the Gordon server status.
 func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
-	resp, err := c.request(ctx, http.MethodGet, "/status", nil)
+	resp, err := c.requestWithRetry(ctx, http.MethodGet, "/status", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/in/cli/remote/client_test.go
+++ b/internal/adapters/in/cli/remote/client_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bnema/gordon/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 func withFastRetry(t *testing.T) {
@@ -32,57 +32,72 @@ func withFastRetry(t *testing.T) {
 	})
 }
 
-func TestClientRestartRetriesOn5xx(t *testing.T) {
+func TestClientRestartDoesNotRetryGatewayResponseAfterSideEffect(t *testing.T) {
 	withFastRetry(t)
 
-	var attempts int32
+	var mutations int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/admin/restart/test.example.com", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
-		current := atomic.AddInt32(&attempts, 1)
-		if current < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"error":"temporary outage"}`))
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"restarted","domain":"test.example.com"}`))
+		atomic.AddInt32(&mutations, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"upstream response unavailable"}`))
 	}))
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
 	result, err := client.Restart(context.Background(), "test.example.com", false)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.Equal(t, "test.example.com", result.Domain)
-	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+
+	require.Nil(t, result)
+	var outcomeErr *OutcomeUnknownError
+	require.ErrorAs(t, err, &outcomeErr)
+	assert.Contains(t, err.Error(), "inspect current state before retrying")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&mutations))
 }
 
-func TestClientReloadRetriesOn5xx(t *testing.T) {
+func TestClientRestartDoesNotRetryAmbiguousTransportFailure(t *testing.T) {
+	withFastRetry(t)
+
+	var mutations int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&mutations, 1)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	result, err := client.Restart(context.Background(), "test.example.com", true)
+
+	require.Nil(t, result)
+	var outcomeErr *OutcomeUnknownError
+	require.ErrorAs(t, err, &outcomeErr)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&mutations))
+}
+
+func TestClientReloadDoesNotRetryGatewayResponse(t *testing.T) {
 	withFastRetry(t)
 
 	var attempts int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/admin/reload", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
-		current := atomic.AddInt32(&attempts, 1)
-		if current < 2 {
-			w.WriteHeader(http.StatusBadGateway)
-			_, _ = w.Write([]byte(`upstream down`))
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"reloaded"}`))
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`upstream down`))
 	}))
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
 	err := client.Reload(context.Background())
-	require.NoError(t, err)
-	assert.EqualValues(t, 2, atomic.LoadInt32(&attempts))
+
+	var outcomeErr *OutcomeUnknownError
+	require.ErrorAs(t, err, &outcomeErr)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&attempts))
 }
 
-func TestClientDeployReturnsErrorAfterRetryExhaustion(t *testing.T) {
+func TestClientDeployDoesNotRetryGatewayResponse(t *testing.T) {
 	withFastRetry(t)
 
 	var attempts int32
@@ -96,10 +111,108 @@ func TestClientDeployReturnsErrorAfterRetryExhaustion(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
-	_, err := client.Deploy(context.Background(), "test.example.com")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "502 Bad Gateway: upstream unavailable")
-	assert.EqualValues(t, retryMaxAttempts, atomic.LoadInt32(&attempts))
+	result, err := client.Deploy(context.Background(), "test.example.com")
+
+	require.Nil(t, result)
+	var outcomeErr *OutcomeUnknownError
+	require.ErrorAs(t, err, &outcomeErr)
+	assert.ErrorContains(t, err, "502 Bad Gateway: upstream unavailable")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&attempts))
+}
+
+func TestClientDeployConfirmedRejectionIsNotOutcomeUnknown(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"error":"invalid deployment"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	result, err := client.Deploy(context.Background(), "test.example.com")
+
+	require.Nil(t, result)
+	var outcomeErr *OutcomeUnknownError
+	assert.NotErrorAs(t, err, &outcomeErr)
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&attempts))
+}
+
+func TestClientDeployAuthenticationRejectionIsNotOutcomeUnknown(t *testing.T) {
+	var deployAttempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/token" {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"invalid credentials"}`))
+			return
+		}
+		atomic.AddInt32(&deployAttempts, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, WithToken("invalid-token"))
+	result, err := client.Deploy(context.Background(), "test.example.com")
+
+	require.Nil(t, result)
+	var outcomeErr *OutcomeUnknownError
+	assert.NotErrorAs(t, err, &outcomeErr)
+	assert.ErrorContains(t, err, "ephemeral token exchange: 403 Forbidden")
+	assert.Zero(t, atomic.LoadInt32(&deployAttempts))
+}
+
+func TestClientGetStatusRetriesTransientGatewayResponse(t *testing.T) {
+	withFastRetry(t)
+
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/admin/status", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = w.Write([]byte(`{"error":"upstream timeout"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"routes":2,"container_status":{}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	status, err := client.GetStatus(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, 2, status.Routes)
+	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+}
+
+func TestClientGetStatusRetriesTransientTransportFailure(t *testing.T) {
+	withFastRetry(t)
+
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			require.NoError(t, err)
+			require.NoError(t, conn.Close())
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"routes":2,"container_status":{}}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	status, err := client.GetStatus(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, 2, status.Routes)
+	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
 }
 
 func TestClientWithInsecureTLS_AllowsSelfSignedCertificate(t *testing.T) {

--- a/internal/adapters/in/cli/remote/client_test.go
+++ b/internal/adapters/in/cli/remote/client_test.go
@@ -164,6 +164,26 @@ func TestClientDeployAuthenticationRejectionIsNotOutcomeUnknown(t *testing.T) {
 	assert.Zero(t, atomic.LoadInt32(&deployAttempts))
 }
 
+func TestClientGetStatusDoesNotRetryAuthenticationRejection(t *testing.T) {
+	withFastRetry(t)
+
+	var tokenAttempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/auth/token", r.URL.Path)
+		atomic.AddInt32(&tokenAttempts, 1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"invalid credentials"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, WithToken("invalid-token"))
+	status, err := client.GetStatus(context.Background())
+
+	require.Nil(t, status)
+	assert.ErrorContains(t, err, "ephemeral token exchange: 403 Forbidden")
+	assert.EqualValues(t, 1, atomic.LoadInt32(&tokenAttempts))
+}
+
 func TestClientGetStatusRetriesTransientGatewayResponse(t *testing.T) {
 	withFastRetry(t)
 
@@ -213,6 +233,26 @@ func TestClientGetStatusRetriesTransientTransportFailure(t *testing.T) {
 	require.NotNil(t, status)
 	assert.Equal(t, 2, status.Routes)
 	assert.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+}
+
+func TestClientGetStatusReportsTransportContextAfterRetryExhaustion(t *testing.T) {
+	withFastRetry(t)
+
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	status, err := client.GetStatus(context.Background())
+
+	require.Nil(t, status)
+	assert.ErrorContains(t, err, "GET /status transport request")
+	assert.EqualValues(t, retryMaxAttempts, atomic.LoadInt32(&attempts))
 }
 
 func TestClientWithInsecureTLS_AllowsSelfSignedCertificate(t *testing.T) {


### PR DESCRIPTION
## Summary

- retry transient transport and gateway failures only for idempotent HTTP methods
- return a typed outcome-unknown error when a dispatched mutation may have completed
- retain bounded retries for status reads and preserve confirmed rejection errors
- cover restart, reload, deploy, gateway, transport, and authentication outcomes

## Verification

- `go test ./...`
- `go vet ./...`
- configured golangci-lint checks except `staticcheck` and `unused` (their current analyzer panics on Go 1.27)

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of remote request failures by distinguishing confirmed errors from outcomes that may be uncertain.
  * Prevented potentially duplicating non-idempotent operations when transient failures occur.
  * Continued retrying safe status checks and other idempotent requests when appropriate.
  * Improved deployment error reporting for gateway, validation, and authentication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->