### PR TITLE
feat(proxy): route HTTP traffic to standalone services

### DIFF
--- a/docs/config/external-routes.md
+++ b/docs/config/external-routes.md
@@ -25,24 +25,14 @@ External routes allow proxying to independently managed, non-containerized servi
 
 ## Use Cases
 
-### Database Admin Tools
-
-Proxy to database admin interfaces:
+Proxy to an independently managed public backend:
 
 ```toml
 [external_routes]
-"pgadmin.mydomain.com" = "localhost:5050"
-"redis-commander.mydomain.com" = "localhost:8081"
+"legacy-api.mydomain.com" = "api.example.net:8080"
 ```
 
-### Legacy Services
-
-Proxy to services that can't be containerized:
-
-```toml
-[external_routes]
-"legacy-api.mydomain.com" = "192.168.1.50:8080"
-```
+For a local or private backend owned by Gordon, define it as `[[services]]` and select its HTTP port with `[service_routes]` instead.
 
 ## How It Works
 
@@ -73,7 +63,7 @@ vim ~/.config/gordon/gordon.toml
 
 # Add external route
 [external_routes]
-"newservice.mydomain.com" = "localhost:9000"
+"newservice.mydomain.com" = "service.example.net:9000"
 
 # Save - Gordon reloads automatically
 ```

--- a/docs/config/external-routes.md
+++ b/docs/config/external-routes.md
@@ -1,13 +1,13 @@
 # External Routes Configuration
 
-External routes allow proxying to non-containerized services running on the host or network.
+External routes allow proxying to independently managed, non-containerized services on public network addresses. They are not a bridge to Gordon-managed standalone services.
 
 ## Configuration
 
 ```toml
 [external_routes]
-"service.mydomain.com" = "localhost:3000"
-"cache.mydomain.com" = "192.168.1.100:6379"
+"service.mydomain.com" = "198.51.100.10:3000"
+"cache.mydomain.com" = "backend.example.net:6379"
 ```
 
 ## Syntax
@@ -58,6 +58,7 @@ Client ─> Gordon Proxy ─> External Service
 
 ## Limitations
 
+- Loopback, private, link-local, and otherwise internal targets are blocked by SSRF protection. Use `[service_routes]` for an HTTP hostname targeting a Gordon-managed `[[services]]` port.
 - HTTP only (no HTTPS upstream)
 - No health checks
 - No load balancing

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -168,19 +168,25 @@ preserve = true                              # Keep volumes when containers are 
 # Legacy "http://domain.com" keys are read for compatibility and rewritten on save.
 
 # =============================================================================
+# SERVICE ROUTES
+# =============================================================================
+[service_routes]
+# "app.domain.com" = { service = "app", port = "web" } # HTTP to a standalone service TCP port
+
+# =============================================================================
 # EXTERNAL ROUTES
 # =============================================================================
 [external_routes]
-# "domain.com" = "host:port"                 # Proxy to non-container services
+# "domain.com" = "host:port"                 # Proxy to a non-private external service
 
 # =============================================================================
 # STANDALONE SERVICES
 # =============================================================================
 # [[services]]
-# name = "rust"
-# image = "registry.example.com:5000/rust:latest"
+# name = "app"
+# image = "registry.example.com:5000/app:latest"
 # enabled = true
-# env_file = "/srv/gordon/services/rust.env"
+# env_file = "/srv/gordon/services/app.env"
 #
 # [[services.ports]]
 # name = "game"
@@ -314,6 +320,8 @@ keep_last = 3                                # Keep N newest tags per repository
 | `volumes.auto_create` | `true` | Auto-create volumes |
 | `volumes.prefix` | `"gordon"` | Volume prefix |
 | `volumes.preserve` | `true` | Keep volumes |
+| `service_routes.<domain>.service` | none | Name of the target standalone service |
+| `service_routes.<domain>.port` | none | Name of the target TCP service port; does not create a route container |
 | `services[].name` | none | Standalone service name used by `service:<service>:<port-name>` traffic refs |
 | `services[].image` | none | Container image for enabled standalone services |
 | `services[].enabled` | `false` | Whether Gordon creates, starts, and reconciles the service container |
@@ -322,7 +330,7 @@ keep_last = 3                                # Keep N newest tags per repository
 | `services[].ports[].name` | none | Port name used by traffic service refs |
 | `services[].ports[].container` | none | Container port number |
 | `services[].ports[].protocol` | none | `tcp` or `udp` |
-| `services[].ports[].publish` | `""` | Host-side bind address, usually loopback, that the traffic manager dials |
+| `services[].ports[].publish` | `""` | Host-side bind address, usually loopback, that Gordon dials |
 | `services[].ports[].private` | `false` | Require matching service and entrypoint `trusted_cidrs` for this port |
 | `services[].ports[].public` | `false` | Explicit public opt-out for admin port names such as `rcon` |
 | `services[].ports[].trusted_cidrs` | `[]` | CIDRs allowed for private port routing; must match the target entrypoint |

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -171,7 +171,7 @@ preserve = true                              # Keep volumes when containers are 
 # SERVICE ROUTES
 # =============================================================================
 [service_routes]
-# "app.domain.com" = { service = "app", port = "web" } # HTTP to a standalone service TCP port
+# "app.domain.com" = { service = "app", port_name = "web" } # HTTP to a standalone service TCP port
 
 # =============================================================================
 # EXTERNAL ROUTES
@@ -321,7 +321,7 @@ keep_last = 3                                # Keep N newest tags per repository
 | `volumes.prefix` | `"gordon"` | Volume prefix |
 | `volumes.preserve` | `true` | Keep volumes |
 | `service_routes.<domain>.service` | none | Name of the target standalone service |
-| `service_routes.<domain>.port` | none | Name of the target TCP service port; does not create a route container |
+| `service_routes.<domain>.port_name` | none | Name of the target TCP service port; does not create a route container |
 | `services[].name` | none | Standalone service name used by `service:<service>:<port-name>` traffic refs |
 | `services[].image` | none | Container image for enabled standalone services |
 | `services[].enabled` | `false` | Whether Gordon creates, starts, and reconciles the service container |

--- a/docs/config/reference.md
+++ b/docs/config/reference.md
@@ -190,13 +190,13 @@ preserve = true                              # Keep volumes when containers are 
 #
 # [[services.ports]]
 # name = "game"
-# container = 28015
+# container_port = 28015
 # protocol = "udp"
 # publish = "127.0.0.1:38015"
 #
 # [[services.ports]]
 # name = "rcon"
-# container = 28016
+# container_port = 28016
 # protocol = "tcp"
 # publish = "127.0.0.1:38016"
 # trusted_cidrs = ["100.64.0.0/10"]
@@ -328,7 +328,7 @@ keep_last = 3                                # Keep N newest tags per repository
 | `services[].env` | `[]` | Inline `KEY=value` environment entries |
 | `services[].env_file` | `""` | Env file loaded before inline entries |
 | `services[].ports[].name` | none | Port name used by traffic service refs |
-| `services[].ports[].container` | none | Container port number |
+| `services[].ports[].container_port` | none | Port number inside the container |
 | `services[].ports[].protocol` | none | `tcp` or `udp` |
 | `services[].ports[].publish` | `""` | Host-side bind address, usually loopback, that Gordon dials |
 | `services[].ports[].private` | `false` | Require matching service and entrypoint `trusted_cidrs` for this port |

--- a/docs/config/routes.md
+++ b/docs/config/routes.md
@@ -28,6 +28,17 @@ Legacy `http://...` route keys are still read for backward compatibility and rew
 
 ## Route Types
 
+### Service Routes
+
+`[routes]` owns an image-backed route container. To send HTTP traffic to an existing Gordon-managed standalone service port, use `[service_routes]` instead:
+
+```toml
+[service_routes]
+"app.mydomain.com" = { service = "app", port = "web" }
+```
+
+The standalone service owns its single container; this mapping only forwards HTTP traffic to its validated published TCP port. See [Standalone Services](./services.md).
+
 ### HTTPS Routes (Default)
 
 Standard routes expect HTTPS traffic (terminated by Cloudflare or similar):

--- a/docs/config/routes.md
+++ b/docs/config/routes.md
@@ -34,7 +34,7 @@ Legacy `http://...` route keys are still read for backward compatibility and rew
 
 ```toml
 [service_routes]
-"app.mydomain.com" = { service = "app", port = "web" }
+"app.mydomain.com" = { service = "app", port_name = "web" }
 ```
 
 The standalone service owns its single container; this mapping only forwards HTTP traffic to its validated published TCP port. See [Standalone Services](./services.md).

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -1,66 +1,63 @@
 # Standalone Services
 
-Standalone services are Gordon-managed containers for non-HTTP workloads such as game servers, databases, or TCP/UDP daemons. Gordon creates, starts, restarts, reconciles, and removes these containers from the `[[services]]` configuration during startup and reload.
+Use `[[services]]` when Gordon should run one container that exposes more than one named port. Gordon owns that one container; each route only chooses which published port receives traffic.
 
-Standalone services are separate from HTTP `[routes]`. Route normal web apps with `[routes]`; use `[[services]]` when Gordon must manage a long-running container that is reached by explicit L4 traffic routers.
+## One container, several ports
 
-## Example
+This image exposes a web server, an optional TCP service, and an optional UDP service:
 
 ```toml
 [[services]]
-name = "rust"
-image = "registry.example.com:5000/rust:latest"
+name = "app"
+image = "registry.example.com:5000/app:latest"
 enabled = true
-env_file = "/srv/gordon/services/rust.env"
-
-[services.readiness]
-type = "log"
-path = "/steamcmd/rust/server.log"
-contains = "Server startup complete"
-timeout = "2m"
 
 [[services.ports]]
-name = "game"
-container = 28015
-protocol = "udp"
-publish = "127.0.0.1:38015"
-
-[[services.ports]]
-name = "rcon"
-container = 28016
+name = "web"
+container = 8080
 protocol = "tcp"
-publish = "127.0.0.1:38016"
-trusted_cidrs = ["100.64.0.0/10"]
+publish = "127.0.0.1:18080"
+
+[[services.ports]]
+name = "tcp"
+container = 9000
+protocol = "tcp"
+publish = "127.0.0.1:19000"
+
+[[services.ports]]
+name = "udp"
+container = 9001
+protocol = "udp"
+publish = "127.0.0.1:19001"
 ```
 
-The `publish` address is the host-side bind address that Gordon's traffic manager dials; use loopback for private backends. Expose services through `[traffic]` routers instead of binding service containers directly to a public interface.
-
-## Traffic routing
-
-Use `service:<service>:<port-name>` from TCP, UDP, or TLS passthrough routers:
+To expose the web port on a hostname, select it explicitly:
 
 ```toml
-[entrypoints.rust]
-address = "0.0.0.0:28015"
+[service_routes]
+"app.example.com" = { service = "app", port = "web" }
+```
+
+Gordon creates **one** `app` container and forwards HTTP traffic to its `web` port. It does not create a normal `[routes]` container for `app.example.com`.
+
+The selected port must be TCP and have a valid `publish` address. `[service_routes]` is only for Gordon-managed services; external routes remain for non-private, independently managed backends.
+
+## Optional TCP and UDP traffic
+
+Use a traffic router only for ports that need L4 traffic. It can target another named port on the same container:
+
+```toml
+[entrypoints.app-udp]
+address = ":9001"
 protocol = "udp"
 
 [[traffic.udp.routers]]
-name = "rust-game"
-entrypoint = "rust"
-service = "service:rust:game"
-
-[entrypoints.rcon]
-address = "0.0.0.0:28016"
-protocol = "tcp"
-trusted_cidrs = ["100.64.0.0/10"]
-
-[[traffic.tcp.routers]]
-name = "rust-rcon"
-entrypoint = "rcon"
-service = "service:rust:rcon"
+name = "app-udp"
+entrypoint = "app-udp"
+service = "service:app:udp"
 ```
 
-Ports named `rcon` default to private. Private ports require non-empty `trusted_cidrs` on both the service port and target entrypoint, and the CIDR sets must match. To intentionally expose an RCON port publicly, set `public = true` on that port.
+The `web`, `tcp`, and `udp` names are yours. They make the intended port clear in configuration. Private ports require `trusted_cidrs`; Gordon enforces that policy before forwarding.
 
 ## Volumes
 
@@ -68,8 +65,8 @@ Explicit volumes are optional:
 
 ```toml
 [[services.volumes]]
-source = "rust-data"
-target = "/steamcmd/rust"
+source = "app-data"
+target = "/var/lib/app"
 read_only = false
 ```
 

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -35,7 +35,7 @@ To expose the web port on a hostname, select it explicitly:
 
 ```toml
 [service_routes]
-"app.example.com" = { service = "app", port = "web" }
+"app.example.com" = { service = "app", port_name = "web" }
 ```
 
 Gordon creates **one** `app` container and forwards HTTP traffic to its `web` port. It does not create a normal `[routes]` container for `app.example.com`.

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -14,19 +14,19 @@ enabled = true
 
 [[services.ports]]
 name = "web"
-container = 8080
+container_port = 8080
 protocol = "tcp"
 publish = "127.0.0.1:18080"
 
 [[services.ports]]
 name = "tcp"
-container = 9000
+container_port = 9000
 protocol = "tcp"
 publish = "127.0.0.1:19000"
 
 [[services.ports]]
 name = "udp"
-container = 9001
+container_port = 9001
 protocol = "udp"
 publish = "127.0.0.1:19001"
 ```

--- a/docs/config/traffic.md
+++ b/docs/config/traffic.md
@@ -45,7 +45,7 @@ enabled = true
 
 [[services.ports]]
 name = "udp"
-container = 9001
+container_port = 9001
 protocol = "udp"
 publish = "127.0.0.1:19001"
 

--- a/docs/config/traffic.md
+++ b/docs/config/traffic.md
@@ -39,24 +39,24 @@ Standalone services are Gordon-managed containers that L4 routers can target wit
 
 ```toml
 [[services]]
-name = "rust"
-image = "registry.example.com:5000/rust:latest"
+name = "app"
+image = "registry.example.com:5000/app:latest"
 enabled = true
 
 [[services.ports]]
-name = "game"
-container = 28015
+name = "udp"
+container = 9001
 protocol = "udp"
-publish = "127.0.0.1:38015"
+publish = "127.0.0.1:19001"
 
-[entrypoints.rust]
-address = "0.0.0.0:28015"
+[entrypoints.app-udp]
+address = ":9001"
 protocol = "udp"
 
 [[traffic.udp.routers]]
-name = "rust-game"
-entrypoint = "rust"
-service = "service:rust:game"
+name = "app-udp"
+entrypoint = "app-udp"
+service = "service:app:udp"
 ```
 
 Network services describe manually managed non-HTTP backends that L4 routers can target.

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -192,7 +192,7 @@ keep = 14
 # publish = "127.0.0.1:19001"
 
 [service_routes]
-# "app.example.com" = { service = "app", port = "web" }
+# "app.example.com" = { service = "app", port_name = "web" }
 
 [external_routes]
 # "status.example.com" = "198.51.100.10:9000"

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -171,48 +171,40 @@ keep = 14
 [routes]
 # "app.example.com" = { image = "myapp:latest" }
 
-[external_routes]
-# "status.example.com" = "127.0.0.1:9000"
-
-# Gordon-managed standalone L4 services. Use service:<name>:<port> from
-# traffic routers to expose published loopback ports.
+# One Gordon-managed image can expose several named ports. Gordon creates one
+# container; service_routes selects its HTTP port, while traffic routers can
+# optionally expose its TCP or UDP ports.
 # [[services]]
-# name = "rust"
-# image = "registry.example.com:5000/rust:latest"
+# name = "app"
+# image = "registry.example.com:5000/app:latest"
 # enabled = true
-# env_file = "/srv/gordon/services/rust.env"
 #
 # [[services.ports]]
-# name = "game"
-# container = 28015
-# protocol = "udp"
-# publish = "127.0.0.1:38015"
-#
-# [[services.ports]]
-# name = "rcon"
-# container = 28016
+# name = "web"
+# container = 8080
 # protocol = "tcp"
-# publish = "127.0.0.1:38016"
-# trusted_cidrs = ["100.64.0.0/10"]
+# publish = "127.0.0.1:18080"
 #
-# [entrypoints.rust]
-# address = "0.0.0.0:28015"
+# [[services.ports]]
+# name = "udp"
+# container = 9001
+# protocol = "udp"
+# publish = "127.0.0.1:19001"
+
+[service_routes]
+# "app.example.com" = { service = "app", port = "web" }
+
+[external_routes]
+# "status.example.com" = "198.51.100.10:9000"
+
+# [entrypoints.app-udp]
+# address = ":9001"
 # protocol = "udp"
 #
 # [[traffic.udp.routers]]
-# name = "rust-game"
-# entrypoint = "rust"
-# service = "service:rust:game"
-#
-# [entrypoints.rcon]
-# address = "0.0.0.0:28016"
-# protocol = "tcp"
-# trusted_cidrs = ["100.64.0.0/10"]
-#
-# [[traffic.tcp.routers]]
-# name = "rust-rcon"
-# entrypoint = "rcon"
-# service = "service:rust:rcon"
+# name = "app-udp"
+# entrypoint = "app-udp"
+# service = "service:app:udp"
 
 [network_groups]
 # "backend" = ["app.example.com", "api.example.com"]

--- a/gordon.toml.example
+++ b/gordon.toml.example
@@ -181,13 +181,13 @@ keep = 14
 #
 # [[services.ports]]
 # name = "web"
-# container = 8080
+# container_port = 8080
 # protocol = "tcp"
 # publish = "127.0.0.1:18080"
 #
 # [[services.ports]]
 # name = "udp"
-# container = 9001
+# container_port = 9001
 # protocol = "udp"
 # publish = "127.0.0.1:19001"
 

--- a/internal/adapters/dto/admin_config.go
+++ b/internal/adapters/dto/admin_config.go
@@ -8,6 +8,7 @@ type ConfigResponse struct {
 	Volumes          VolumesConfig          `json:"volumes"`
 	Routes           []Route                `json:"routes"`
 	ExternalRoutes   []ExternalRoute        `json:"external_routes"`
+	ServiceRoutes    []ServiceRoute         `json:"service_routes"`
 }
 
 // ServerConfig represents server config details.
@@ -40,4 +41,11 @@ type VolumesConfig struct {
 type ExternalRoute struct {
 	Domain string `json:"domain"`
 	Target string `json:"target,omitempty"`
+}
+
+// ServiceRoute represents a redacted HTTP-to-standalone-service route config entry.
+type ServiceRoute struct {
+	Domain  string `json:"domain"`
+	Service string `json:"service"`
+	Port    string `json:"port"`
 }

--- a/internal/adapters/dto/admin_config.go
+++ b/internal/adapters/dto/admin_config.go
@@ -45,7 +45,7 @@ type ExternalRoute struct {
 
 // ServiceRoute represents a redacted HTTP-to-standalone-service route config entry.
 type ServiceRoute struct {
-	Domain  string `json:"domain"`
-	Service string `json:"service"`
-	Port    string `json:"port"`
+	Domain   string `json:"domain"`
+	Service  string `json:"service"`
+	PortName string `json:"port_name"`
 }

--- a/internal/adapters/in/cli/config.go
+++ b/internal/adapters/in/cli/config.go
@@ -160,13 +160,13 @@ func renderConfigServiceRoutes(out io.Writer, config *remote.Config) error {
 	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
 	rows := make([][]string, 0, len(routes))
 	for _, route := range routes {
-		rows = append(rows, []string{route.Domain, route.Service, route.Port})
+		rows = append(rows, []string{route.Domain, route.Service, route.PortName})
 	}
 	table := components.NewTable(
 		components.WithColumns([]components.TableColumn{
 			{Title: "Domain", Width: 30},
 			{Title: "Service", Width: 30},
-			{Title: "Port", Width: 15},
+			{Title: "Port name", Width: 15},
 		}),
 		components.WithRows(rows),
 	)

--- a/internal/adapters/in/cli/config.go
+++ b/internal/adapters/in/cli/config.go
@@ -75,6 +75,9 @@ func renderConfigTable(out io.Writer, config *remote.Config) error {
 	if err := renderConfigRoutes(out, config); err != nil {
 		return err
 	}
+	if err := renderConfigServiceRoutes(out, config); err != nil {
+		return err
+	}
 	return renderConfigExternalRoutes(out, config)
 }
 
@@ -141,6 +144,33 @@ func renderConfigRoutes(out io.Writer, config *remote.Config) error {
 		}
 	}
 	return nil
+}
+
+func renderConfigServiceRoutes(out io.Writer, config *remote.Config) error {
+	if err := cliWriteLine(out, ""); err != nil {
+		return err
+	}
+	if err := cliWriteLine(out, cliRenderTitle("Service Routes")); err != nil {
+		return err
+	}
+	if len(config.ServiceRoutes) == 0 {
+		return cliWriteLine(out, cliRenderMuted("No service routes configured"))
+	}
+	routes := append([]remote.ServiceRoute(nil), config.ServiceRoutes...)
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
+	rows := make([][]string, 0, len(routes))
+	for _, route := range routes {
+		rows = append(rows, []string{route.Domain, route.Service, route.Port})
+	}
+	table := components.NewTable(
+		components.WithColumns([]components.TableColumn{
+			{Title: "Domain", Width: 30},
+			{Title: "Service", Width: 30},
+			{Title: "Port", Width: 15},
+		}),
+		components.WithRows(rows),
+	)
+	return cliWriteLine(out, table.View())
 }
 
 func renderConfigExternalRoutes(out io.Writer, config *remote.Config) error {

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -502,7 +502,7 @@ func (l *localControlPlane) GetConfig(ctx context.Context) (*remote.Config, erro
 	serviceRoutes := l.configSvc.GetServiceRoutes()
 	serviceRouteResponses := make([]remote.ServiceRoute, 0, len(serviceRoutes))
 	for _, route := range serviceRoutes {
-		serviceRouteResponses = append(serviceRouteResponses, remote.ServiceRoute{Domain: route.Domain, Service: route.Service, Port: route.Port})
+		serviceRouteResponses = append(serviceRouteResponses, remote.ServiceRoute{Domain: route.Domain, Service: route.Service, PortName: route.PortName})
 	}
 	cfg := &remote.Config{
 		Routes:         l.configSvc.GetRoutes(ctx),

--- a/internal/adapters/in/cli/controlplane_local.go
+++ b/internal/adapters/in/cli/controlplane_local.go
@@ -499,9 +499,15 @@ func (l *localControlPlane) GetConfig(ctx context.Context) (*remote.Config, erro
 	sort.Slice(externalResponses, func(i, j int) bool {
 		return externalResponses[i].Domain < externalResponses[j].Domain
 	})
+	serviceRoutes := l.configSvc.GetServiceRoutes()
+	serviceRouteResponses := make([]remote.ServiceRoute, 0, len(serviceRoutes))
+	for _, route := range serviceRoutes {
+		serviceRouteResponses = append(serviceRouteResponses, remote.ServiceRoute{Domain: route.Domain, Service: route.Service, Port: route.Port})
+	}
 	cfg := &remote.Config{
 		Routes:         l.configSvc.GetRoutes(ctx),
 		ExternalRoutes: externalResponses,
+		ServiceRoutes:  serviceRouteResponses,
 	}
 	cfg.Server.Port = l.configSvc.GetServerPort()
 	cfg.Server.RegistryPort = l.configSvc.GetRegistryPort()

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -1031,9 +1031,9 @@ type ExternalRoute struct {
 
 // ServiceRoute represents a redacted HTTP-to-standalone-service route config entry.
 type ServiceRoute struct {
-	Domain  string `json:"domain"`
-	Service string `json:"service"`
-	Port    string `json:"port"`
+	Domain   string `json:"domain"`
+	Service  string `json:"service"`
+	PortName string `json:"port_name"`
 }
 
 // GetConfig returns the Gordon configuration.

--- a/internal/adapters/in/cli/remote/client.go
+++ b/internal/adapters/in/cli/remote/client.go
@@ -1020,12 +1020,20 @@ type Config struct {
 	} `json:"volumes"`
 	Routes         []domain.Route  `json:"routes"`
 	ExternalRoutes []ExternalRoute `json:"external_routes"`
+	ServiceRoutes  []ServiceRoute  `json:"service_routes"`
 }
 
 // ExternalRoute represents a redacted external route config entry.
 type ExternalRoute struct {
 	Domain string `json:"domain"`
 	Target string `json:"target,omitempty"`
+}
+
+// ServiceRoute represents a redacted HTTP-to-standalone-service route config entry.
+type ServiceRoute struct {
+	Domain  string `json:"domain"`
+	Service string `json:"service"`
+	Port    string `json:"port"`
 }
 
 // GetConfig returns the Gordon configuration.

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -1650,6 +1650,11 @@ func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
 			Domain: domain,
 		})
 	}
+	serviceRoutes := h.configSvc.GetServiceRoutes()
+	serviceRouteResponses := make([]dto.ServiceRoute, 0, len(serviceRoutes))
+	for _, route := range serviceRoutes {
+		serviceRouteResponses = append(serviceRouteResponses, dto.ServiceRoute{Domain: route.Domain, Service: route.Service, Port: route.Port})
+	}
 
 	config := dto.ConfigResponse{
 		Server: dto.ServerConfig{
@@ -1666,6 +1671,7 @@ func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
 		},
 		Routes:         routeResponses,
 		ExternalRoutes: externalResponses,
+		ServiceRoutes:  serviceRouteResponses,
 	}
 	if volumeCfg, ok := any(h.configSvc).(interface{ GetVolumeConfig() (bool, string, bool) }); ok {
 		config.Volumes.AutoCreate, config.Volumes.Prefix, config.Volumes.Preserve = volumeCfg.GetVolumeConfig()

--- a/internal/adapters/in/http/admin/handler.go
+++ b/internal/adapters/in/http/admin/handler.go
@@ -1653,7 +1653,7 @@ func (h *Handler) handleConfig(w http.ResponseWriter, r *http.Request) {
 	serviceRoutes := h.configSvc.GetServiceRoutes()
 	serviceRouteResponses := make([]dto.ServiceRoute, 0, len(serviceRoutes))
 	for _, route := range serviceRoutes {
-		serviceRouteResponses = append(serviceRouteResponses, dto.ServiceRoute{Domain: route.Domain, Service: route.Service, Port: route.Port})
+		serviceRouteResponses = append(serviceRouteResponses, dto.ServiceRoute{Domain: route.Domain, Service: route.Service, PortName: route.PortName})
 	}
 
 	config := dto.ConfigResponse{

--- a/internal/adapters/in/http/proxy/handler.go
+++ b/internal/adapters/in/http/proxy/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
 	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Handler implements http.Handler for the reverse proxy.
@@ -94,6 +95,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !targetAllowsPeer(target, r.RemoteAddr) {
+		log.Warn().Str("route_host", target.RouteHost).Msg("request source is not allowed for private service target")
+		proxyError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	log.Debug().
 		Str("host", target.Host).
 		Int("port", target.Port).
@@ -101,6 +108,27 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Msg("resolved proxy target")
 
 	h.forwardToTarget(w, r, target, cfg.MaxResponseSize)
+}
+
+func targetAllowsPeer(target *domain.ProxyTarget, remoteAddr string) bool {
+	if len(target.TrustedCIDRs) == 0 {
+		return true
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	peer := net.ParseIP(host)
+	if peer == nil {
+		return false
+	}
+	for _, cidr := range target.TrustedCIDRs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err == nil && network.Contains(peer) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeRequestHost(host string) string {

--- a/internal/adapters/in/http/proxy/handler_test.go
+++ b/internal/adapters/in/http/proxy/handler_test.go
@@ -114,6 +114,24 @@ func TestHandler_RejectsInvalidRequestHost(t *testing.T) {
 	}
 }
 
+func TestHandler_RejectsUntrustedPeerForPrivateServiceTarget(t *testing.T) {
+	proxySvc := inmocks.NewMockProxyService(t)
+	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+	proxySvc.EXPECT().IsRegistryDomain("play.example.com").Return(false)
+	proxySvc.EXPECT().GetTarget(mock.Anything, "play.example.com").Return(&domain.ProxyTarget{
+		Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "play.example.com", TrustedCIDRs: []string{"100.64.0.0/10"},
+	}, nil)
+
+	handler := NewHandler(proxySvc, nil, testLogger())
+	req := httptest.NewRequest(http.MethodGet, "http://play.example.com/", nil)
+	req.Host = "play.example.com"
+	req.RemoteAddr = "203.0.113.10:12345"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestHandler_Returns404WhenNoTarget(t *testing.T) {
 	proxySvc := inmocks.NewMockProxyService(t)
 

--- a/internal/adapters/in/http/proxy/handler_test.go
+++ b/internal/adapters/in/http/proxy/handler_test.go
@@ -123,13 +123,17 @@ func TestHandler_RejectsUntrustedPeerForPrivateServiceTarget(t *testing.T) {
 	}, nil)
 
 	handler := NewHandler(proxySvc, nil, testLogger())
-	req := httptest.NewRequest(http.MethodGet, "http://play.example.com/", nil)
-	req.Host = "play.example.com"
-	req.RemoteAddr = "203.0.113.10:12345"
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
+	server := httptest.NewServer(handler)
+	defer server.Close()
 
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+	req.Host = "play.example.com"
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
 func TestHandler_Returns404WhenNoTarget(t *testing.T) {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -818,7 +818,7 @@ func (si *serviceInit) registerReloadCoordinatorHooks() {
 				return tlsErr
 			}
 		}
-		if err := applyTrafficRuntimeConfig(reloadCtx, si.svc.trafficManager, reloadCfg, si.svc.configSvc); err != nil {
+		if err := applyTrafficRuntimeConfig(reloadCtx, si.svc.trafficManager, reloadCfg, si.svc.configSvc, si.svc.proxySvc); err != nil {
 			return err
 		}
 		si.svc.tlsHTTPEntryPoints = registerTLSMuxHTTPServers(si.svc.trafficManager, reloadCfg, si.svc.httpsProxyHandler, tlsConfig, si.svc.tlsHTTPEntryPoints)
@@ -2966,7 +2966,7 @@ func waitForCoreProxyReadyAndApplyTraffic(ctx context.Context, cfg Config, svc *
 	if err := waitForServerReady(proxyReady, errChan); err != nil {
 		return err
 	}
-	if err := applyTrafficRuntimeConfig(ctx, svc.trafficManager, cfg, svc.configSvc); err != nil {
+	if err := applyTrafficRuntimeConfig(ctx, svc.trafficManager, cfg, svc.configSvc, svc.proxySvc); err != nil {
 		return err
 	}
 	return reconcileStandaloneServices(ctx, svc.standaloneServiceSvc, cfg)

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -826,6 +826,9 @@ func (si *serviceInit) registerReloadCoordinatorHooks() {
 		if err := reconcileStandaloneServices(reloadCtx, si.svc.standaloneServiceSvc, reloadCfg); err != nil {
 			return err
 		}
+		if si.svc.proxySvc != nil {
+			si.svc.proxySvc.CommitStagedServiceTargets()
+		}
 		si.svc.containerSvc.UpdateConfig(containerCfg)
 		return nil
 	})
@@ -2969,7 +2972,13 @@ func waitForCoreProxyReadyAndApplyTraffic(ctx context.Context, cfg Config, svc *
 	if err := applyTrafficRuntimeConfig(ctx, svc.trafficManager, cfg, svc.configSvc, svc.proxySvc); err != nil {
 		return err
 	}
-	return reconcileStandaloneServices(ctx, svc.standaloneServiceSvc, cfg)
+	if err := reconcileStandaloneServices(ctx, svc.standaloneServiceSvc, cfg); err != nil {
+		return err
+	}
+	if svc.proxySvc != nil {
+		svc.proxySvc.CommitStagedServiceTargets()
+	}
+	return nil
 }
 
 func reconcileStandaloneServices(ctx context.Context, serviceSvc in.StandaloneServiceService, cfg Config) error {

--- a/internal/app/start_proxy_servers_test.go
+++ b/internal/app/start_proxy_servers_test.go
@@ -131,7 +131,7 @@ func TestStartProxyServers_ConfiguresSmartTCPHTTPAndHTTPSRoutesWithoutPublicHTTP
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, smartPortText, err := net.SplitHostPort(cfg.EntryPoints[traffic.DefaultEdgeEntryPointName].Address)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestStartProxyServers_ConfiguresTrafficManagerHTTPSRoute(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, portText, err := net.SplitHostPort(cfg.EntryPoints[traffic.DefaultEdgeEntryPointName].Address)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestStartProxyServers_ConfiguresCustomTLSMuxHTTPSRoute(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, customPort, err := net.SplitHostPort(cfg.EntryPoints["custom-secure"].Address)
 	require.NoError(t, err)

--- a/internal/app/traffic.go
+++ b/internal/app/traffic.go
@@ -7,35 +7,44 @@ import (
 	trafficadapter "github.com/bnema/gordon/internal/adapters/in/traffic"
 	"github.com/bnema/gordon/internal/boundaries/in"
 	"github.com/bnema/gordon/internal/domain"
+	"github.com/bnema/gordon/internal/usecase/proxy"
 	servicecfg "github.com/bnema/gordon/internal/usecase/services"
 	trafficbuilder "github.com/bnema/gordon/internal/usecase/traffic"
 )
 
-func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService) error {
-	if manager == nil || configSvc == nil {
+func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService, proxySvcs ...*proxy.Service) error {
+	if configSvc == nil {
 		return nil
 	}
 	standaloneServices, err := servicecfg.ToDomain(cfg.Services)
 	if err != nil {
 		return fmt.Errorf("convert standalone service config: %w", err)
 	}
-	graph, err := trafficbuilder.Build(trafficbuilder.Input{
+	plan, err := trafficbuilder.BuildPlan(trafficbuilder.Input{
 		EntryPoints:     cfg.EntryPoints,
 		Traffic:         cfg.Traffic,
 		Routes:          configSvc.GetRoutes(ctx),
 		ExternalRoutes:  configSvc.GetExternalRoutes(),
+		ServiceRoutes:   configSvc.GetServiceRoutes(),
 		NetworkServices: cfg.NetworkServices,
 		Services:        standaloneServices,
 	})
 	if err != nil {
 		return fmt.Errorf("build traffic graph: %w", err)
 	}
-	owned, err := trafficRuntimeGraph(graph)
-	if err != nil {
-		return fmt.Errorf("filter traffic graph for runtime ownership: %w", err)
+	if manager != nil {
+		owned, err := trafficRuntimeGraph(plan.Graph)
+		if err != nil {
+			return fmt.Errorf("filter traffic graph for runtime ownership: %w", err)
+		}
+		if err := manager.Apply(ctx, &owned); err != nil {
+			return fmt.Errorf("apply traffic graph: %w", err)
+		}
 	}
-	if err := manager.Apply(ctx, &owned); err != nil {
-		return fmt.Errorf("apply traffic graph: %w", err)
+	if len(proxySvcs) > 0 && proxySvcs[0] != nil {
+		if err := proxySvcs[0].ReconcileServiceTargets(plan.ServiceTargets); err != nil {
+			return fmt.Errorf("reconcile HTTP service targets: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/app/traffic.go
+++ b/internal/app/traffic.go
@@ -12,7 +12,7 @@ import (
 	trafficbuilder "github.com/bnema/gordon/internal/usecase/traffic"
 )
 
-func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService, proxySvcs ...*proxy.Service) error {
+func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService, proxySvc *proxy.Service) error {
 	if configSvc == nil {
 		return nil
 	}
@@ -41,9 +41,9 @@ func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Mana
 			return fmt.Errorf("apply traffic graph: %w", err)
 		}
 	}
-	if len(proxySvcs) > 0 && proxySvcs[0] != nil {
-		if err := proxySvcs[0].ReconcileServiceTargets(plan.ServiceTargets); err != nil {
-			return fmt.Errorf("reconcile HTTP service targets: %w", err)
+	if proxySvc != nil {
+		if err := proxySvc.StageServiceTargets(plan.ServiceTargets); err != nil {
+			return fmt.Errorf("stage HTTP service targets: %w", err)
 		}
 	}
 	return nil

--- a/internal/app/traffic_test.go
+++ b/internal/app/traffic_test.go
@@ -110,7 +110,7 @@ func TestApplyTrafficRuntimeConfigAppliesSmartTCPEntrypointWithRawFallbackPolicy
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, traffic.DefaultEdgeEntryPointName, status.EntryPoints[0].Name)
@@ -138,7 +138,7 @@ func TestApplyTrafficRuntimeConfigPassesStandaloneServicesToBuilder(t *testing.T
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, "rust", status.EntryPoints[0].Name)
@@ -163,7 +163,7 @@ func TestApplyTrafficRuntimeConfigAppliesCustomL4Entrypoint(t *testing.T) {
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, "postgres", status.EntryPoints[0].Name)

--- a/internal/boundaries/in/config.go
+++ b/internal/boundaries/in/config.go
@@ -65,6 +65,9 @@ type ConfigService interface {
 	// GetExternalRoutes returns all configured external routes.
 	GetExternalRoutes() map[string]string
 
+	// GetServiceRoutes returns HTTP routes targeting named standalone-service ports.
+	GetServiceRoutes() []domain.HTTPServiceRoute
+
 	// GetAllAttachments returns all configured attachments.
 	GetAllAttachments(ctx context.Context) map[string][]string
 

--- a/internal/boundaries/in/mocks/mock_config_service.go
+++ b/internal/boundaries/in/mocks/mock_config_service.go
@@ -652,6 +652,50 @@ func (_c *MockConfigService_GetExternalRoutes_Call) RunAndReturn(run func() map[
 	return _c
 }
 
+// GetServiceRoutes provides a mock function for the type MockConfigService.
+func (_mock *MockConfigService) GetServiceRoutes() []domain.HTTPServiceRoute {
+	for _, expected := range _mock.ExpectedCalls {
+		if expected.Method == "GetServiceRoutes" {
+			ret := _mock.Called()
+			var r0 []domain.HTTPServiceRoute
+			if returnFunc, ok := ret.Get(0).(func() []domain.HTTPServiceRoute); ok {
+				r0 = returnFunc()
+			} else if ret.Get(0) != nil {
+				r0 = ret.Get(0).([]domain.HTTPServiceRoute)
+			}
+			return r0
+		}
+	}
+	return nil
+}
+
+// MockConfigService_GetServiceRoutes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetServiceRoutes'.
+type MockConfigService_GetServiceRoutes_Call struct {
+	*mock.Call
+}
+
+// GetServiceRoutes is a helper method to define mock.On call.
+func (_e *MockConfigService_Expecter) GetServiceRoutes() *MockConfigService_GetServiceRoutes_Call {
+	return &MockConfigService_GetServiceRoutes_Call{Call: _e.mock.On("GetServiceRoutes")}
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) Run(run func()) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) Return(routes []domain.HTTPServiceRoute) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Return(routes)
+	return _c
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) RunAndReturn(run func() []domain.HTTPServiceRoute) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNetworkPrefix provides a mock function for the type MockConfigService
 func (_mock *MockConfigService) GetNetworkPrefix() string {
 	ret := _mock.Called()

--- a/internal/domain/route.go
+++ b/internal/domain/route.go
@@ -11,9 +11,9 @@ type Route struct {
 // HTTPServiceRoute maps a hostname to a named, published standalone service port.
 // It does not own a route container.
 type HTTPServiceRoute struct {
-	Domain  string
-	Service string
-	Port    string
+	Domain   string
+	Service  string
+	PortName string
 }
 
 // ProxyTarget represents the destination for proxying requests.

--- a/internal/domain/route.go
+++ b/internal/domain/route.go
@@ -8,15 +8,24 @@ type Route struct {
 	Env    []string // Pre-resolved env vars ("KEY=VALUE"); when set, Deploy skips EnvLoader lookup.
 }
 
+// HTTPServiceRoute maps a hostname to a named, published standalone service port.
+// It does not own a route container.
+type HTTPServiceRoute struct {
+	Domain  string
+	Service string
+	Port    string
+}
+
 // ProxyTarget represents the destination for proxying requests.
 type ProxyTarget struct {
 	Host         string
 	Port         int
 	ContainerID  string
-	Scheme       string // "http" or "https"
-	Protocol     string // "" (default HTTP/1.1) or "h2c" (cleartext HTTP/2)
-	OriginalHost string // Original hostname before DNS resolution (for external-route Host header)
-	RouteHost    string // Canonical matched route domain for managed-route Host header
+	Scheme       string   // "http" or "https"
+	Protocol     string   // "" (default HTTP/1.1) or "h2c" (cleartext HTTP/2)
+	OriginalHost string   // Original hostname before DNS resolution (for external-route Host header)
+	RouteHost    string   // Canonical matched route domain for managed-route Host header
+	TrustedCIDRs []string // Direct peers allowed to access a private standalone-service port
 }
 
 // RouteMatch represents the result of matching a request to a route.

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -61,8 +61,8 @@ type routeConfig struct {
 }
 
 type serviceRouteConfig struct {
-	Service string
-	Port    string
+	Service  string
+	PortName string
 }
 
 // Service implements the ConfigService interface.
@@ -287,9 +287,9 @@ func loadServiceRoutes(raw any) (map[string]serviceRouteConfig, error) {
 		if !ok || strings.TrimSpace(service) == "" {
 			return nil, fmt.Errorf("service route %q must include a non-empty service", key)
 		}
-		port, ok := route["port"].(string)
-		if !ok || strings.TrimSpace(port) == "" {
-			return nil, fmt.Errorf("service route %q must include a non-empty port", key)
+		portName, ok := route["port_name"].(string)
+		if !ok || strings.TrimSpace(portName) == "" {
+			return nil, fmt.Errorf("service route %q must include a non-empty port_name", key)
 		}
 		canonicalKey, ok := domain.CanonicalRouteDomain(key)
 		if !ok {
@@ -298,7 +298,7 @@ func loadServiceRoutes(raw any) (map[string]serviceRouteConfig, error) {
 		if _, exists := result[canonicalKey]; exists {
 			return nil, fmt.Errorf("duplicate service route key %q canonicalizes to %q", key, canonicalKey)
 		}
-		result[canonicalKey] = serviceRouteConfig{Service: service, Port: port}
+		result[canonicalKey] = serviceRouteConfig{Service: service, PortName: portName}
 	}
 	return result, nil
 }
@@ -1622,7 +1622,7 @@ func (s *Service) GetServiceRoutes() []domain.HTTPServiceRoute {
 
 	routes := make([]domain.HTTPServiceRoute, 0, len(s.config.ServiceRoutes))
 	for domainName, route := range s.config.ServiceRoutes {
-		routes = append(routes, domain.HTTPServiceRoute{Domain: domainName, Service: route.Service, Port: route.Port})
+		routes = append(routes, domain.HTTPServiceRoute{Domain: domainName, Service: route.Service, PortName: route.PortName})
 	}
 	slices.SortFunc(routes, func(a, b domain.HTTPServiceRoute) int {
 		return cmp.Compare(a.Domain, b.Domain)

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -44,6 +44,7 @@ type Config struct {
 	NetworkPrefix           string
 	Routes                  map[string]routeConfig
 	ExternalRoutes          map[string]string // domain -> "host:port"
+	ServiceRoutes           map[string]serviceRouteConfig
 	RegistryAuthEnabled     bool
 	RegistryAuthUsername    string
 	RegistryAuthPassword    string
@@ -57,6 +58,11 @@ type Config struct {
 type routeConfig struct {
 	Image string `toml:"image"`
 	HTTPS bool   `toml:"https"`
+}
+
+type serviceRouteConfig struct {
+	Service string
+	Port    string
 }
 
 // Service implements the ConfigService interface.
@@ -100,12 +106,25 @@ func (s *Service) Load(ctx context.Context) error {
 	if err != nil {
 		return log.WrapErr(err, "failed to load external routes")
 	}
+	serviceRoutes, err := loadServiceRoutes(s.viper.Get("service_routes"))
+	if err != nil {
+		return log.WrapErr(err, "failed to load service routes")
+	}
 	for domainName := range externalRoutes {
 		if _, exists := routes[domainName]; exists {
 			return fmt.Errorf("external route %q conflicts with configured route", domainName)
 		}
+		if _, exists := serviceRoutes[domainName]; exists {
+			return fmt.Errorf("external route %q conflicts with service route", domainName)
+		}
+	}
+	for domainName := range serviceRoutes {
+		if _, exists := routes[domainName]; exists {
+			return fmt.Errorf("service route %q conflicts with configured route", domainName)
+		}
 	}
 	newConfig.ExternalRoutes = externalRoutes
+	newConfig.ServiceRoutes = serviceRoutes
 	newConfig.NetworkGroups = loadStringArrayMap(s.viper.Get("network_groups"))
 	newConfig.Attachments = loadStringArrayMap(s.viper.Get("attachments"))
 
@@ -198,6 +217,7 @@ func (s *Service) loadConfigValues() Config {
 		VolumePreserve:          s.viper.GetBool("volumes.preserve"),
 		Routes:                  make(map[string]routeConfig),
 		ExternalRoutes:          make(map[string]string),
+		ServiceRoutes:           make(map[string]serviceRouteConfig),
 		NetworkGroups:           make(map[string][]string),
 		Attachments:             make(map[string][]string),
 	}
@@ -244,6 +264,41 @@ func loadExternalRoutes(raw any) (map[string]string, error) {
 			return nil, fmt.Errorf("duplicate external route key %q canonicalizes to %q", k, canonicalKey)
 		}
 		result[canonicalKey] = vs
+	}
+	return result, nil
+}
+
+// loadServiceRoutes loads HTTP routes that target named standalone-service ports.
+func loadServiceRoutes(raw any) (map[string]serviceRouteConfig, error) {
+	result := make(map[string]serviceRouteConfig)
+	if raw == nil {
+		return result, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("service_routes section must be a table, got %T", raw)
+	}
+	for key, value := range m {
+		route, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("service route %q must be an inline table", key)
+		}
+		service, ok := route["service"].(string)
+		if !ok || strings.TrimSpace(service) == "" {
+			return nil, fmt.Errorf("service route %q must include a non-empty service", key)
+		}
+		port, ok := route["port"].(string)
+		if !ok || strings.TrimSpace(port) == "" {
+			return nil, fmt.Errorf("service route %q must include a non-empty port", key)
+		}
+		canonicalKey, ok := domain.CanonicalRouteDomain(key)
+		if !ok {
+			return nil, fmt.Errorf("invalid service route key %q: %w", key, domain.ErrRouteDomainInvalid)
+		}
+		if _, exists := result[canonicalKey]; exists {
+			return nil, fmt.Errorf("duplicate service route key %q canonicalizes to %q", key, canonicalKey)
+		}
+		result[canonicalKey] = serviceRouteConfig{Service: service, Port: port}
 	}
 	return result, nil
 }
@@ -1558,6 +1613,21 @@ func (s *Service) GetExternalRoutes() map[string]string {
 		result[k] = v
 	}
 	return result
+}
+
+// GetServiceRoutes returns all configured HTTP-to-standalone-service routes.
+func (s *Service) GetServiceRoutes() []domain.HTTPServiceRoute {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	routes := make([]domain.HTTPServiceRoute, 0, len(s.config.ServiceRoutes))
+	for domainName, route := range s.config.ServiceRoutes {
+		routes = append(routes, domain.HTTPServiceRoute{Domain: domainName, Service: route.Service, Port: route.Port})
+	}
+	slices.SortFunc(routes, func(a, b domain.HTTPServiceRoute) int {
+		return cmp.Compare(a.Domain, b.Domain)
+	})
+	return routes
 }
 
 // ExtractDomainFromImageName extracts domain from image names like "myapp.bamen.dev:latest".

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -2881,6 +2881,40 @@ func TestLoadStringMap(t *testing.T) {
 	}
 }
 
+func TestService_LoadsServiceRoutesSeparatelyFromContainerRoutes(t *testing.T) {
+	v := viper.New()
+	v.Set("routes", map[string]any{"app.example.com": "app:latest"})
+	v.Set("service_routes", map[string]any{"play.example.com": map[string]any{"service": "rust", "port": "web"}})
+
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	require.NoError(t, svc.Load(testContext()))
+	require.Equal(t, []domain.Route{{Domain: "app.example.com", Image: "app:latest", HTTPS: true}}, svc.GetRoutes(testContext()))
+	require.Equal(t, []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}}, svc.GetServiceRoutes())
+}
+
+func TestService_LoadRejectsServiceRouteConflictsAndInvalidReferences(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		routes        map[string]any
+		external      map[string]any
+		serviceRoutes map[string]any
+		want          string
+	}{
+		{name: "conflicts with route", routes: map[string]any{"app.example.com": "app:latest"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port": "web"}}, want: "conflicts"},
+		{name: "conflicts with external", external: map[string]any{"app.example.com": "203.0.113.10:8080"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port": "web"}}, want: "conflicts"},
+		{name: "missing port", serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust"}}, want: "non-empty port"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			v := viper.New()
+			v.Set("routes", tt.routes)
+			v.Set("external_routes", tt.external)
+			v.Set("service_routes", tt.serviceRoutes)
+			svc := NewService(v, mocks.NewMockEventPublisher(t))
+			require.ErrorContains(t, svc.Load(testContext()), tt.want)
+		})
+	}
+}
+
 func TestLoadStringArrayMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -2884,12 +2884,12 @@ func TestLoadStringMap(t *testing.T) {
 func TestService_LoadsServiceRoutesSeparatelyFromContainerRoutes(t *testing.T) {
 	v := viper.New()
 	v.Set("routes", map[string]any{"app.example.com": "app:latest"})
-	v.Set("service_routes", map[string]any{"play.example.com": map[string]any{"service": "rust", "port": "web"}})
+	v.Set("service_routes", map[string]any{"play.example.com": map[string]any{"service": "rust", "port_name": "web"}})
 
 	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	require.NoError(t, svc.Load(testContext()))
 	require.Equal(t, []domain.Route{{Domain: "app.example.com", Image: "app:latest", HTTPS: true}}, svc.GetRoutes(testContext()))
-	require.Equal(t, []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}}, svc.GetServiceRoutes())
+	require.Equal(t, []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", PortName: "web"}}, svc.GetServiceRoutes())
 }
 
 func TestService_LoadRejectsServiceRouteConflictsAndInvalidReferences(t *testing.T) {
@@ -2900,9 +2900,9 @@ func TestService_LoadRejectsServiceRouteConflictsAndInvalidReferences(t *testing
 		serviceRoutes map[string]any
 		want          string
 	}{
-		{name: "conflicts with route", routes: map[string]any{"app.example.com": "app:latest"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port": "web"}}, want: "conflicts"},
-		{name: "conflicts with external", external: map[string]any{"app.example.com": "203.0.113.10:8080"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port": "web"}}, want: "conflicts"},
-		{name: "missing port", serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust"}}, want: "non-empty port"},
+		{name: "conflicts with route", routes: map[string]any{"app.example.com": "app:latest"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port_name": "web"}}, want: "conflicts"},
+		{name: "conflicts with external", external: map[string]any{"app.example.com": "203.0.113.10:8080"}, serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust", "port_name": "web"}}, want: "conflicts"},
+		{name: "missing port name", serviceRoutes: map[string]any{"app.example.com": map[string]any{"service": "rust"}}, want: "non-empty port_name"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			v := viper.New()

--- a/internal/usecase/pki/service.go
+++ b/internal/usecase/pki/service.go
@@ -203,7 +203,22 @@ func (s *Service) isDomainAllowed(ctx context.Context, domainName string) bool {
 	if _, ok := s.routes.GetExternalRoutes()[domainName]; ok {
 		return true
 	}
+	for _, route := range configuredServiceRoutes(s.routes) {
+		if route.Domain == domainName {
+			return true
+		}
+	}
 	return false
+}
+
+func configuredServiceRoutes(source out.RouteChecker) []domain.HTTPServiceRoute {
+	provider, ok := source.(interface {
+		GetServiceRoutes() []domain.HTTPServiceRoute
+	})
+	if !ok {
+		return nil
+	}
+	return provider.GetServiceRoutes()
 }
 
 func canonicalDomainSet(domains []string) map[string]struct{} {
@@ -256,9 +271,10 @@ func (s *Service) sweepExpiredCerts(ctx context.Context) {
 	// Fetch routes once for all cache entries.
 	routes := s.routes.GetRoutes(ctx)
 	extRoutes := s.routes.GetExternalRoutes()
+	serviceRoutes := configuredServiceRoutes(s.routes)
 
 	s.allowedMu.RLock()
-	allowed := make(map[string]struct{}, len(routes)+len(extRoutes)+len(s.allowedDomains))
+	allowed := make(map[string]struct{}, len(routes)+len(extRoutes)+len(serviceRoutes)+len(s.allowedDomains))
 	for domain := range s.allowedDomains {
 		allowed[domain] = struct{}{}
 	}
@@ -268,6 +284,9 @@ func (s *Service) sweepExpiredCerts(ctx context.Context) {
 	}
 	for d := range extRoutes {
 		allowed[d] = struct{}{}
+	}
+	for _, route := range serviceRoutes {
+		allowed[route.Domain] = struct{}{}
 	}
 
 	swept := 0

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -41,6 +41,7 @@ type Service struct {
 	configSvc        in.ConfigService
 	config           Config
 	targets          map[string]*domain.ProxyTarget
+	serviceTargets   map[string]*domain.ProxyTarget
 	mu               sync.RWMutex
 	inFlight         map[string]int
 	inFlightMu       sync.Mutex
@@ -55,12 +56,13 @@ func NewService(
 	config Config,
 ) *Service {
 	return &Service{
-		runtime:      runtime,
-		containerSvc: containerSvc,
-		configSvc:    configSvc,
-		config:       config,
-		targets:      make(map[string]*domain.ProxyTarget),
-		inFlight:     make(map[string]int),
+		runtime:        runtime,
+		containerSvc:   containerSvc,
+		configSvc:      configSvc,
+		config:         config,
+		targets:        make(map[string]*domain.ProxyTarget),
+		serviceTargets: make(map[string]*domain.ProxyTarget),
+		inFlight:       make(map[string]int),
 	}
 }
 
@@ -89,8 +91,13 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	// Check cache first
+	// Service targets are validated at configuration load/reload time and must
+	// take precedence over dynamic deployment targets and external routes.
 	s.mu.RLock()
+	if target, exists := s.serviceTargets[domainName]; exists {
+		s.mu.RUnlock()
+		return cloneProxyTarget(target), nil
+	}
 	if target, exists := s.targets[domainName]; exists {
 		s.mu.RUnlock()
 		log.Debug().
@@ -235,6 +242,32 @@ func (s *Service) resolveExternalRoute(_ context.Context, domainName, targetAddr
 	return t, nil
 }
 
+// ReconcileServiceTargets atomically replaces the validated standalone-service targets.
+func (s *Service) ReconcileServiceTargets(targets map[string]*domain.ProxyTarget) error {
+	next := make(map[string]*domain.ProxyTarget, len(targets))
+	for domainName, target := range targets {
+		canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+		if !ok || target == nil || target.Host == "" || target.Port < 1 || target.Port > 65535 {
+			return fmt.Errorf("invalid service target for %q", domainName)
+		}
+		next[canonicalDomain] = cloneProxyTarget(target)
+	}
+
+	s.mu.Lock()
+	s.serviceTargets = next
+	s.mu.Unlock()
+	return nil
+}
+
+func cloneProxyTarget(target *domain.ProxyTarget) *domain.ProxyTarget {
+	if target == nil {
+		return nil
+	}
+	copy := *target
+	copy.TrustedCIDRs = append([]string(nil), target.TrustedCIDRs...)
+	return &copy
+}
+
 // RegisterTarget registers a new proxy target for a domain.
 func (s *Service) RegisterTarget(_ context.Context, domainName string, target *domain.ProxyTarget) error {
 	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
@@ -351,6 +384,12 @@ func (s *Service) IsKnownHost(ctx context.Context, host string) bool {
 		return true
 	}
 	if _, err := s.configSvc.GetRoute(ctx, canonicalHost); err == nil {
+		return true
+	}
+	s.mu.RLock()
+	_, serviceRoute := s.serviceTargets[canonicalHost]
+	s.mu.RUnlock()
+	if serviceRoute {
 		return true
 	}
 	_, ok = s.configSvc.GetExternalRoutes()[canonicalHost]

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -36,16 +36,17 @@ type Config struct {
 
 // Service implements the ProxyService interface.
 type Service struct {
-	runtime          out.ContainerRuntime
-	containerSvc     in.ContainerService
-	configSvc        in.ConfigService
-	config           Config
-	targets          map[string]*domain.ProxyTarget
-	serviceTargets   map[string]*domain.ProxyTarget
-	mu               sync.RWMutex
-	inFlight         map[string]int
-	inFlightMu       sync.Mutex
-	registryInFlight atomic.Int64 // active registry proxy requests, for graceful drain
+	runtime               out.ContainerRuntime
+	containerSvc          in.ContainerService
+	configSvc             in.ConfigService
+	config                Config
+	targets               map[string]*domain.ProxyTarget
+	serviceTargets        map[string]*domain.ProxyTarget
+	pendingServiceTargets map[string]*domain.ProxyTarget
+	mu                    sync.RWMutex
+	inFlight              map[string]int
+	inFlightMu            sync.Mutex
+	registryInFlight      atomic.Int64 // active registry proxy requests, for graceful drain
 }
 
 // NewService creates a new proxy service.
@@ -56,13 +57,14 @@ func NewService(
 	config Config,
 ) *Service {
 	return &Service{
-		runtime:        runtime,
-		containerSvc:   containerSvc,
-		configSvc:      configSvc,
-		config:         config,
-		targets:        make(map[string]*domain.ProxyTarget),
-		serviceTargets: make(map[string]*domain.ProxyTarget),
-		inFlight:       make(map[string]int),
+		runtime:               runtime,
+		containerSvc:          containerSvc,
+		configSvc:             configSvc,
+		config:                config,
+		targets:               make(map[string]*domain.ProxyTarget),
+		serviceTargets:        make(map[string]*domain.ProxyTarget),
+		pendingServiceTargets: make(map[string]*domain.ProxyTarget),
+		inFlight:              make(map[string]int),
 	}
 }
 
@@ -242,20 +244,39 @@ func (s *Service) resolveExternalRoute(_ context.Context, domainName, targetAddr
 	return t, nil
 }
 
-// ReconcileServiceTargets atomically replaces the validated standalone-service targets.
-func (s *Service) ReconcileServiceTargets(targets map[string]*domain.ProxyTarget) error {
+// StageServiceTargets validates and stages standalone-service targets without publishing them.
+func (s *Service) StageServiceTargets(targets map[string]*domain.ProxyTarget) error {
 	next := make(map[string]*domain.ProxyTarget, len(targets))
 	for domainName, target := range targets {
 		canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
 		if !ok || target == nil || target.Host == "" || target.Port < 1 || target.Port > 65535 {
 			return fmt.Errorf("invalid service target for %q", domainName)
 		}
-		next[canonicalDomain] = cloneProxyTarget(target)
+		prepared := cloneProxyTarget(target)
+		prepared.RouteHost = canonicalDomain
+		next[canonicalDomain] = prepared
 	}
 
 	s.mu.Lock()
-	s.serviceTargets = next
+	s.pendingServiceTargets = next
 	s.mu.Unlock()
+	return nil
+}
+
+// CommitStagedServiceTargets atomically publishes the last staged service targets.
+func (s *Service) CommitStagedServiceTargets() {
+	s.mu.Lock()
+	s.serviceTargets = s.pendingServiceTargets
+	s.pendingServiceTargets = make(map[string]*domain.ProxyTarget)
+	s.mu.Unlock()
+}
+
+// ReconcileServiceTargets validates and immediately publishes standalone-service targets.
+func (s *Service) ReconcileServiceTargets(targets map[string]*domain.ProxyTarget) error {
+	if err := s.StageServiceTargets(targets); err != nil {
+		return err
+	}
+	s.CommitStagedServiceTargets()
 	return nil
 }
 

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -62,6 +62,19 @@ func TestService_GetTarget_ServiceRouteUsesStaticTrustedTarget(t *testing.T) {
 	assert.Equal(t, []string{"100.64.0.0/10"}, target.TrustedCIDRs)
 }
 
+func TestService_StageServiceTargetsPublishesOnlyAfterCommit(t *testing.T) {
+	svc := NewService(outmocks.NewMockContainerRuntime(t), inmocks.NewMockContainerService(t), inmocks.NewMockConfigService(t), Config{})
+	require.NoError(t, svc.StageServiceTargets(map[string]*domain.ProxyTarget{
+		"App.Example.com": {Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "untrusted.example.com"},
+	}))
+	assert.Empty(t, svc.serviceTargets)
+
+	svc.CommitStagedServiceTargets()
+	target := svc.serviceTargets["app.example.com"]
+	require.NotNil(t, target)
+	assert.Equal(t, "app.example.com", target.RouteHost)
+}
+
 func TestService_ReconcileServiceTargetsRemovesDeletedRoute(t *testing.T) {
 	containerSvc := inmocks.NewMockContainerService(t)
 	configSvc := inmocks.NewMockConfigService(t)

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
@@ -45,6 +46,34 @@ func TestService_GetTarget_FromCache(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedTarget, result)
+}
+
+func TestService_GetTarget_ServiceRouteUsesStaticTrustedTarget(t *testing.T) {
+	svc := NewService(outmocks.NewMockContainerRuntime(t), inmocks.NewMockContainerService(t), inmocks.NewMockConfigService(t), Config{})
+	require.NoError(t, svc.ReconcileServiceTargets(map[string]*domain.ProxyTarget{
+		"play.example.com": {Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "play.example.com", TrustedCIDRs: []string{"100.64.0.0/10"}},
+	}))
+
+	target, err := svc.GetTarget(testContext(), "Play.Example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", target.Host)
+	assert.Equal(t, 18080, target.Port)
+	assert.Empty(t, target.ContainerID)
+	assert.Equal(t, []string{"100.64.0.0/10"}, target.TrustedCIDRs)
+}
+
+func TestService_ReconcileServiceTargetsRemovesDeletedRoute(t *testing.T) {
+	containerSvc := inmocks.NewMockContainerService(t)
+	configSvc := inmocks.NewMockConfigService(t)
+	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
+	containerSvc.EXPECT().Get(mock.Anything, "play.example.com").Return(nil, false)
+	svc := NewService(outmocks.NewMockContainerRuntime(t), containerSvc, configSvc, Config{})
+	require.NoError(t, svc.ReconcileServiceTargets(map[string]*domain.ProxyTarget{
+		"play.example.com": {Host: "127.0.0.1", Port: 18080, Scheme: "http"},
+	}))
+	require.NoError(t, svc.ReconcileServiceTargets(nil))
+	_, err := svc.GetTarget(testContext(), "play.example.com")
+	assert.ErrorIs(t, err, domain.ErrNoTargetAvailable)
 }
 
 func TestService_GetTarget_CanonicalizesHostForLookup(t *testing.T) {

--- a/internal/usecase/publictls/service.go
+++ b/internal/usecase/publictls/service.go
@@ -106,7 +106,7 @@ func (s *Service) Load(ctx context.Context) error {
 	if s.deps.Routes != nil {
 		routes := s.deps.Routes.GetRoutes(ctx)
 		external := s.deps.Routes.GetExternalRoutes()
-		required = canonicalHostSet(routeHosts(routes, external, s.additionalHosts))
+		required = canonicalHostSet(routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts))
 	}
 
 	s.mu.Lock()
@@ -145,7 +145,7 @@ func (s *Service) SetAdditionalHosts(ctx context.Context, hosts []string) {
 	if s.deps.Routes != nil {
 		routes := s.deps.Routes.GetRoutes(ctx)
 		external := s.deps.Routes.GetExternalRoutes()
-		required = canonicalHostSet(routeHosts(routes, external, s.additionalHosts))
+		required = canonicalHostSet(routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts))
 	}
 
 	s.mu.Lock()
@@ -201,6 +201,9 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	// DeriveCertificateTargets fails (e.g. broken DNS-01 zone resolver).
 	routes := s.deps.Routes.GetRoutes(ctx)
 	external := s.deps.Routes.GetExternalRoutes()
+	for _, route := range serviceRoutes(s.deps.Routes) {
+		routes = append(routes, domain.Route{Domain: route.Domain})
+	}
 	hosts := routeHosts(routes, external, s.additionalHosts)
 
 	// Build required hosts set from route hosts (before target derivation).

--- a/internal/usecase/publictls/status.go
+++ b/internal/usecase/publictls/status.go
@@ -129,6 +129,15 @@ func collectRouteDomains(ctx context.Context, routes RouteSource) []string {
 			}
 		}
 	}
+	for _, route := range serviceRoutes(routes) {
+		canonical, ok := domain.CanonicalRouteDomain(route.Domain)
+		if ok {
+			if _, exists := routeSet[canonical]; !exists {
+				routeSet[canonical] = struct{}{}
+				domains = append(domains, canonical)
+			}
+		}
+	}
 	return domains
 }
 

--- a/internal/usecase/publictls/targets.go
+++ b/internal/usecase/publictls/targets.go
@@ -42,6 +42,10 @@ func DeriveCertificateTargets(
 // routeHosts collects all unique canonical hosts from routes and external keys,
 // sorted alphabetically. Trailing dots are stripped before canonicalization.
 func routeHosts(routes []domain.Route, external map[string]string, additionalHosts []string) []string {
+	return routeHostsWithServiceRoutes(routes, external, nil, additionalHosts)
+}
+
+func routeHostsWithServiceRoutes(routes []domain.Route, external map[string]string, serviceRoutes []domain.HTTPServiceRoute, additionalHosts []string) []string {
 	seen := make(map[string]struct{})
 	var hosts []string
 
@@ -63,12 +67,25 @@ func routeHosts(routes []domain.Route, external map[string]string, additionalHos
 	for h := range external {
 		addHost(h)
 	}
+	for _, route := range serviceRoutes {
+		addHost(route.Domain)
+	}
 	for _, h := range additionalHosts {
 		addHost(h)
 	}
 
 	sort.Strings(hosts)
 	return hosts
+}
+
+func serviceRoutes(source RouteSource) []domain.HTTPServiceRoute {
+	provider, ok := source.(interface {
+		GetServiceRoutes() []domain.HTTPServiceRoute
+	})
+	if !ok {
+		return nil
+	}
+	return provider.GetServiceRoutes()
 }
 
 // deriveHTTP01Targets creates one target per host for HTTP-01 challenge.

--- a/internal/usecase/services/config.go
+++ b/internal/usecase/services/config.go
@@ -23,7 +23,7 @@ type Config struct {
 
 type PortConfig struct {
 	Name         string                 `mapstructure:"name"`
-	Container    int                    `mapstructure:"container"`
+	Container    int                    `mapstructure:"container_port"`
 	Protocol     domain.NetworkProtocol `mapstructure:"protocol"`
 	Publish      string                 `mapstructure:"publish"`
 	Private      bool                   `mapstructure:"private"`

--- a/internal/usecase/services/config_test.go
+++ b/internal/usecase/services/config_test.go
@@ -3,11 +3,27 @@ package services
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bnema/gordon/internal/domain"
 )
+
+func TestConfigUnmarshalUsesContainerPort(t *testing.T) {
+	v := viper.New()
+	v.Set("services", []map[string]any{{
+		"name": "app", "image": "app:latest", "enabled": true,
+		"ports": []map[string]any{{"name": "web", "container_port": 8080, "protocol": "tcp", "publish": "127.0.0.1:18080"}},
+	}})
+	var config struct {
+		Services []Config `mapstructure:"services"`
+	}
+	require.NoError(t, v.Unmarshal(&config))
+	require.Len(t, config.Services, 1)
+	require.Len(t, config.Services[0].Ports, 1)
+	assert.Equal(t, 8080, config.Services[0].Ports[0].Container)
+}
 
 func TestToDomainRejectsDuplicateServiceNames(t *testing.T) {
 	configs := []Config{

--- a/internal/usecase/traffic/builder.go
+++ b/internal/usecase/traffic/builder.go
@@ -185,7 +185,7 @@ func (b *builder) addHTTPServiceRoutes(_ *domain.TrafficGraph) error {
 	}
 	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
 	for _, route := range routes {
-		ref := domain.TrafficServiceRef{Kind: domain.TrafficServiceRefService, Name: route.Service, PortName: route.Port}
+		ref := domain.TrafficServiceRef{Kind: domain.TrafficServiceRefService, Name: route.Service, PortName: route.PortName}
 		service, port, backend, err := b.resolveStandaloneServicePort(ref, domain.NetworkProtocolTCP)
 		if err != nil {
 			return fmt.Errorf("service route %q: %w", route.Domain, err)

--- a/internal/usecase/traffic/builder.go
+++ b/internal/usecase/traffic/builder.go
@@ -20,6 +20,7 @@ type Input struct {
 	Traffic         Config
 	Routes          []domain.Route
 	ExternalRoutes  map[string]string
+	ServiceRoutes   []domain.HTTPServiceRoute
 	NetworkServices []NetworkServiceConfig
 	Services        []domain.StandaloneService
 }
@@ -78,33 +79,51 @@ type PortConfig struct {
 	Protocol  domain.NetworkProtocol `mapstructure:"protocol"`
 }
 
+// Plan is the validated routing configuration shared by the traffic manager and HTTP proxy.
+type Plan struct {
+	Graph          domain.TrafficGraph
+	ServiceTargets map[string]*domain.ProxyTarget
+}
+
 // Build builds and validates a TrafficGraph snapshot. Managed route services are
 // intentionally backend-less because their concrete container endpoints are resolved at runtime.
 func Build(input Input) (domain.TrafficGraph, error) {
-	b := builder{input: input, services: map[string]domain.TrafficService{}}
+	plan, err := BuildPlan(input)
+	if err != nil {
+		return domain.TrafficGraph{}, err
+	}
+	return plan.Graph, nil
+}
+
+// BuildPlan validates routing and resolves HTTP service routes to static, trusted targets.
+func BuildPlan(input Input) (Plan, error) {
+	b := builder{input: input, services: map[string]domain.TrafficService{}, serviceTargets: map[string]*domain.ProxyTarget{}}
 	graph := domain.TrafficGraph{}
 
 	options, err := buildOptions(input.Traffic)
 	if err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("build traffic options: %w", err)
+		return Plan{}, fmt.Errorf("build traffic options: %w", err)
 	}
 	if err := validateNetworkServices(input.NetworkServices); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate network services: %w", err)
+		return Plan{}, fmt.Errorf("validate network services: %w", err)
 	}
 	if err := validateStandaloneServices(input.Services); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate standalone services: %w", err)
+		return Plan{}, fmt.Errorf("validate standalone services: %w", err)
 	}
 	graph.Options = options
 	graph.EntryPoints = b.buildEntryPoints()
 
 	if err := b.addHTTPRoutes(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add HTTP routes: %w", err)
+		return Plan{}, fmt.Errorf("add HTTP routes: %w", err)
 	}
 	if err := b.addExternalRoutes(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add external routes: %w", err)
+		return Plan{}, fmt.Errorf("add external routes: %w", err)
+	}
+	if err := b.addHTTPServiceRoutes(&graph); err != nil {
+		return Plan{}, fmt.Errorf("add HTTP service routes: %w", err)
 	}
 	if err := b.addExplicitRouters(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add explicit traffic routers: %w", err)
+		return Plan{}, fmt.Errorf("add explicit traffic routers: %w", err)
 	}
 
 	graph.Services = make([]domain.TrafficService, 0, len(b.services))
@@ -113,14 +132,15 @@ func Build(input Input) (domain.TrafficGraph, error) {
 	}
 	sort.Slice(graph.Services, func(i, j int) bool { return graph.Services[i].Name < graph.Services[j].Name })
 	if err := graph.Validate(); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate traffic graph: %w", err)
+		return Plan{}, fmt.Errorf("validate traffic graph: %w", err)
 	}
-	return graph, nil
+	return Plan{Graph: graph, ServiceTargets: b.serviceTargets}, nil
 }
 
 type builder struct {
-	input    Input
-	services map[string]domain.TrafficService
+	input          Input
+	services       map[string]domain.TrafficService
+	serviceTargets map[string]*domain.ProxyTarget
 }
 
 func (b *builder) buildEntryPoints() []domain.EntryPoint {
@@ -154,6 +174,30 @@ func (b *builder) addHTTPRoutes(graph *domain.TrafficGraph) error {
 		serviceName := string(domain.TrafficServiceRefRoute) + ":" + route.Domain
 		b.addService(domain.TrafficService{Name: serviceName})
 		graph.Routers = append(graph.Routers, domain.TrafficRouter{Name: "route:" + route.Domain, EntryPoint: entryPoint, Protocol: domain.RouterProtocolHTTP, Rule: domain.TrafficRule{Host: route.Domain}, Service: serviceName})
+	}
+	return nil
+}
+
+func (b *builder) addHTTPServiceRoutes(_ *domain.TrafficGraph) error {
+	routes := append([]domain.HTTPServiceRoute(nil), b.input.ServiceRoutes...)
+	if len(routes) == 0 {
+		return nil
+	}
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
+	for _, route := range routes {
+		ref := domain.TrafficServiceRef{Kind: domain.TrafficServiceRefService, Name: route.Service, PortName: route.Port}
+		service, port, backend, err := b.resolveStandaloneServicePort(ref, domain.NetworkProtocolTCP)
+		if err != nil {
+			return fmt.Errorf("service route %q: %w", route.Domain, err)
+		}
+		if isPrivateStandalonePort(port) && len(port.TrustedCIDRs) == 0 {
+			return fmt.Errorf("private service %q port %q service route %q requires non-empty service port trusted_cidrs", service.Name, port.Name, route.Domain)
+		}
+		target := &domain.ProxyTarget{Host: backend.Host, Port: backend.Port, Scheme: "http", RouteHost: route.Domain}
+		if isPrivateStandalonePort(port) {
+			target.TrustedCIDRs = append([]string(nil), port.TrustedCIDRs...)
+		}
+		b.serviceTargets[route.Domain] = target
 	}
 	return nil
 }
@@ -270,27 +314,47 @@ func (b *builder) resolveNetworkService(refValue string, ref domain.TrafficServi
 }
 
 func (b *builder) resolveStandaloneService(router RouterConfig, ref domain.TrafficServiceRef, protocol domain.NetworkProtocol) (domain.TrafficService, error) {
-	svc, ok := b.standaloneService(ref.Name)
-	if !ok || !svc.Enabled {
-		return domain.TrafficService{}, fmt.Errorf("unknown service %q", ref.Name)
-	}
-	port, ok := standaloneServicePort(svc, ref.PortName)
-	if !ok {
-		return domain.TrafficService{}, fmt.Errorf("unknown port %q on service %q", ref.PortName, ref.Name)
-	}
-	if port.Protocol != protocol {
-		return domain.TrafficService{}, fmt.Errorf("service %q port %q protocol %s does not match router protocol %s", ref.Name, ref.PortName, port.Protocol, protocol)
+	svc, port, backend, err := b.resolveStandaloneServicePort(ref, protocol)
+	if err != nil {
+		return domain.TrafficService{}, err
 	}
 	if isPrivateStandalonePort(port) {
 		if err := b.validatePrivateStandalonePortRoute(router, svc, port); err != nil {
 			return domain.TrafficService{}, err
 		}
 	}
+	return domain.TrafficService{Name: router.Service, Backends: []domain.TrafficBackend{backend}}, nil
+}
+
+func (b *builder) resolveStandaloneServicePort(ref domain.TrafficServiceRef, protocol domain.NetworkProtocol) (domain.StandaloneService, domain.StandaloneServicePort, domain.TrafficBackend, error) {
+	svc, ok := b.standaloneService(ref.Name)
+	if !ok || !svc.Enabled {
+		return domain.StandaloneService{}, domain.StandaloneServicePort{}, domain.TrafficBackend{}, fmt.Errorf("unknown service %q", ref.Name)
+	}
+	port, ok := standaloneServicePort(svc, ref.PortName)
+	if !ok {
+		return domain.StandaloneService{}, domain.StandaloneServicePort{}, domain.TrafficBackend{}, fmt.Errorf("unknown port %q on service %q", ref.PortName, ref.Name)
+	}
+	if port.Protocol != protocol {
+		return domain.StandaloneService{}, domain.StandaloneServicePort{}, domain.TrafficBackend{}, fmt.Errorf("service %q port %q protocol %s does not match router protocol %s", ref.Name, ref.PortName, port.Protocol, protocol)
+	}
 	host, backendPort, err := parseBackendAddress(port.Publish)
 	if err != nil {
-		return domain.TrafficService{}, fmt.Errorf("service %q port %q publish address %q is invalid: %w", ref.Name, ref.PortName, port.Publish, err)
+		return domain.StandaloneService{}, domain.StandaloneServicePort{}, domain.TrafficBackend{}, fmt.Errorf("service %q port %q publish address %q is invalid: %w", ref.Name, ref.PortName, port.Publish, err)
 	}
-	return domain.TrafficService{Name: router.Service, Backends: []domain.TrafficBackend{{Name: ref.Name + ":" + ref.PortName, Host: host, Port: backendPort, Protocol: port.Protocol}}}, nil
+	host = normalizePublishedBackendHost(host)
+	return svc, port, domain.TrafficBackend{Name: ref.Name + ":" + ref.PortName, Host: host, Port: backendPort, Protocol: port.Protocol}, nil
+}
+
+func normalizePublishedBackendHost(host string) string {
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsUnspecified() {
+		return host
+	}
+	if ip.To4() != nil {
+		return "127.0.0.1"
+	}
+	return "::1"
 }
 
 func validateStandaloneServices(services []domain.StandaloneService) error {

--- a/internal/usecase/traffic/builder.go
+++ b/internal/usecase/traffic/builder.go
@@ -184,7 +184,16 @@ func (b *builder) addHTTPServiceRoutes(_ *domain.TrafficGraph) error {
 		return nil
 	}
 	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
+	seenDomains := make(map[string]struct{}, len(routes))
 	for _, route := range routes {
+		canonicalDomain, ok := domain.CanonicalRouteDomain(route.Domain)
+		if !ok {
+			return fmt.Errorf("invalid service route domain %q", route.Domain)
+		}
+		if _, exists := seenDomains[canonicalDomain]; exists {
+			return fmt.Errorf("duplicate service route domain %q", canonicalDomain)
+		}
+		seenDomains[canonicalDomain] = struct{}{}
 		ref := domain.TrafficServiceRef{Kind: domain.TrafficServiceRefService, Name: route.Service, PortName: route.PortName}
 		service, port, backend, err := b.resolveStandaloneServicePort(ref, domain.NetworkProtocolTCP)
 		if err != nil {
@@ -193,11 +202,11 @@ func (b *builder) addHTTPServiceRoutes(_ *domain.TrafficGraph) error {
 		if isPrivateStandalonePort(port) && len(port.TrustedCIDRs) == 0 {
 			return fmt.Errorf("private service %q port %q service route %q requires non-empty service port trusted_cidrs", service.Name, port.Name, route.Domain)
 		}
-		target := &domain.ProxyTarget{Host: backend.Host, Port: backend.Port, Scheme: "http", RouteHost: route.Domain}
+		target := &domain.ProxyTarget{Host: backend.Host, Port: backend.Port, Scheme: "http", RouteHost: canonicalDomain}
 		if isPrivateStandalonePort(port) {
 			target.TrustedCIDRs = append([]string(nil), port.TrustedCIDRs...)
 		}
-		b.serviceTargets[route.Domain] = target
+		b.serviceTargets[canonicalDomain] = target
 	}
 	return nil
 }

--- a/internal/usecase/traffic/builder_test.go
+++ b/internal/usecase/traffic/builder_test.go
@@ -390,7 +390,7 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 
 func TestBuildPlanResolvesHTTPServiceRouteWithoutRouteContainer(t *testing.T) {
 	plan, err := BuildPlan(Input{
-		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", PortName: "web"}},
+		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "Play.Example.com", Service: "rust", PortName: "web"}},
 		Services: []domain.StandaloneService{{
 			Name: "rust", Enabled: true, Image: "example/rust:latest",
 			Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:18080"}},

--- a/internal/usecase/traffic/builder_test.go
+++ b/internal/usecase/traffic/builder_test.go
@@ -390,7 +390,7 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 
 func TestBuildPlanResolvesHTTPServiceRouteWithoutRouteContainer(t *testing.T) {
 	plan, err := BuildPlan(Input{
-		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}},
+		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", PortName: "web"}},
 		Services: []domain.StandaloneService{{
 			Name: "rust", Enabled: true, Image: "example/rust:latest",
 			Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:18080"}},
@@ -404,7 +404,7 @@ func TestBuildPlanResolvesHTTPServiceRouteWithoutRouteContainer(t *testing.T) {
 func TestBuildPlanRejectsInvalidHTTPServiceRoutes(t *testing.T) {
 	base := func() Input {
 		return Input{
-			ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}},
+			ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", PortName: "web"}},
 			Services: []domain.StandaloneService{{
 				Name: "rust", Enabled: true, Image: "example/rust:latest",
 				Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:18080"}},

--- a/internal/usecase/traffic/builder_test.go
+++ b/internal/usecase/traffic/builder_test.go
@@ -388,6 +388,50 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 	})
 }
 
+func TestBuildPlanResolvesHTTPServiceRouteWithoutRouteContainer(t *testing.T) {
+	plan, err := BuildPlan(Input{
+		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}},
+		Services: []domain.StandaloneService{{
+			Name: "rust", Enabled: true, Image: "example/rust:latest",
+			Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:18080"}},
+		}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, plan.Graph.Routers, "service routes are HTTP proxy targets, not traffic-manager routers")
+	require.Equal(t, &domain.ProxyTarget{Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "play.example.com"}, plan.ServiceTargets["play.example.com"])
+}
+
+func TestBuildPlanRejectsInvalidHTTPServiceRoutes(t *testing.T) {
+	base := func() Input {
+		return Input{
+			ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "play.example.com", Service: "rust", Port: "web"}},
+			Services: []domain.StandaloneService{{
+				Name: "rust", Enabled: true, Image: "example/rust:latest",
+				Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:18080"}},
+			}},
+		}
+	}
+
+	t.Run("disabled service", func(t *testing.T) {
+		input := base()
+		input.Services[0].Enabled = false
+		_, err := BuildPlan(input)
+		require.ErrorContains(t, err, "unknown service")
+	})
+	t.Run("UDP port", func(t *testing.T) {
+		input := base()
+		input.Services[0].Ports[0].Protocol = domain.NetworkProtocolUDP
+		_, err := BuildPlan(input)
+		require.ErrorContains(t, err, "does not match")
+	})
+	t.Run("private port without policy", func(t *testing.T) {
+		input := base()
+		input.Services[0].Ports[0].Private = true
+		_, err := BuildPlan(input)
+		require.ErrorContains(t, err, "requires non-empty")
+	})
+}
+
 func TestBuildRejectsInvalidServiceRefs(t *testing.T) {
 	base := Input{
 		EntryPoints:     map[string]EntryPointConfig{"tcp": {Address: ":1234", Protocol: domain.EntryPointProtocolTCP}},


### PR DESCRIPTION
## Summary
- add `[service_routes]` for HTTP hostnames backed by a named TCP port on a standalone service
- model the common case directly: one image, many named ports, with `service` and `port` fields selecting the HTTP backend
- resolve and atomically reconcile trusted static proxy targets without creating route containers
- enforce private service-port CIDRs at the HTTP edge and include service-route hosts in TLS/PKI and config views

## Configuration
```toml
[[services]]
name = "app"
image = "registry.example.com:5000/app:latest"
enabled = true

[[services.ports]]
name = "web"
container = 8080
protocol = "tcp"
publish = "127.0.0.1:18080"

[service_routes]
"app.example.com" = { service = "app", port = "web" }
```

## Validation
- `go test ./...`
- `go vet ./...`

## Notes
- `golangci-lint run ./...` could not start because the installed binary was built with Go 1.26 while this repository targets Go 1.27.