### PR TITLE
feat: unify managed services and routing

### DIFF
--- a/docs/config/routes.md
+++ b/docs/config/routes.md
@@ -1,206 +1,103 @@
-# Routes Configuration
+# Routes
 
-Routes map hostnames to container images.
+A **route** sends HTTP requests for a hostname to one named port of a service.
 
-## Configuration
+Routes do not run images and do not create containers. Services own applications and their deployment lifecycle; routes only decide where HTTP requests go.
+
+## Example
+
+```toml
+[services.app]
+image = "registry.example.com/app:latest"
+ports = { web = "8080/http" }
+
+[routes]
+"app.example.com" = { service = "app", port = "web" }
+```
+
+Read this route as:
+
+> Send HTTP requests for `app.example.com` to the `web` port of the `app` service.
+
+Gordon creates one container for the `app` service. Adding another route to the same service does not create another container:
 
 ```toml
 [routes]
-"app.mydomain.com" = { image = "myapp:latest" }
-"api.mydomain.com" = { image = "myapi:v2.1.0" }
-"admin.mydomain.com" = { image = "admin-panel:v1.0.0" }
+"app.example.com" = { service = "app", port = "web" }
+"www.example.com" = { service = "app", port = "web" }
 ```
 
-## Syntax
+## Route fields
+
+| Field | Required | Description |
+|---|---:|---|
+| `service` | yes | Name of a configured service |
+| `port` | yes | Name of an `http` port on that service |
+| `https` | no | Whether the hostname should receive HTTPS certificate coverage; defaults to `true` |
+
+The hostname is the key in the `[routes]` table. It must be a valid fully qualified domain name.
+
+## HTTP-only development route
 
 ```toml
 [routes]
-"<domain>" = { image = "<image>:<tag>" }
+"dev-app.example.com" = { service = "app", port = "web", https = false }
 ```
 
-| Component | Description |
-|-----------|-------------|
-| `domain` | Public, fully qualified domain name |
-| `image` | Full container image reference, including tag |
-| `https` | Optional; add `false` for HTTP-only routes |
+Setting `https = false` disables certificate coverage for that hostname. It does not change the protocol spoken by the application port.
 
-Legacy `http://...` route keys are still read for backward compatibility and rewritten on the next save.
+## Backend protocols
 
-## Route Types
-
-### HTTPS Routes (Default)
-
-Standard routes expect HTTPS traffic (terminated by Cloudflare or similar):
+A route targets an `http` service port. TLS is a separate property of that port:
 
 ```toml
-[routes]
-"app.mydomain.com" = { image = "myapp:latest" }
+[services.app.ports.secure_web]
+port = 8443
+protocol = "http"
+tls = true
 ```
 
-Route domains must be plain hostnames. Gordon rejects `http://` and `https://` prefixes, `.local` and `.internal` suffixes, localhost names, and IP literals.
+With `tls = true`, Gordon uses HTTPS when connecting to the service. Without it, Gordon uses HTTP. This backend setting is independent of public HTTPS termination on the route.
 
-### Development Routes
+A route cannot target a `tcp` or `udp` port. Use a traffic router for those protocols.
 
-For local testing, use a hostname you can resolve yourself:
+## External applications
+
+Use `[external_routes]` when Gordon does not deploy or manage the destination application:
 
 ```toml
-[routes]
-"dev-app.example.com" = { image = "internal-app:latest", https = false }
+[external_routes]
+"legacy.example.com" = "backend.example.net:8080"
 ```
 
-## Version Strategies
+External routes have separate SSRF protections. A normal route cannot contain an arbitrary network address.
 
-### Latest Tag
+## Removed image-backed route syntax
 
-Always deploy the most recent push:
+Routes previously combined application deployment and HTTP routing:
 
 ```toml
+# Removed
 [routes]
-"app.mydomain.com" = { image = "myapp:latest" }
+"app.example.com" = { image = "app:latest" }
 ```
 
-### Pinned Version
-
-Deploy a specific version:
+Split the application and route explicitly:
 
 ```toml
+[services.app]
+image = "app:latest"
+ports = { web = "8080/http" }
+
 [routes]
-"app.mydomain.com" = { image = "myapp:v2.1.0" }
+"app.example.com" = { service = "app", port = "web" }
 ```
 
-Update the config to deploy a new version:
-
-```toml
-[routes]
-"app.mydomain.com" = { image = "myapp:v2.2.0" }  # Changed
-```
-
-### Semantic Versioning
-
-Use different routes for different versions:
-
-```toml
-[routes]
-"app.mydomain.com" = { image = "myapp:v2.1.0" }        # Production
-"staging.mydomain.com" = { image = "myapp:staging" }    # Staging
-"canary.mydomain.com" = { image = "myapp:canary" }      # Canary
-```
-
-## Multiple Routes
-
-### Same Image, Different Domains
-
-```toml
-[routes]
-"app.mydomain.com" = { image = "myapp:latest" }
-"www.mydomain.com" = { image = "myapp:latest" }
-"mydomain.com" = { image = "myapp:latest" }
-```
-
-### Multiple Services
-
-```toml
-[routes]
-"app.mydomain.com" = { image = "frontend:latest" }
-"api.mydomain.com" = { image = "backend:v2.1.0" }
-"docs.mydomain.com" = { image = "documentation:latest" }
-"status.mydomain.com" = { image = "status-page:v1.0.0" }
-```
-
-## How Routing Works
-
-1. Request arrives for `app.mydomain.com`
-2. Gordon looks up the route in configuration
-3. Finds running container for `myapp:latest`
-4. Proxies request to container's exposed port
-5. Returns response to client
-
-```
-Client ─> Gordon Proxy ─> Container
-          (port 80)       (exposed port)
-```
-
-## Deployment Flow
-
-When you push an image:
-
-```bash
-docker push registry.mydomain.com/myapp:latest
-```
-
-1. Gordon receives the image
-2. Checks routes for any that use `myapp:latest`
-3. Deploys new container for each matching route
-4. Updates proxy to route traffic to new container
-5. Stops old container
-
-## Route Changes
-
-Route changes in the config file are hot-reloaded automatically:
-
-1. Edit `[routes]` in `gordon.toml`
-2. Save the file
-3. Gordon reloads the updated routes and proxy config
-
-Legacy `http://...` route keys are still read here for backward compatibility and rewritten the next time Gordon saves the config.
-
-You can still manage routes with the API or CLI if you prefer live mutations:
-
-```bash
-gordon routes add newapp.mydomain.com newapp:latest
-gordon routes add app.mydomain.com myapp:v2.2.0
-gordon routes remove oldapp.mydomain.com
-```
-
-## Examples
-
-### Development Setup
-
-```toml
-[routes]
-"dev-app.example.com" = { image = "myapp:latest" }
-"dev-api.example.com" = { image = "myapi:latest" }
-```
-
-Add to `/etc/hosts`:
-
-```text
-127.0.0.1  dev-app.example.com dev-api.example.com registry.example.com
-```
-
-### Production Setup
-
-```toml
-[routes]
-"app.company.com" = { image = "company-app:v2.1.0" }
-"api.company.com" = { image = "company-api:v1.5.2" }
-"admin.company.com" = { image = "admin-panel:v1.0.1" }
-"docs.company.com" = { image = "company-docs:latest" }
-```
-
-### Multi-Tenant SaaS
-
-```toml
-[routes]
-# Platform services
-"app.saas-platform.com" = { image = "saas-frontend:v2.1.0" }
-"api.saas-platform.com" = { image = "saas-api:v3.2.1" }
-
-# Customer subdomains
-"acme.saas-platform.com" = { image = "saas-app:v2.1.0" }
-"beta.saas-platform.com" = { image = "saas-app:v2.1.0" }
-
-# Customer custom domains
-"portal.acme-corp.com" = { image = "saas-app:v2.1.0" }
-```
-
-## External Services
-
-For non-containerized services (databases, legacy apps, etc.), see [External Routes](./external-routes.md).
+Gordon reports a focused configuration error when it detects an image-backed route and points to this migration.
 
 ## Related
 
-- [Configuration Overview](./index.md)
-- [Auto Route](./auto-route.md)
-- [Attachments](./attachments.md)
+- [Services](./services.md)
 - [External Routes](./external-routes.md)
+- [Traffic Plane Configuration](./traffic.md)
+- [Configuration Reference](./reference.md)

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -83,12 +83,11 @@ Use an expanded declaration when a port needs additional settings:
 [services.game.ports.rcon]
 port = 28016
 protocol = "tcp"
-publish = "127.0.0.1:38016"
 private = true
 trusted_cidrs = ["100.64.0.0/10"]
 ```
 
-A port used by Gordon's current proxy runtime must have a loopback `publish` address. This is the private backend address Gordon dials; it is not the public listener. Public listeners are configured with routes or traffic entrypoints.
+Gordon allocates the loopback backend port that it uses to reach the container. Public listeners are configured with routes or traffic entrypoints.
 
 ## Send HTTP traffic to a service
 
@@ -120,7 +119,7 @@ An entrypoint tells Gordon where to listen. A traffic router connects that liste
 image = "registry.example.com/game:latest"
 
 [services.game.ports]
-game = { port = 28015, protocol = "udp", publish = "127.0.0.1:38015" }
+game = { port = 28015, protocol = "udp" }
 
 [entrypoints.game]
 address = ":28015"
@@ -149,7 +148,6 @@ image = "registry.example.com/api:latest"
 port = 9443
 protocol = "tcp"
 tls = true
-publish = "127.0.0.1:19443"
 
 [entrypoints.secure-api]
 address = ":9443"

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -1,94 +1,245 @@
-# Standalone Services
+# Services
 
-Standalone services are Gordon-managed containers for non-HTTP workloads such as game servers, databases, or TCP/UDP daemons. Gordon creates, starts, restarts, reconciles, and removes these containers from the `[[services]]` configuration during startup and reload.
+A **service** is an application that Gordon runs and keeps available.
 
-Standalone services are separate from HTTP `[routes]`. Route normal web apps with `[routes]`; use `[[services]]` when Gordon must manage a long-running container that is reached by explicit L4 traffic routers.
+You tell Gordon which image contains the application and which named ports the application provides. Gordon then creates the container, starts it, checks that it is ready, replaces it during deployments, and cleans up old containers.
 
-## Example
+The service remains the same even when Gordon replaces its container. Think of the service as the application and the container as the current running copy of that application.
+
+## A first service
 
 ```toml
-[[services]]
-name = "rust"
-image = "registry.example.com:5000/rust:latest"
-enabled = true
-env_file = "/srv/gordon/services/rust.env"
+[services.app]
+image = "registry.example.com/app:latest"
 
-[services.readiness]
-type = "log"
-path = "/steamcmd/rust/server.log"
-contains = "Server startup complete"
-timeout = "2m"
+[services.app.ports]
+web = "8080/http"
+```
 
-[[services.ports]]
-name = "game"
-container = 28015
-protocol = "udp"
-publish = "127.0.0.1:38015"
+This configuration says:
 
-[[services.ports]]
-name = "rcon"
-container = 28016
+- the service is named `app`;
+- Gordon runs the image `registry.example.com/app:latest`;
+- the application accepts HTTP traffic on container port `8080`;
+- that port is named `web`, so routes can refer to it clearly.
+
+Declaring a port does not make it public. A route or traffic router must explicitly expose it.
+
+> **Do not declare ports used only between containers.** The `ports` table is not an inventory of every port opened by the application. It contains only stable, named service ports that Gordon must route. Containers in the same service communicate directly over their private network using the destination container name and port, such as `postgres:5432` or `valkey:6379`.
+
+For example, a web application can use PostgreSQL and Valkey internally while exporting only its HTTP port:
+
+```toml
+[services.shop.containers]
+web = "registry.example.com/shop-web:latest"
+postgres = "postgres:18"
+valkey = "valkey/valkey:latest"
+
+[services.shop.ports]
+web = "web:3000/http"
+```
+
+There is intentionally no `postgres` or `valkey` entry under `services.shop.ports`. Gordon creates private DNS names for those containers, so `web` connects directly to `postgres:5432` and `valkey:6379`.
+
+## One service with several routed ports
+
+One application can provide several protocols from the same container:
+
+```toml
+[services.app]
+image = "registry.example.com/app:latest"
+
+[services.app.ports]
+web = "8080/http"
+database = "5432/tcp"
+game = "9000/udp"
+
+[services.app.ports.secure_web]
+port = 8443
+protocol = "http"
+tls = true
+```
+
+The left side is a name chosen by you. A compact value contains the container port followed by the protocol spoken by the application.
+
+| Protocol | Use it when the application speaks |
+|---|---|
+| `http` | HTTP |
+| `tcp` | A non-HTTP TCP protocol, such as PostgreSQL or RCON |
+| `udp` | A UDP protocol, such as a game or DNS protocol |
+
+TLS is not a protocol value. It is an independent property of a TCP-based port. Use an expanded port table with `tls = true` when the application expects an encrypted connection. Do not write `https`, `tls`, or `http+tls` as a protocol.
+
+A plain integer is shorthand for a TCP port:
+
+```toml
+[services.database.ports]
+postgres = 5432
+```
+
+Use an expanded declaration when a port needs additional settings:
+
+```toml
+[services.game.ports.rcon]
+port = 28016
 protocol = "tcp"
 publish = "127.0.0.1:38016"
+private = true
 trusted_cidrs = ["100.64.0.0/10"]
 ```
 
-The `publish` address is the host-side bind address that Gordon's traffic manager dials; use loopback for private backends. Expose services through `[traffic]` routers instead of binding service containers directly to a public interface.
+A port used by Gordon's current proxy runtime must have a loopback `publish` address. This is the private backend address Gordon dials; it is not the public listener. Public listeners are configured with routes or traffic entrypoints.
 
-## Traffic routing
+## Send HTTP traffic to a service
 
-Use `service:<service>:<port-name>` from TCP, UDP, or TLS passthrough routers:
+A **route** connects an HTTP hostname to one named port of a service:
 
 ```toml
-[entrypoints.rust]
-address = "0.0.0.0:28015"
+[services.app]
+image = "registry.example.com/app:latest"
+ports = { web = "8080/http" }
+
+[routes]
+"app.example.com" = { service = "app", port = "web" }
+```
+
+Read the route as:
+
+> Send requests for `app.example.com` to the `web` port of the `app` service.
+
+A route never creates a second container. The service owns deployment; the route only directs HTTP traffic.
+
+HTTP routes target `http` service ports. When the service port has `tls = true`, Gordon uses HTTPS for the private backend connection. Public HTTPS is configured and terminated at the route layer, so most HTTP service ports do not need `tls = true`.
+
+## Expose TCP or UDP
+
+An entrypoint tells Gordon where to listen. A traffic router connects that listener to a named service port.
+
+```toml
+[services.game]
+image = "registry.example.com/game:latest"
+
+[services.game.ports]
+game = { port = 28015, protocol = "udp", publish = "127.0.0.1:38015" }
+
+[entrypoints.game]
+address = ":28015"
 protocol = "udp"
 
 [[traffic.udp.routers]]
-name = "rust-game"
-entrypoint = "rust"
-service = "service:rust:game"
-
-[entrypoints.rcon]
-address = "0.0.0.0:28016"
-protocol = "tcp"
-trusted_cidrs = ["100.64.0.0/10"]
-
-[[traffic.tcp.routers]]
-name = "rust-rcon"
-entrypoint = "rcon"
-service = "service:rust:rcon"
+name = "game"
+entrypoint = "game"
+service = "game"
+port = "game"
 ```
 
-Ports named `rcon` default to private. Private ports require non-empty `trusted_cidrs` on both the service port and target entrypoint, and the CIDR sets must match. To intentionally expose an RCON port publicly, set `public = true` on that port.
+Read the traffic router as:
+
+> Forward UDP packets received by the `game` entrypoint to the `game` port of the `game` service.
+
+## Pass TLS through unchanged
+
+TLS passthrough is a traffic binding behavior. The service port remains TCP and separately records that its traffic is TLS-wrapped:
+
+```toml
+[services.api]
+image = "registry.example.com/api:latest"
+
+[services.api.ports.secure]
+port = 9443
+protocol = "tcp"
+tls = true
+publish = "127.0.0.1:19443"
+
+[entrypoints.secure-api]
+address = ":9443"
+protocol = "tls"
+
+[[traffic.tls.routers]]
+name = "secure-api"
+entrypoint = "secure-api"
+sni = "api.example.com"
+service = "api"
+port = "secure"
+```
+
+Gordon reads the TLS server name to choose the service but does not decrypt the connection.
+
+## Environment and readiness
+
+```toml
+[services.game]
+image = "registry.example.com/game:latest"
+env_file = "/srv/gordon/services/game.env"
+env = ["REGION=eu"]
+
+[services.game.readiness]
+type = "log"
+path = "/var/log/game/server.log"
+contains = "Server startup complete"
+timeout = "2m"
+```
 
 ## Volumes
 
-Explicit volumes are optional:
-
 ```toml
-[[services.volumes]]
-source = "rust-data"
-target = "/steamcmd/rust"
+[[services.game.volumes]]
+source = "game-data"
+target = "/var/lib/game"
 read_only = false
 ```
 
-When `[[services.volumes]]` is omitted, Gordon inspects the image `VOLUME` metadata and creates deterministic Gordon-managed named volumes for those paths. If the image has no `VOLUME` metadata, the service is stateless unless the image writes inside its own filesystem.
+When no volumes are declared, Gordon inspects the image's `VOLUME` metadata and creates deterministic managed volumes for those paths. Gordon preserves volumes by default when replacing or removing a service container.
 
-Gordon tracks image-discovered managed volumes and only removes those managed volumes when `cleanup.preserve_volumes = false`. Explicit named volumes and bind mounts are not deleted as managed image volumes.
+## Disable or remove a service
 
-## Cleanup
+Services are enabled by default:
 
 ```toml
-[services.cleanup]
+[services.game]
+image = "game:latest"
+enabled = false
+```
+
+When disabled, Gordon stops and removes the service container according to its cleanup policy.
+
+```toml
+[services.game.cleanup]
 preserve_volumes = true
 remove_container = true
 ```
 
-By default Gordon removes old or disabled service containers while preserving volumes. Set `preserve_volumes = false` only for disposable managed image volumes.
+## Removed configuration syntax
+
+The old array syntax is no longer supported:
+
+```toml
+# Removed
+[[services]]
+name = "game"
+image = "game:latest"
+
+[[services.ports]]
+name = "web"
+container = 8080
+protocol = "tcp"
+```
+
+Write the service and port names as table keys instead:
+
+```toml
+[services.game]
+image = "game:latest"
+
+[services.game.ports]
+web = "8080/http"
+```
+
+Gordon reports a focused startup error when it detects the removed syntax.
 
 ## Related
 
+- [Routes Configuration](./routes.md)
 - [Traffic Plane Configuration](./traffic.md)
 - [Configuration Reference](./reference.md)
 - [CLI traffic status](../cli/traffic.md)

--- a/docs/config/traffic.md
+++ b/docs/config/traffic.md
@@ -33,31 +33,27 @@ For each accepted connection on a `smart_tcp` entrypoint Gordon:
 
 Malformed HTTP-looking or TLS-looking traffic is rejected instead of bypassing to raw fallback.
 
-## Standalone and Network Services
+## Services and network services
 
-Standalone services are Gordon-managed containers that L4 routers can target with `service:<service>:<port-name>`. Define them under `[[services]]` when Gordon should own the container lifecycle.
+Services are Gordon-owned applications. Traffic routers target a declared service port using separate `service` and `port` fields.
 
 ```toml
-[[services]]
-name = "rust"
-image = "registry.example.com:5000/rust:latest"
-enabled = true
+[services.game]
+image = "registry.example.com:5000/game-server:latest"
+ports = { gameplay = "28015/udp" }
 
-[[services.ports]]
-name = "game"
-container = 28015
-protocol = "udp"
-publish = "127.0.0.1:38015"
-
-[entrypoints.rust]
+[entrypoints.game]
 address = "0.0.0.0:28015"
 protocol = "udp"
 
 [[traffic.udp.routers]]
-name = "rust-game"
-entrypoint = "rust"
-service = "service:rust:game"
+name = "gameplay"
+entrypoint = "game"
+service = "game"
+port = "gameplay"
 ```
+
+Ports used only between containers in the same service are not declared. Declaring a service port does not expose it until a route or traffic router binds it.
 
 Network services describe manually managed non-HTTP backends that L4 routers can target.
 
@@ -71,14 +67,7 @@ container = 5432
 protocol = "tcp"
 ```
 
-Service references use:
-
-- `route:<domain>` for configured HTTP routes
-- `external_route:<domain>` for configured external HTTP routes
-- `network_service:<service>:<port-name>` for manually managed TCP, UDP, and TLS passthrough backends
-- `service:<service>:<port-name>` for Gordon-managed standalone service backends
-
-`static:<name>` is reserved and currently unsupported.
+A traffic router defines exactly one backend with either `service = "<name>"` or `network_service = "<name>"`, plus `port = "<port-name>"`. Typed strings such as `service:name:port` and `network_service:name:port` have been removed.
 
 ## TLS Passthrough on Smart TCP
 
@@ -93,7 +82,8 @@ protocol = "smart_tcp"
 name = "raw-tls"
 entrypoint = "edge"
 sni = "raw.example.com"
-service = "network_service:raw:tls"
+network_service = "raw"
+port = "tls"
 ```
 
 Exact SNI matches win over wildcard matches. Ambiguous wildcard overlaps and HTTP-host/TLS-passthrough conflicts on the same smart TCP entrypoint are rejected at validation time. HTTPS application routes that do not match a passthrough SNI use Gordon's normal HTTPS fallback and certificate selection.

--- a/docs/reference/service-model.md
+++ b/docs/reference/service-model.md
@@ -1,0 +1,153 @@
+# Service ownership model
+
+This document defines Gordon's service, container, port, route, and traffic ownership boundaries. The configuration forms shown here are canonical; removed forms are rejected rather than interpreted through compatibility logic.
+
+## Ownership
+
+A **service** is an application whose lifecycle Gordon owns. Gordon deploys it, keeps it running, checks readiness, replaces changed containers, updates routing targets, and cleans up removed resources.
+
+A service owns one or more **containers**. Containers in the same service share a private network and resolve each other by their configured container names. Ports used only between those containers are not declared in Gordon configuration.
+
+A named **service port** is a stable interface that Gordon may route. It identifies one owning container, one container port, an application protocol, and whether the application expects TLS-wrapped traffic. Declaring a service port does not create a public listener.
+
+A **route** binds an HTTP hostname to an HTTP service port. It never owns an image or container.
+
+A **traffic router** binds a TCP, UDP, or TLS-aware entrypoint to a compatible service port. Public exposure and source policy belong to the route, traffic router, or entrypoint—not to the container.
+
+## Canonical configuration
+
+### Single-container service
+
+```toml
+[services.app]
+image = "registry.example.com/app:latest"
+ports = { web = "8080/http", admin = "9090/http" }
+
+[routes]
+"app.example.com" = { service = "app", port = "web" }
+"admin.example.com" = { service = "app", port = "admin" }
+```
+
+The top-level `image` form creates one implicit container. It cannot be combined with `services.<name>.containers`.
+
+### Multi-container service
+
+```toml
+[services.shop.containers]
+web = "registry.example.com/shop-web:latest"
+postgres = "postgres:18"
+valkey = "valkey/valkey:latest"
+
+[services.shop.ports]
+web = "web:3000/http"
+
+[routes]
+"shop.example.com" = { service = "shop", port = "web" }
+```
+
+Only `shop.web` is declared because Gordon routes it. The web container connects directly to `postgres:5432` and `valkey:6379` on the service network.
+
+### Backend TLS
+
+TLS is independent of the application protocol. It requires the expanded form:
+
+```toml
+[services.app.ports.secure_web]
+port = 8443
+protocol = "http"
+tls = true
+```
+
+The only service-port protocol values are `http`, `tcp`, and `udp`. Gordon rejects `https`, `tls`, `h2c`, and compound values such as `http+tls`. UDP cannot set `tls = true`.
+
+Public HTTPS termination is a route concern. On an HTTP service port, `tls = true` only means Gordon connects to the application using HTTPS.
+
+### TCP and UDP
+
+```toml
+[services.game]
+image = "registry.example.com/game:latest"
+ports = { game = "28015/udp", rcon = "28016/tcp" }
+
+[entrypoints.game]
+address = ":28015"
+protocol = "udp"
+
+[[traffic.udp.routers]]
+name = "game"
+entrypoint = "game"
+service = "game"
+port = "game"
+
+[entrypoints.rcon]
+address = ":28016"
+protocol = "tcp"
+trusted_cidrs = ["100.64.0.0/10"]
+
+[[traffic.tcp.routers]]
+name = "rcon"
+entrypoint = "rcon"
+service = "game"
+port = "rcon"
+```
+
+### TLS passthrough
+
+```toml
+[services.mail.ports.smtps]
+port = 465
+protocol = "tcp"
+tls = true
+
+[entrypoints.smtps]
+address = ":465"
+protocol = "tls"
+
+[[traffic.tls.routers]]
+name = "smtps"
+entrypoint = "smtps"
+sni = "mail.example.com"
+service = "mail"
+port = "smtps"
+```
+
+The traffic binding selects passthrough. The service port remains TCP and records that the application expects TLS-wrapped bytes.
+
+## Runtime rules
+
+- Gordon creates a private network per multi-container service and stable DNS aliases from container keys.
+- Gordon publishes or resolves only declared service ports. Users do not coordinate host-side `publish` addresses.
+- Internal-only ports remain direct private-network connections.
+- Replacement creates a candidate, waits for readiness, atomically switches routed targets, drains the old container, then removes it.
+- A changed container image replaces that container without restarting unrelated stateful containers after their compatibility checks pass.
+- Removing a route removes only the HTTP binding. Removing a service owns container, network, and managed-volume cleanup.
+- Image pushes resolve matching service containers. An explicit service/container selector disambiguates images used more than once.
+
+## Removed forms
+
+Gordon rejects these forms with migration guidance:
+
+- `[[services]]` and `[[services.ports]]` arrays;
+- image strings or `{ image = ... }` inside `[routes]`;
+- route `{ target = "service:name:port" }` values;
+- traffic `service = "service:name:port"` references;
+- manually coordinated service-port `publish` addresses;
+- service-port protocols `https`, `tls`, `h2c`, or `http+tls`.
+
+## Lifecycle command boundary
+
+Service commands own deployment:
+
+```text
+gordon services add|list|show|deploy|restart|logs|disable|remove
+gordon push --service <service> [--container <container>]
+```
+
+Route commands own HTTP bindings:
+
+```text
+gordon routes add <domain> <service> <port>
+gordon routes remove <domain>
+```
+
+Removing a route must never stop or remove a service container.

--- a/internal/adapters/in/cli/mocks/mock_control_plane.go
+++ b/internal/adapters/in/cli/mocks/mock_control_plane.go
@@ -1838,8 +1838,8 @@ func (_c *MockControlPlane_ListRoutesWithDetails_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *MockControlPlane_ListRoutesWithDetails_Call) Return(vs []remote.RouteInfo, err error) *MockControlPlane_ListRoutesWithDetails_Call {
-	_c.Call.Return(vs, err)
+func (_c *MockControlPlane_ListRoutesWithDetails_Call) Return(routeInfos []remote.RouteInfo, err error) *MockControlPlane_ListRoutesWithDetails_Call {
+	_c.Call.Return(routeInfos, err)
 	return _c
 }
 

--- a/internal/adapters/in/http/proxy/handler.go
+++ b/internal/adapters/in/http/proxy/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bnema/gordon/internal/adapters/in/http/middleware"
 	"github.com/bnema/gordon/internal/boundaries/in"
+	"github.com/bnema/gordon/internal/domain"
 )
 
 // Handler implements http.Handler for the reverse proxy.
@@ -93,6 +94,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		proxyError(w, "404 page not found", http.StatusNotFound)
 		return
 	}
+	if !targetAllowsPeer(target, r.RemoteAddr) {
+		log.Warn().Str("route_host", target.RouteHost).Msg("request source is not allowed for private service target")
+		proxyError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 
 	log.Debug().
 		Str("host", target.Host).
@@ -101,6 +107,27 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Msg("resolved proxy target")
 
 	h.forwardToTarget(w, r, target, cfg.MaxResponseSize)
+}
+
+func targetAllowsPeer(target *domain.ProxyTarget, remoteAddr string) bool {
+	if len(target.TrustedCIDRs) == 0 {
+		return true
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return false
+	}
+	peer := net.ParseIP(host)
+	if peer == nil {
+		return false
+	}
+	for _, cidr := range target.TrustedCIDRs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err == nil && network.Contains(peer) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeRequestHost(host string) string {

--- a/internal/adapters/in/http/proxy/handler_test.go
+++ b/internal/adapters/in/http/proxy/handler_test.go
@@ -114,6 +114,28 @@ func TestHandler_RejectsInvalidRequestHost(t *testing.T) {
 	}
 }
 
+func TestHandler_RejectsUntrustedPeerForPrivateServiceTarget(t *testing.T) {
+	proxySvc := inmocks.NewMockProxyService(t)
+	proxySvc.EXPECT().ProxyConfig().Return(in.ProxyServiceConfig{})
+	proxySvc.EXPECT().IsRegistryDomain("play.example.com").Return(false)
+	proxySvc.EXPECT().GetTarget(mock.Anything, "play.example.com").Return(&domain.ProxyTarget{
+		Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "play.example.com", TrustedCIDRs: []string{"100.64.0.0/10"},
+	}, nil)
+
+	handler := NewHandler(proxySvc, nil, testLogger())
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/", nil)
+	require.NoError(t, err)
+	req.Host = "play.example.com"
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
 func TestHandler_Returns404WhenNoTarget(t *testing.T) {
 	proxySvc := inmocks.NewMockProxyService(t)
 

--- a/internal/adapters/out/docker/runtime.go
+++ b/internal/adapters/out/docker/runtime.go
@@ -881,8 +881,13 @@ func hasConfiguredHealthcheck(cfg *container.Config) bool {
 	return !strings.EqualFold(strings.TrimSpace(cfg.Healthcheck.Test[0]), "NONE")
 }
 
-// GetContainerPort gets the host port for a container's internal port.
+// GetContainerPort gets the TCP host port for a container's internal port.
 func (r *Runtime) GetContainerPort(ctx context.Context, containerID string, internalPort int) (int, error) {
+	return r.GetContainerPublishedPort(ctx, containerID, internalPort, domain.NetworkProtocolTCP)
+}
+
+// GetContainerPublishedPort gets the host port for a container port and transport.
+func (r *Runtime) GetContainerPublishedPort(ctx context.Context, containerID string, internalPort int, protocol domain.NetworkProtocol) (int, error) {
 	ctx = zerowrap.CtxWithFields(ctx, map[string]any{
 		zerowrap.FieldLayer:    "adapter",
 		zerowrap.FieldAdapter:  "docker",
@@ -902,7 +907,10 @@ func (r *Runtime) GetContainerPort(ctx context.Context, containerID string, inte
 		return 0, fmt.Errorf("no port mappings found for container %s", containerID)
 	}
 
-	containerPort, err := network.ParsePort(fmt.Sprintf("%d/tcp", internalPort))
+	if protocol != domain.NetworkProtocolTCP && protocol != domain.NetworkProtocolUDP {
+		return 0, fmt.Errorf("unsupported network protocol %q", protocol)
+	}
+	containerPort, err := network.ParsePort(fmt.Sprintf("%d/%s", internalPort, protocol))
 	if err != nil {
 		return 0, fmt.Errorf("invalid container port %d: %w", internalPort, err)
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/bnema/zerowrap"
 	zerowrapotel "github.com/bnema/zerowrap/otel"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 	"golang.org/x/sys/unix"
 
@@ -181,7 +183,7 @@ type Config struct {
 	EntryPoints     map[string]traffic.EntryPointConfig `mapstructure:"entrypoints"`
 	Traffic         traffic.Config                      `mapstructure:"traffic"`
 	NetworkServices []traffic.NetworkServiceConfig      `mapstructure:"network_services"`
-	Services        []servicecfg.Config                 `mapstructure:"services"`
+	Services        map[string]servicecfg.Config        `mapstructure:"services"`
 
 	Backups struct {
 		// Legacy database backup keys. Prefer backups.databases.* for new configs.
@@ -406,16 +408,84 @@ func initConfig(configPath string) (*viper.Viper, Config, error) {
 	if err := loadConfig(v, configPath); err != nil {
 		return nil, Config{}, fmt.Errorf("failed to load config: %w", err)
 	}
-
 	var cfg Config
-	if err := v.Unmarshal(&cfg); err != nil {
-		return nil, Config{}, fmt.Errorf("failed to unmarshal config: %w", err)
+	if err := unmarshalConfig(v, &cfg); err != nil {
+		return nil, Config{}, err
 	}
 	if err := validateEntrypointMigration(v, cfg); err != nil {
 		return nil, Config{}, err
 	}
 
 	return v, cfg, nil
+}
+
+func unmarshalConfig(v *viper.Viper, cfg *Config) error {
+	if err := validateServiceConfigSyntax(v); err != nil {
+		return err
+	}
+	hook := mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		serviceContainerDecodeHook,
+		servicePortDecodeHook,
+	)
+	if err := v.Unmarshal(cfg, viper.DecodeHook(hook)); err != nil {
+		return fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+	return nil
+}
+
+func validateServiceConfigSyntax(v *viper.Viper) error {
+	services := v.Get("services")
+	if services != nil && reflect.ValueOf(services).Kind() == reflect.Slice {
+		return fmt.Errorf("the [[services]] array syntax is no longer supported; migrate each service to a [services.<name>] table as documented in docs/config/services.md")
+	}
+	return nil
+}
+
+func serviceContainerDecodeHook(from reflect.Type, to reflect.Type, data any) (any, error) {
+	if to != reflect.TypeOf(servicecfg.ContainerConfig{}) {
+		return data, nil
+	}
+	if image, ok := data.(string); ok {
+		return servicecfg.ContainerConfig{Image: image}, nil
+	}
+	return data, nil
+}
+
+func servicePortDecodeHook(from reflect.Type, to reflect.Type, data any) (any, error) {
+	if to != reflect.TypeOf(servicecfg.PortConfig{}) {
+		return data, nil
+	}
+	switch value := data.(type) {
+	case int64:
+		return servicecfg.PortConfig{Container: int(value)}, nil
+	case string:
+		return parseServicePortShorthand(value)
+	default:
+		return data, nil
+	}
+}
+
+func parseServicePortShorthand(value string) (servicecfg.PortConfig, error) {
+	targetText, protocolText, hasProtocol := strings.Cut(value, "/")
+	containerName, portText, hasContainer := strings.Cut(targetText, ":")
+	if !hasContainer {
+		portText = containerName
+		containerName = ""
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return servicecfg.PortConfig{}, fmt.Errorf("service port shorthand %q must use PORT or PORT/protocol", value)
+	}
+	protocol := domain.ServicePortProtocolTCP
+	if hasProtocol {
+		protocol = domain.ServicePortProtocol(protocolText)
+		if !protocol.Valid() {
+			return servicecfg.PortConfig{}, fmt.Errorf("service port shorthand %q protocol must be http, tcp, or udp; use an expanded port table for TLS", value)
+		}
+	}
+	return servicecfg.PortConfig{ContainerName: containerName, Container: port, Protocol: protocol}, nil
 }
 
 func validateEntrypointMigration(v *viper.Viper, cfg Config) error {
@@ -818,13 +888,13 @@ func (si *serviceInit) registerReloadCoordinatorHooks() {
 				return tlsErr
 			}
 		}
-		if err := applyTrafficRuntimeConfig(reloadCtx, si.svc.trafficManager, reloadCfg, si.svc.configSvc); err != nil {
+		if err := applyTrafficRuntimeConfig(reloadCtx, si.svc.trafficManager, reloadCfg, si.svc.configSvc, si.svc.proxySvc, si.svc.standaloneServiceSvc); err != nil {
 			return err
 		}
 		si.svc.tlsHTTPEntryPoints = registerTLSMuxHTTPServers(si.svc.trafficManager, reloadCfg, si.svc.httpsProxyHandler, tlsConfig, si.svc.tlsHTTPEntryPoints)
 		si.svc.smartHTTPEntryPoints = registerSmartTCPHTTPServers(si.svc.trafficManager, reloadCfg, si.svc.httpProxyHandler, si.svc.httpsProxyHandler, tlsConfig, si.svc.smartHTTPEntryPoints)
-		if err := reconcileStandaloneServices(reloadCtx, si.svc.standaloneServiceSvc, reloadCfg); err != nil {
-			return err
+		if si.svc.proxySvc != nil {
+			si.svc.proxySvc.CommitStagedServiceTargets()
 		}
 		si.svc.containerSvc.UpdateConfig(containerCfg)
 		return nil
@@ -1852,7 +1922,7 @@ func (c *reloadCoordinator) reloadLocked(ctx context.Context, loadConfig bool) e
 
 func (c *reloadCoordinator) applyLoadedConfig(ctx context.Context, now time.Time) error {
 	var reloadCfg Config
-	if err := c.v.Unmarshal(&reloadCfg); err != nil {
+	if err := unmarshalConfig(c.v, &reloadCfg); err != nil {
 		c.log.Error().Err(err).Msg("failed to unmarshal config on reload")
 		return fmt.Errorf("failed to unmarshal config on reload: %w", err)
 	}
@@ -2966,22 +3036,11 @@ func waitForCoreProxyReadyAndApplyTraffic(ctx context.Context, cfg Config, svc *
 	if err := waitForServerReady(proxyReady, errChan); err != nil {
 		return err
 	}
-	if err := applyTrafficRuntimeConfig(ctx, svc.trafficManager, cfg, svc.configSvc); err != nil {
+	if err := applyTrafficRuntimeConfig(ctx, svc.trafficManager, cfg, svc.configSvc, svc.proxySvc, svc.standaloneServiceSvc); err != nil {
 		return err
 	}
-	return reconcileStandaloneServices(ctx, svc.standaloneServiceSvc, cfg)
-}
-
-func reconcileStandaloneServices(ctx context.Context, serviceSvc in.StandaloneServiceService, cfg Config) error {
-	if serviceSvc == nil {
-		return nil
-	}
-	standaloneServices, err := servicecfg.ToDomain(cfg.Services)
-	if err != nil {
-		return fmt.Errorf("convert standalone service config: %w", err)
-	}
-	if err := serviceSvc.Reconcile(ctx, standaloneServices); err != nil {
-		return fmt.Errorf("reconcile standalone services: %w", err)
+	if svc.proxySvc != nil {
+		svc.proxySvc.CommitStagedServiceTargets()
 	}
 	return nil
 }

--- a/internal/app/run_entrypoint_migration_test.go
+++ b/internal/app/run_entrypoint_migration_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+	servicecfg "github.com/bnema/gordon/internal/usecase/services"
 )
 
 func TestInitConfigRejectsLegacyPortsWithoutEntrypoints(t *testing.T) {
@@ -25,4 +28,91 @@ func TestInitConfigAcceptsLegacyPortsWithEntrypoint(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Contains(t, cfg.EntryPoints, "edge")
+}
+
+func TestInitConfigLoadsExpandedHTTPPortWithTLS(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gordon.toml")
+	config := `[services.app]
+image = "app:latest"
+
+[services.app.ports.secure_web]
+port = 8443
+protocol = "http"
+tls = true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+
+	_, cfg, err := initConfig(configPath)
+	require.NoError(t, err)
+	services, err := servicecfg.ToDomain(cfg.Services)
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+	require.Equal(t, []domain.StandaloneServicePort{{
+		Name: "secure_web", Container: 8443, Protocol: domain.ServicePortProtocolHTTP, TLS: true,
+	}}, services[0].Ports)
+}
+
+func TestInitConfigLoadsMultiContainerServiceWithoutDeclaringInternalPorts(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gordon.toml")
+	config := `[services.shop.containers]
+web = "shop-web:latest"
+postgres = "postgres:18"
+valkey = "valkey/valkey:latest"
+
+[services.shop.ports]
+web = "web:3000/http"
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+
+	_, cfg, err := initConfig(configPath)
+	require.NoError(t, err)
+	services, err := servicecfg.ToDomain(cfg.Services)
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+	require.Equal(t, "shop", services[0].Name)
+	require.Len(t, services[0].Containers, 3)
+	require.Equal(t, "postgres", services[0].Containers[0].Name)
+	require.Equal(t, "postgres:18", services[0].Containers[0].Image)
+	require.Equal(t, "valkey", services[0].Containers[1].Name)
+	require.Equal(t, "valkey/valkey:latest", services[0].Containers[1].Image)
+	require.Equal(t, "web", services[0].Containers[2].Name)
+	require.Equal(t, "shop-web:latest", services[0].Containers[2].Image)
+	require.Equal(t, []domain.StandaloneServicePort{{
+		Name: "web", ContainerName: "web", Container: 3000, Protocol: domain.ServicePortProtocolHTTP,
+	}}, services[0].Ports)
+}
+
+func TestInitConfigRejectsRemovedServiceArraySyntax(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gordon.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte("[[services]]\nname = \"app\"\nimage = \"app:latest\"\n"), 0o600))
+
+	_, _, err := initConfig(configPath)
+
+	require.ErrorContains(t, err, "[[services]] array syntax is no longer supported")
+	require.ErrorContains(t, err, "[services.<name>]")
+	require.ErrorContains(t, err, "docs/config/services.md")
+}
+
+func TestInitConfigLoadsKeyedServicesWithCompactPorts(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "gordon.toml")
+	config := `[services.app]
+image = "app:latest"
+ports = { web = "8080/http", game = "9000/udp", rcon = { port = 9001, protocol = "tcp", private = true } }
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+
+	_, cfg, err := initConfig(configPath)
+
+	require.NoError(t, err)
+	services, err := servicecfg.ToDomain(cfg.Services)
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+	require.Len(t, services[0].Ports, 3)
+	require.Equal(t, "game", services[0].Ports[0].Name)
+	require.Equal(t, 9000, services[0].Ports[0].Container)
+	require.Equal(t, domain.ServicePortProtocolUDP, services[0].Ports[0].Protocol)
+	require.Equal(t, "rcon", services[0].Ports[1].Name)
+	require.True(t, services[0].Ports[1].Private)
+	require.Equal(t, "web", services[0].Ports[2].Name)
+	require.Equal(t, domain.ServicePortProtocolHTTP, services[0].Ports[2].Protocol)
 }

--- a/internal/app/run_reload_test.go
+++ b/internal/app/run_reload_test.go
@@ -141,11 +141,10 @@ func (r *containerConfigApplyRecorder) Apply(ctx context.Context, cfg Config) er
 }
 
 type standaloneServiceRecorder struct {
-	mu          sync.Mutex
-	calls       int
-	services    []domain.StandaloneService
-	err         error
-	onReconcile func()
+	mu       sync.Mutex
+	calls    int
+	services []domain.StandaloneService
+	err      error
 }
 
 func (r *standaloneServiceRecorder) Reconcile(_ context.Context, services []domain.StandaloneService) error {
@@ -153,12 +152,12 @@ func (r *standaloneServiceRecorder) Reconcile(_ context.Context, services []doma
 	r.calls++
 	r.services = append([]domain.StandaloneService(nil), services...)
 	err := r.err
-	onReconcile := r.onReconcile
 	r.mu.Unlock()
-	if onReconcile != nil {
-		onReconcile()
-	}
 	return err
+}
+
+func (r *standaloneServiceRecorder) ResolvePorts(context.Context, []domain.StandaloneService) ([]domain.ServicePortBackend, error) {
+	return nil, nil
 }
 
 func (r *standaloneServiceRecorder) Status(context.Context) ([]domain.StandaloneServiceStatus, error) {
@@ -367,7 +366,7 @@ func TestServiceInit_ReloadUpdatesManagementHostsBeforeLaterFailure(t *testing.T
 	reloadCfg := Config{}
 	reloadCfg.Server.GordonDomain = "new.example.com"
 	reloadCfg.Server.RegistryPort = 5000
-	reloadCfg.Services = []servicecfg.Config{{Name: "game", Image: "game:latest", Enabled: true}}
+	reloadCfg.Services = map[string]servicecfg.Config{"game": {Image: "game:latest"}}
 
 	err := si.svc.reloadCoordinator.applyContainerConfig(ctx, reloadCfg)
 	require.ErrorIs(t, err, reconcileErr)
@@ -435,7 +434,7 @@ func TestStandaloneServiceSecretProviderUnsafeBackendReconcilesServiceSecrets(t 
 	assert.True(t, sawSecretEnv)
 }
 
-func TestServiceInit_RegisterReloadCoordinatorHooks_AppliesTrafficBeforeStandaloneServices(t *testing.T) {
+func TestServiceInit_RegisterReloadCoordinatorHooks_ReconcilesServicesOnceBeforeApplyingTraffic(t *testing.T) {
 	ctx := context.Background()
 	v := viper.New()
 	v.Set("server.gordon_domain", "reload.example.com")
@@ -446,9 +445,7 @@ func TestServiceInit_RegisterReloadCoordinatorHooks_AppliesTrafficBeforeStandalo
 	manager := trafficadapter.NewManager()
 	defer func() { require.NoError(t, manager.Shutdown(ctx)) }()
 
-	reconciler := &standaloneServiceRecorder{onReconcile: func() {
-		assert.NotEmpty(t, manager.Status().EntryPoints, "traffic graph should apply before standalone services reconcile")
-	}}
+	reconciler := &standaloneServiceRecorder{}
 	si := &serviceInit{
 		ctx: ctx,
 		v:   v,
@@ -469,10 +466,10 @@ func TestServiceInit_RegisterReloadCoordinatorHooks_AppliesTrafficBeforeStandalo
 	reloadCfg := Config{}
 	reloadCfg.Server.GordonDomain = "reload.example.com"
 	reloadCfg.Server.RegistryPort = 5000
-	reloadCfg.Services = []servicecfg.Config{{Name: "game", Image: "game:latest", Enabled: true}}
+	reloadCfg.Services = map[string]servicecfg.Config{"game": {Image: "game:latest"}}
 	reloadCfg.EntryPoints = map[string]traffic.EntryPointConfig{"game": {Address: freeTCPAddress(t), Protocol: domain.EntryPointProtocolTCP}}
 	reloadCfg.NetworkServices = []traffic.NetworkServiceConfig{{Name: "game", Ports: []traffic.PortConfig{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolTCP}}}}
-	reloadCfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "game", EntryPoint: "game", Service: "network_service:game:game"}}
+	reloadCfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "game", EntryPoint: "game", NetworkService: "game", Port: "game"}}
 
 	require.NoError(t, si.svc.reloadCoordinator.applyContainerConfig(ctx, reloadCfg))
 	require.Equal(t, 1, reconciler.Calls())
@@ -481,7 +478,7 @@ func TestServiceInit_RegisterReloadCoordinatorHooks_AppliesTrafficBeforeStandalo
 	assert.NotEmpty(t, manager.Status().EntryPoints)
 }
 
-func TestWaitForCoreProxyReadyAndApplyTraffic_AppliesTrafficBeforeStandaloneServices(t *testing.T) {
+func TestWaitForCoreProxyReadyAndApplyTraffic_ReconcilesServicesOnceBeforeApplyingTraffic(t *testing.T) {
 	ctx := context.Background()
 	v := viper.New()
 	configSvc := cfgusecase.NewService(v, nil)
@@ -489,14 +486,12 @@ func TestWaitForCoreProxyReadyAndApplyTraffic_AppliesTrafficBeforeStandaloneServ
 	manager := trafficadapter.NewManager()
 	defer func() { require.NoError(t, manager.Shutdown(ctx)) }()
 
-	reconciler := &standaloneServiceRecorder{onReconcile: func() {
-		assert.NotEmpty(t, manager.Status().EntryPoints, "traffic graph should apply before standalone services reconcile")
-	}}
+	reconciler := &standaloneServiceRecorder{}
 	cfg := Config{}
-	cfg.Services = []servicecfg.Config{{Name: "game", Image: "game:latest", Enabled: true}}
+	cfg.Services = map[string]servicecfg.Config{"game": {Image: "game:latest"}}
 	cfg.EntryPoints = map[string]traffic.EntryPointConfig{"game": {Address: freeTCPAddress(t), Protocol: domain.EntryPointProtocolTCP}}
 	cfg.NetworkServices = []traffic.NetworkServiceConfig{{Name: "game", Ports: []traffic.PortConfig{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolTCP}}}}
-	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "game", EntryPoint: "game", Service: "network_service:game:game"}}
+	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "game", EntryPoint: "game", NetworkService: "game", Port: "game"}}
 
 	ready := make(chan struct{})
 	close(ready)
@@ -504,14 +499,6 @@ func TestWaitForCoreProxyReadyAndApplyTraffic_AppliesTrafficBeforeStandaloneServ
 	require.NoError(t, waitForCoreProxyReadyAndApplyTraffic(ctx, cfg, svc, ready, ready, nil))
 	require.Equal(t, 1, reconciler.Calls())
 	assert.NotEmpty(t, manager.Status().EntryPoints)
-}
-
-func TestReconcileStandaloneServices_ConfigConversionErrorIsClear(t *testing.T) {
-	reconciler := &standaloneServiceRecorder{}
-	err := reconcileStandaloneServices(context.Background(), reconciler, Config{Services: []servicecfg.Config{{Name: "broken", Image: "", Enabled: true}}})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "convert standalone service config")
-	assert.Equal(t, 0, reconciler.Calls())
 }
 
 func TestReloadCoordinator_DebouncesRepeatedWatchCallbacks(t *testing.T) {

--- a/internal/app/start_proxy_servers_test.go
+++ b/internal/app/start_proxy_servers_test.go
@@ -131,7 +131,8 @@ func TestStartProxyServers_ConfiguresSmartTCPHTTPAndHTTPSRoutesWithoutPublicHTTP
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, smartPortText, err := net.SplitHostPort(cfg.EntryPoints[traffic.DefaultEdgeEntryPointName].Address)
 	require.NoError(t, err)
@@ -172,7 +173,8 @@ func TestStartProxyServers_ConfiguresTrafficManagerHTTPSRoute(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(map[string]string{})
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, portText, err := net.SplitHostPort(cfg.EntryPoints[traffic.DefaultEdgeEntryPointName].Address)
 	require.NoError(t, err)
@@ -189,7 +191,7 @@ func TestStartProxyServers_ConfiguresCustomTLSMuxHTTPSRoute(t *testing.T) {
 	cfg.EntryPoints = map[string]traffic.EntryPointConfig{
 		"custom-secure": {Address: fmt.Sprintf("127.0.0.1:%d", freeTCPPort(t)), Protocol: domain.EntryPointProtocolTLSMux},
 	}
-	cfg.Traffic.TLS.Routers = []traffic.RouterConfig{{Name: "raw", EntryPoint: "custom-secure", SNI: "raw.example.com", Service: "network_service:raw:tls"}}
+	cfg.Traffic.TLS.Routers = []traffic.RouterConfig{{Name: "raw", EntryPoint: "custom-secure", SNI: "raw.example.com", NetworkService: "raw", Port: "tls"}}
 	cfg.NetworkServices = []traffic.NetworkServiceConfig{{Name: "raw", Ports: []traffic.PortConfig{{Name: "tls", Container: 443, Protocol: domain.NetworkProtocolTCP}}}}
 
 	manager := trafficadapter.NewManager()
@@ -214,7 +216,8 @@ func TestStartProxyServers_ConfiguresCustomTLSMuxHTTPSRoute(t *testing.T) {
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 
 	_, customPort, err := net.SplitHostPort(cfg.EntryPoints["custom-secure"].Address)
 	require.NoError(t, err)

--- a/internal/app/traffic.go
+++ b/internal/app/traffic.go
@@ -7,35 +7,55 @@ import (
 	trafficadapter "github.com/bnema/gordon/internal/adapters/in/traffic"
 	"github.com/bnema/gordon/internal/boundaries/in"
 	"github.com/bnema/gordon/internal/domain"
+	proxyusecase "github.com/bnema/gordon/internal/usecase/proxy"
 	servicecfg "github.com/bnema/gordon/internal/usecase/services"
 	trafficbuilder "github.com/bnema/gordon/internal/usecase/traffic"
 )
 
-func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService) error {
-	if manager == nil || configSvc == nil {
+func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Manager, cfg Config, configSvc in.ConfigService, proxySvc *proxyusecase.Service, serviceSvcs ...in.StandaloneServiceService) error {
+	if configSvc == nil {
 		return nil
 	}
 	standaloneServices, err := servicecfg.ToDomain(cfg.Services)
 	if err != nil {
-		return fmt.Errorf("convert standalone service config: %w", err)
+		return fmt.Errorf("convert service config: %w", err)
 	}
-	graph, err := trafficbuilder.Build(trafficbuilder.Input{
+	var serviceBackends []domain.ServicePortBackend
+	if len(serviceSvcs) > 0 && serviceSvcs[0] != nil {
+		if err := serviceSvcs[0].Reconcile(ctx, standaloneServices); err != nil {
+			return fmt.Errorf("reconcile services: %w", err)
+		}
+		serviceBackends, err = serviceSvcs[0].ResolvePorts(ctx, standaloneServices)
+		if err != nil {
+			return fmt.Errorf("resolve service ports: %w", err)
+		}
+	}
+	plan, err := trafficbuilder.BuildPlan(trafficbuilder.Input{
 		EntryPoints:     cfg.EntryPoints,
 		Traffic:         cfg.Traffic,
 		Routes:          configSvc.GetRoutes(ctx),
 		ExternalRoutes:  configSvc.GetExternalRoutes(),
+		ServiceRoutes:   configSvc.GetServiceRoutes(),
 		NetworkServices: cfg.NetworkServices,
 		Services:        standaloneServices,
+		ServiceBackends: serviceBackends,
 	})
 	if err != nil {
 		return fmt.Errorf("build traffic graph: %w", err)
 	}
-	owned, err := trafficRuntimeGraph(graph)
-	if err != nil {
-		return fmt.Errorf("filter traffic graph for runtime ownership: %w", err)
+	if manager != nil {
+		owned, err := trafficRuntimeGraph(plan.Graph)
+		if err != nil {
+			return fmt.Errorf("filter traffic graph for runtime ownership: %w", err)
+		}
+		if err := manager.Apply(ctx, &owned); err != nil {
+			return fmt.Errorf("apply traffic graph: %w", err)
+		}
 	}
-	if err := manager.Apply(ctx, &owned); err != nil {
-		return fmt.Errorf("apply traffic graph: %w", err)
+	if proxySvc != nil {
+		if err := proxySvc.StageServiceTargets(plan.ServiceTargets); err != nil {
+			return fmt.Errorf("stage HTTP service targets: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/app/traffic.go
+++ b/internal/app/traffic.go
@@ -20,17 +20,7 @@ func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Mana
 	if err != nil {
 		return fmt.Errorf("convert service config: %w", err)
 	}
-	var serviceBackends []domain.ServicePortBackend
-	if len(serviceSvcs) > 0 && serviceSvcs[0] != nil {
-		if err := serviceSvcs[0].Reconcile(ctx, standaloneServices); err != nil {
-			return fmt.Errorf("reconcile services: %w", err)
-		}
-		serviceBackends, err = serviceSvcs[0].ResolvePorts(ctx, standaloneServices)
-		if err != nil {
-			return fmt.Errorf("resolve service ports: %w", err)
-		}
-	}
-	plan, err := trafficbuilder.BuildPlan(trafficbuilder.Input{
+	input := trafficbuilder.Input{
 		EntryPoints:     cfg.EntryPoints,
 		Traffic:         cfg.Traffic,
 		Routes:          configSvc.GetRoutes(ctx),
@@ -38,8 +28,20 @@ func applyTrafficRuntimeConfig(ctx context.Context, manager *trafficadapter.Mana
 		ServiceRoutes:   configSvc.GetServiceRoutes(),
 		NetworkServices: cfg.NetworkServices,
 		Services:        standaloneServices,
-		ServiceBackends: serviceBackends,
-	})
+	}
+	if err := trafficbuilder.Validate(input); err != nil {
+		return fmt.Errorf("validate traffic graph: %w", err)
+	}
+	if len(serviceSvcs) > 0 && serviceSvcs[0] != nil {
+		if err := serviceSvcs[0].Reconcile(ctx, standaloneServices); err != nil {
+			return fmt.Errorf("reconcile services: %w", err)
+		}
+		input.ServiceBackends, err = serviceSvcs[0].ResolvePorts(ctx, standaloneServices)
+		if err != nil {
+			return fmt.Errorf("resolve service ports: %w", err)
+		}
+	}
+	plan, err := trafficbuilder.BuildPlan(input)
 	if err != nil {
 		return fmt.Errorf("build traffic graph: %w", err)
 	}

--- a/internal/app/traffic_test.go
+++ b/internal/app/traffic_test.go
@@ -155,6 +155,29 @@ func TestApplyTrafficRuntimeConfigPassesStandaloneServicesToBuilder(t *testing.T
 	assert.True(t, status.EntryPoints[0].Active)
 }
 
+func TestApplyTrafficRuntimeConfigValidatesRoutesBeforeServiceReconciliation(t *testing.T) {
+	cfg := Config{Services: map[string]servicecfg.Config{
+		"app": {
+			Image: "localhost/app:latest",
+			Ports: map[string]servicecfg.PortConfig{
+				"web": {Container: 8080, Protocol: domain.ServicePortProtocolHTTP},
+			},
+		},
+	}}
+	configSvc := inmocks.NewMockConfigService(t)
+	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
+	configSvc.EXPECT().GetExternalRoutes().Return(nil)
+	configSvc.EXPECT().GetServiceRoutes().Return([]domain.HTTPServiceRoute{{
+		Domain: "app.example.com", Service: "missing", PortName: "web", HTTPS: true,
+	}})
+	serviceSvc := &standaloneServiceRecorder{}
+
+	err := applyTrafficRuntimeConfig(context.Background(), nil, cfg, configSvc, nil, serviceSvc)
+
+	require.ErrorContains(t, err, `unknown service "missing"`)
+	require.Zero(t, serviceSvc.Calls())
+}
+
 func TestApplyTrafficRuntimeConfigAppliesCustomL4Entrypoint(t *testing.T) {
 	manager := trafficadapter.NewManager()
 	defer func() { require.NoError(t, manager.Shutdown(context.Background())) }()

--- a/internal/app/traffic_test.go
+++ b/internal/app/traffic_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	trafficadapter "github.com/bnema/gordon/internal/adapters/in/traffic"
@@ -104,13 +105,14 @@ func TestApplyTrafficRuntimeConfigAppliesSmartTCPEntrypointWithRawFallbackPolicy
 			Ports: []traffic.PortConfig{{Name: "ssh", Container: 22, Protocol: domain.NetworkProtocolTCP}},
 		}},
 	}
-	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "ssh", EntryPoint: traffic.DefaultEdgeEntryPointName, Service: "network_service:ssh:ssh"}}
+	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "ssh", EntryPoint: traffic.DefaultEdgeEntryPointName, NetworkService: "ssh", Port: "ssh"}}
 
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return([]domain.Route{{Domain: "app.example.com", HTTPS: true}})
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, traffic.DefaultEdgeEntryPointName, status.EntryPoints[0].Name)
@@ -125,20 +127,28 @@ func TestApplyTrafficRuntimeConfigPassesStandaloneServicesToBuilder(t *testing.T
 		EntryPoints: map[string]traffic.EntryPointConfig{
 			"rust": {Address: freeUDPAddress(t), Protocol: domain.EntryPointProtocolUDP},
 		},
-		Services: []servicecfg.Config{{
-			Name:    "rust",
-			Image:   "localhost/rust:latest",
-			Enabled: true,
-			Ports:   []servicecfg.PortConfig{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolUDP, Publish: "127.0.0.1:38015"}},
-		}},
+		Services: map[string]servicecfg.Config{
+			"rust": {
+				Image: "localhost/rust:latest",
+				Ports: map[string]servicecfg.PortConfig{
+					"game": {Container: 28015, Protocol: domain.ServicePortProtocolUDP},
+				},
+			},
+		},
 	}
-	cfg.Traffic.UDP.Routers = []traffic.RouterConfig{{Name: "rust-game", EntryPoint: "rust", Service: "service:rust:game"}}
+	cfg.Traffic.UDP.Routers = []traffic.RouterConfig{{Name: "rust-game", EntryPoint: "rust", Service: "rust", Port: "game"}}
 
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
+	serviceSvc := inmocks.NewMockStandaloneServiceService(t)
+	serviceSvc.EXPECT().Reconcile(context.Background(), mock.Anything).Return(nil)
+	serviceSvc.EXPECT().ResolvePorts(context.Background(), mock.Anything).Return([]domain.ServicePortBackend{{
+		Service: "rust", PortName: "game", Host: "127.0.0.1", Port: 38015, Protocol: domain.ServicePortProtocolUDP,
+	}}, nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil, serviceSvc))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, "rust", status.EntryPoints[0].Name)
@@ -157,13 +167,14 @@ func TestApplyTrafficRuntimeConfigAppliesCustomL4Entrypoint(t *testing.T) {
 			Ports: []traffic.PortConfig{{Name: "db", Container: 5432, Protocol: domain.NetworkProtocolTCP}},
 		}},
 	}
-	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "postgres", EntryPoint: "postgres", Service: "network_service:postgres:db"}}
+	cfg.Traffic.TCP.Routers = []traffic.RouterConfig{{Name: "postgres", EntryPoint: "postgres", NetworkService: "postgres", Port: "db"}}
 
 	configSvc := inmocks.NewMockConfigService(t)
 	configSvc.EXPECT().GetRoutes(context.Background()).Return(nil)
 	configSvc.EXPECT().GetExternalRoutes().Return(nil)
+	configSvc.EXPECT().GetServiceRoutes().Return(nil)
 
-	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc))
+	require.NoError(t, applyTrafficRuntimeConfig(context.Background(), manager, cfg, configSvc, nil))
 	status := manager.Status()
 	require.Len(t, status.EntryPoints, 1)
 	assert.Equal(t, "postgres", status.EntryPoints[0].Name)

--- a/internal/boundaries/in/config.go
+++ b/internal/boundaries/in/config.go
@@ -15,10 +15,13 @@ type ConfigService interface {
 	// This is different from Load() which only loads from the cached viper values.
 	Reload(ctx context.Context) error
 
-	// GetRoutes returns all configured routes.
+	// GetRoutes returns image-backed routes that own route containers.
 	GetRoutes(ctx context.Context) []domain.Route
 
-	// GetRoute returns a single route by domain.
+	// GetServiceRoutes returns HTTP bindings to named Gordon-owned service ports.
+	GetServiceRoutes() []domain.HTTPServiceRoute
+
+	// GetRoute returns a single image-backed route by domain.
 	GetRoute(ctx context.Context, domain string) (*domain.Route, error)
 
 	// FindRoutesByImage returns all routes that match the given image name.

--- a/internal/boundaries/in/mocks/mock_backup_service.go
+++ b/internal/boundaries/in/mocks/mock_backup_service.go
@@ -165,8 +165,8 @@ func (_c *MockBackupService_ListBackups_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *MockBackupService_ListBackups_Call) Return(vs []domain.DatabaseBackupJob, err error) *MockBackupService_ListBackups_Call {
-	_c.Call.Return(vs, err)
+func (_c *MockBackupService_ListBackups_Call) Return(databaseBackupJobs []domain.DatabaseBackupJob, err error) *MockBackupService_ListBackups_Call {
+	_c.Call.Return(databaseBackupJobs, err)
 	return _c
 }
 
@@ -365,8 +365,8 @@ func (_c *MockBackupService_RunBackup_Call) Run(run func(ctx context.Context, do
 	return _c
 }
 
-func (_c *MockBackupService_RunBackup_Call) Return(v *domain.DatabaseBackupResult, err error) *MockBackupService_RunBackup_Call {
-	_c.Call.Return(v, err)
+func (_c *MockBackupService_RunBackup_Call) Return(databaseBackupResult *domain.DatabaseBackupResult, err error) *MockBackupService_RunBackup_Call {
+	_c.Call.Return(databaseBackupResult, err)
 	return _c
 }
 
@@ -427,8 +427,8 @@ func (_c *MockBackupService_Status_Call) Run(run func(ctx context.Context)) *Moc
 	return _c
 }
 
-func (_c *MockBackupService_Status_Call) Return(vs []domain.DatabaseBackupJob, err error) *MockBackupService_Status_Call {
-	_c.Call.Return(vs, err)
+func (_c *MockBackupService_Status_Call) Return(databaseBackupJobs []domain.DatabaseBackupJob, err error) *MockBackupService_Status_Call {
+	_c.Call.Return(databaseBackupJobs, err)
 	return _c
 }
 

--- a/internal/boundaries/in/mocks/mock_config_service.go
+++ b/internal/boundaries/in/mocks/mock_config_service.go
@@ -1039,6 +1039,52 @@ func (_c *MockConfigService_GetServerPort_Call) RunAndReturn(run func() int) *Mo
 	return _c
 }
 
+// GetServiceRoutes provides a mock function for the type MockConfigService
+func (_mock *MockConfigService) GetServiceRoutes() []domain.HTTPServiceRoute {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetServiceRoutes")
+	}
+
+	var r0 []domain.HTTPServiceRoute
+	if returnFunc, ok := ret.Get(0).(func() []domain.HTTPServiceRoute); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]domain.HTTPServiceRoute)
+		}
+	}
+	return r0
+}
+
+// MockConfigService_GetServiceRoutes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetServiceRoutes'
+type MockConfigService_GetServiceRoutes_Call struct {
+	*mock.Call
+}
+
+// GetServiceRoutes is a helper method to define mock.On call
+func (_e *MockConfigService_Expecter) GetServiceRoutes() *MockConfigService_GetServiceRoutes_Call {
+	return &MockConfigService_GetServiceRoutes_Call{Call: _e.mock.On("GetServiceRoutes")}
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) Run(run func()) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) Return(hTTPServiceRoutes []domain.HTTPServiceRoute) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Return(hTTPServiceRoutes)
+	return _c
+}
+
+func (_c *MockConfigService_GetServiceRoutes_Call) RunAndReturn(run func() []domain.HTTPServiceRoute) *MockConfigService_GetServiceRoutes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsAutoEnabled provides a mock function for the type MockConfigService
 func (_mock *MockConfigService) IsAutoEnabled() bool {
 	ret := _mock.Called()

--- a/internal/boundaries/in/mocks/mock_standalone_service_service.go
+++ b/internal/boundaries/in/mocks/mock_standalone_service_service.go
@@ -95,6 +95,74 @@ func (_c *MockStandaloneServiceService_Reconcile_Call) RunAndReturn(run func(ctx
 	return _c
 }
 
+// ResolvePorts provides a mock function for the type MockStandaloneServiceService
+func (_mock *MockStandaloneServiceService) ResolvePorts(ctx context.Context, services []domain.StandaloneService) ([]domain.ServicePortBackend, error) {
+	ret := _mock.Called(ctx, services)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolvePorts")
+	}
+
+	var r0 []domain.ServicePortBackend
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []domain.StandaloneService) ([]domain.ServicePortBackend, error)); ok {
+		return returnFunc(ctx, services)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []domain.StandaloneService) []domain.ServicePortBackend); ok {
+		r0 = returnFunc(ctx, services)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]domain.ServicePortBackend)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []domain.StandaloneService) error); ok {
+		r1 = returnFunc(ctx, services)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStandaloneServiceService_ResolvePorts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolvePorts'
+type MockStandaloneServiceService_ResolvePorts_Call struct {
+	*mock.Call
+}
+
+// ResolvePorts is a helper method to define mock.On call
+//   - ctx context.Context
+//   - services []domain.StandaloneService
+func (_e *MockStandaloneServiceService_Expecter) ResolvePorts(ctx any, services any) *MockStandaloneServiceService_ResolvePorts_Call {
+	return &MockStandaloneServiceService_ResolvePorts_Call{Call: _e.mock.On("ResolvePorts", ctx, services)}
+}
+
+func (_c *MockStandaloneServiceService_ResolvePorts_Call) Run(run func(ctx context.Context, services []domain.StandaloneService)) *MockStandaloneServiceService_ResolvePorts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []domain.StandaloneService
+		if args[1] != nil {
+			arg1 = args[1].([]domain.StandaloneService)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStandaloneServiceService_ResolvePorts_Call) Return(servicePortBackends []domain.ServicePortBackend, err error) *MockStandaloneServiceService_ResolvePorts_Call {
+	_c.Call.Return(servicePortBackends, err)
+	return _c
+}
+
+func (_c *MockStandaloneServiceService_ResolvePorts_Call) RunAndReturn(run func(ctx context.Context, services []domain.StandaloneService) ([]domain.ServicePortBackend, error)) *MockStandaloneServiceService_ResolvePorts_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Status provides a mock function for the type MockStandaloneServiceService
 func (_mock *MockStandaloneServiceService) Status(ctx context.Context) ([]domain.StandaloneServiceStatus, error) {
 	ret := _mock.Called(ctx)

--- a/internal/boundaries/in/services.go
+++ b/internal/boundaries/in/services.go
@@ -12,5 +12,6 @@ import (
 // StandaloneServiceService defines standalone service lifecycle operations.
 type StandaloneServiceService interface {
 	Reconcile(ctx context.Context, services []domain.StandaloneService) error
+	ResolvePorts(ctx context.Context, services []domain.StandaloneService) ([]domain.ServicePortBackend, error)
 	Status(ctx context.Context) ([]domain.StandaloneServiceStatus, error)
 }

--- a/internal/boundaries/out/mocks/mock_backup_storage.go
+++ b/internal/boundaries/out/mocks/mock_backup_storage.go
@@ -301,8 +301,8 @@ func (_c *MockBackupStorage_List_Call) Run(run func(ctx context.Context, domainN
 	return _c
 }
 
-func (_c *MockBackupStorage_List_Call) Return(vs []domain.DatabaseBackupJob, err error) *MockBackupStorage_List_Call {
-	_c.Call.Return(vs, err)
+func (_c *MockBackupStorage_List_Call) Return(databaseBackupJobs []domain.DatabaseBackupJob, err error) *MockBackupStorage_List_Call {
+	_c.Call.Return(databaseBackupJobs, err)
 	return _c
 }
 

--- a/internal/boundaries/out/mocks/mock_blob_storage.go
+++ b/internal/boundaries/out/mocks/mock_blob_storage.go
@@ -469,6 +469,66 @@ func (_c *MockBlobStorage_GetBlob_Call) RunAndReturn(run func(digest string) (io
 	return _c
 }
 
+// GetBlobModTime provides a mock function for the type MockBlobStorage
+func (_mock *MockBlobStorage) GetBlobModTime(digest string) (time.Time, error) {
+	ret := _mock.Called(digest)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBlobModTime")
+	}
+
+	var r0 time.Time
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (time.Time, error)); ok {
+		return returnFunc(digest)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) time.Time); ok {
+		r0 = returnFunc(digest)
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(digest)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlobStorage_GetBlobModTime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBlobModTime'
+type MockBlobStorage_GetBlobModTime_Call struct {
+	*mock.Call
+}
+
+// GetBlobModTime is a helper method to define mock.On call
+//   - digest string
+func (_e *MockBlobStorage_Expecter) GetBlobModTime(digest any) *MockBlobStorage_GetBlobModTime_Call {
+	return &MockBlobStorage_GetBlobModTime_Call{Call: _e.mock.On("GetBlobModTime", digest)}
+}
+
+func (_c *MockBlobStorage_GetBlobModTime_Call) Run(run func(digest string)) *MockBlobStorage_GetBlobModTime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobStorage_GetBlobModTime_Call) Return(time1 time.Time, err error) *MockBlobStorage_GetBlobModTime_Call {
+	_c.Call.Return(time1, err)
+	return _c
+}
+
+func (_c *MockBlobStorage_GetBlobModTime_Call) RunAndReturn(run func(digest string) (time.Time, error)) *MockBlobStorage_GetBlobModTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBlobPath provides a mock function for the type MockBlobStorage
 func (_mock *MockBlobStorage) GetBlobPath(digest string) (string, error) {
 	ret := _mock.Called(digest)
@@ -642,63 +702,6 @@ func (_c *MockBlobStorage_ListBlobs_Call) Return(strings []string, err error) *M
 }
 
 func (_c *MockBlobStorage_ListBlobs_Call) RunAndReturn(run func() ([]string, error)) *MockBlobStorage_ListBlobs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBlobModTime provides a mock function for the type MockBlobStorage.
-func (_mock *MockBlobStorage) GetBlobModTime(digest string) (time.Time, error) {
-	ret := _mock.Called(digest)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBlobModTime")
-	}
-
-	var r0 time.Time
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (time.Time, error)); ok {
-		return returnFunc(digest)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) time.Time); ok {
-		r0 = returnFunc(digest)
-	} else if ret.Get(0) != nil {
-		r0 = ret.Get(0).(time.Time)
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(digest)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockBlobStorage_GetBlobModTime_Call is a typed expectation for GetBlobModTime.
-type MockBlobStorage_GetBlobModTime_Call struct {
-	*mock.Call
-}
-
-// GetBlobModTime is a helper method to define mock.On call.
-func (_e *MockBlobStorage_Expecter) GetBlobModTime(digest any) *MockBlobStorage_GetBlobModTime_Call {
-	return &MockBlobStorage_GetBlobModTime_Call{Call: _e.mock.On("GetBlobModTime", digest)}
-}
-
-func (_c *MockBlobStorage_GetBlobModTime_Call) Run(run func(digest string)) *MockBlobStorage_GetBlobModTime_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockBlobStorage_GetBlobModTime_Call) Return(modTime time.Time, err error) *MockBlobStorage_GetBlobModTime_Call {
-	_c.Call.Return(modTime, err)
-	return _c
-}
-
-func (_c *MockBlobStorage_GetBlobModTime_Call) RunAndReturn(run func(digest string) (time.Time, error)) *MockBlobStorage_GetBlobModTime_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/boundaries/out/mocks/mock_container_runtime.go
+++ b/internal/boundaries/out/mocks/mock_container_runtime.go
@@ -926,6 +926,84 @@ func (_c *MockContainerRuntime_GetContainerPort_Call) RunAndReturn(run func(ctx 
 	return _c
 }
 
+// GetContainerPublishedPort provides a mock function for the type MockContainerRuntime
+func (_mock *MockContainerRuntime) GetContainerPublishedPort(ctx context.Context, containerID string, internalPort int, protocol domain.NetworkProtocol) (int, error) {
+	ret := _mock.Called(ctx, containerID, internalPort, protocol)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetContainerPublishedPort")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, domain.NetworkProtocol) (int, error)); ok {
+		return returnFunc(ctx, containerID, internalPort, protocol)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, domain.NetworkProtocol) int); ok {
+		r0 = returnFunc(ctx, containerID, internalPort, protocol)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, domain.NetworkProtocol) error); ok {
+		r1 = returnFunc(ctx, containerID, internalPort, protocol)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockContainerRuntime_GetContainerPublishedPort_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetContainerPublishedPort'
+type MockContainerRuntime_GetContainerPublishedPort_Call struct {
+	*mock.Call
+}
+
+// GetContainerPublishedPort is a helper method to define mock.On call
+//   - ctx context.Context
+//   - containerID string
+//   - internalPort int
+//   - protocol domain.NetworkProtocol
+func (_e *MockContainerRuntime_Expecter) GetContainerPublishedPort(ctx any, containerID any, internalPort any, protocol any) *MockContainerRuntime_GetContainerPublishedPort_Call {
+	return &MockContainerRuntime_GetContainerPublishedPort_Call{Call: _e.mock.On("GetContainerPublishedPort", ctx, containerID, internalPort, protocol)}
+}
+
+func (_c *MockContainerRuntime_GetContainerPublishedPort_Call) Run(run func(ctx context.Context, containerID string, internalPort int, protocol domain.NetworkProtocol)) *MockContainerRuntime_GetContainerPublishedPort_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
+		var arg3 domain.NetworkProtocol
+		if args[3] != nil {
+			arg3 = args[3].(domain.NetworkProtocol)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerRuntime_GetContainerPublishedPort_Call) Return(n int, err error) *MockContainerRuntime_GetContainerPublishedPort_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockContainerRuntime_GetContainerPublishedPort_Call) RunAndReturn(run func(ctx context.Context, containerID string, internalPort int, protocol domain.NetworkProtocol) (int, error)) *MockContainerRuntime_GetContainerPublishedPort_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetImageExposedPorts provides a mock function for the type MockContainerRuntime
 func (_mock *MockContainerRuntime) GetImageExposedPorts(ctx context.Context, imageRef string) ([]int, error) {
 	ret := _mock.Called(ctx, imageRef)

--- a/internal/boundaries/out/runtime.go
+++ b/internal/boundaries/out/runtime.go
@@ -42,6 +42,7 @@ type ContainerRuntime interface {
 	IsContainerRunning(ctx context.Context, containerID string) (bool, error)
 	GetContainerHealthStatus(ctx context.Context, containerID string) (status string, hasHealthcheck bool, err error)
 	GetContainerPort(ctx context.Context, containerID string, internalPort int) (int, error)
+	GetContainerPublishedPort(ctx context.Context, containerID string, internalPort int, protocol domain.NetworkProtocol) (int, error)
 
 	// Image and port inspection
 	GetImageExposedPorts(ctx context.Context, imageRef string) ([]int, error)

--- a/internal/domain/labels.go
+++ b/internal/domain/labels.go
@@ -18,6 +18,7 @@ const (
 	// Standalone service labels identify Gordon-managed L4 service containers.
 	LabelService                       = "gordon.service"
 	LabelServiceName                   = "gordon.service.name"
+	LabelServiceContainer              = "gordon.service.container"
 	LabelServiceConfigHash             = "gordon.service.config-hash"
 	LabelServiceManagedVolumes         = "gordon.service.managed-volumes"
 	LabelServiceCleanupPreserveVolumes = "gordon.service.cleanup.preserve-volumes"

--- a/internal/domain/route.go
+++ b/internal/domain/route.go
@@ -1,11 +1,22 @@
 package domain
 
-// Route represents a mapping from a domain to a container image.
+// Route binds an HTTP hostname to a named port on a Gordon-owned service.
 type Route struct {
-	Domain string
-	Image  string
-	HTTPS  bool
-	Env    []string // Pre-resolved env vars ("KEY=VALUE"); when set, Deploy skips EnvLoader lookup.
+	Domain   string
+	Service  string
+	PortName string
+	Image    string // Removed public model; retained temporarily while route-owned deployment code is migrated.
+	HTTPS    bool
+	Env      []string // Pre-resolved env vars ("KEY=VALUE"); when set, Deploy skips EnvLoader lookup.
+}
+
+// HTTPServiceRoute maps a hostname to a named port on a Gordon-owned service.
+// It binds HTTP traffic but does not own a separate route container.
+type HTTPServiceRoute struct {
+	Domain   string
+	Service  string
+	PortName string
+	HTTPS    bool
 }
 
 // ProxyTarget represents the destination for proxying requests.
@@ -13,10 +24,11 @@ type ProxyTarget struct {
 	Host         string
 	Port         int
 	ContainerID  string
-	Scheme       string // "http" or "https"
-	Protocol     string // "" (default HTTP/1.1) or "h2c" (cleartext HTTP/2)
-	OriginalHost string // Original hostname before DNS resolution (for external-route Host header)
-	RouteHost    string // Canonical matched route domain for managed-route Host header
+	Scheme       string   // "http" or "https"
+	Protocol     string   // "" (default HTTP/1.1) or "h2c" (cleartext HTTP/2)
+	OriginalHost string   // Original hostname before DNS resolution (for external-route Host header)
+	RouteHost    string   // Canonical matched route domain for managed-route Host header
+	TrustedCIDRs []string // Direct peers allowed to access a private service port
 }
 
 // RouteMatch represents the result of matching a request to a route.

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -161,10 +161,37 @@ func validateStandaloneServiceIdentity(s StandaloneService) error {
 		if _, exists := containerNames[container.Name]; exists {
 			return fmt.Errorf("standalone service %q duplicate container %q", s.Name, container.Name)
 		}
+		if err := validateStandaloneServiceContainer(s.Name, container); err != nil {
+			return err
+		}
 		containerNames[container.Name] = struct{}{}
 	}
-	if s.EnvFile != "" && strings.TrimSpace(s.EnvFile) == "" {
-		return fmt.Errorf("standalone service %q env_file must be non-empty when set", s.Name)
+	return validateStandaloneServiceEnvFile(s.Name, s.EnvFile)
+}
+
+func validateStandaloneServiceContainer(serviceName string, container StandaloneServiceContainer) error {
+	owner := serviceName + "." + container.Name
+	if err := validateStandaloneServiceEnvFile(owner, container.EnvFile); err != nil {
+		return err
+	}
+	nested := StandaloneService{
+		Name:      owner,
+		Secrets:   container.Secrets,
+		Readiness: container.Readiness,
+		Volumes:   container.Volumes,
+	}
+	if err := validateStandaloneServiceVolumes(nested); err != nil {
+		return err
+	}
+	if err := validateStandaloneServiceSecrets(nested); err != nil {
+		return err
+	}
+	return validateStandaloneServiceReadiness(nested)
+}
+
+func validateStandaloneServiceEnvFile(serviceName, envFile string) error {
+	if envFile != "" && strings.TrimSpace(envFile) == "" {
+		return fmt.Errorf("standalone service %q env_file must be non-empty when set", serviceName)
 	}
 	return nil
 }

--- a/internal/domain/service.go
+++ b/internal/domain/service.go
@@ -15,21 +15,53 @@ const (
 	StandaloneServiceReadinessLog  = "log"
 )
 
+// ServicePortProtocol describes what an application speaks on a named port.
+type ServicePortProtocol string
+
+const (
+	ServicePortProtocolHTTP ServicePortProtocol = "http"
+	ServicePortProtocolTCP  ServicePortProtocol = "tcp"
+	ServicePortProtocolUDP  ServicePortProtocol = "udp"
+)
+
 type StandaloneService struct {
+	Name          string
+	Image         string // Single-container shorthand.
+	Containers    []StandaloneServiceContainer
+	Enabled       bool
+	ContainerName string // Normalized runtime component name.
+	NetworkName   string // Normalized private service network.
+	Env           []string
+	EnvFile       string
+	Secrets       []StandaloneServiceSecretRef
+	Readiness     StandaloneServiceReadiness
+	Cleanup       StandaloneServiceCleanup
+	Ports         []StandaloneServicePort
+	Volumes       []StandaloneServiceVolume
+}
+
+type StandaloneServiceContainer struct {
 	Name      string
 	Image     string
-	Enabled   bool
 	Env       []string
 	EnvFile   string
 	Secrets   []StandaloneServiceSecretRef
 	Readiness StandaloneServiceReadiness
-	Cleanup   StandaloneServiceCleanup
-	Ports     []StandaloneServicePort
 	Volumes   []StandaloneServiceVolume
+}
+
+type ServicePortBackend struct {
+	Service  string
+	PortName string
+	Host     string
+	Port     int
+	Protocol ServicePortProtocol
+	TLS      bool
 }
 
 type StandaloneServiceStatus struct {
 	Name          string
+	ComponentName string
 	ContainerID   string
 	ContainerName string
 	Status        ContainerStatus
@@ -37,13 +69,15 @@ type StandaloneServiceStatus struct {
 }
 
 type StandaloneServicePort struct {
-	Name         string
-	Container    int
-	Protocol     NetworkProtocol
-	Publish      string
-	Private      bool
-	Public       bool
-	TrustedCIDRs []string
+	Name          string
+	ContainerName string
+	Container     int
+	Protocol      ServicePortProtocol
+	TLS           bool
+	Publish       string
+	Private       bool
+	Public        bool
+	TrustedCIDRs  []string
 }
 
 type StandaloneServiceVolume struct {
@@ -87,18 +121,8 @@ func (c StandaloneServiceCleanup) WithDefaults() StandaloneServiceCleanup {
 
 func (s StandaloneService) Validate() error {
 	s = s.WithDefaults()
-	name := strings.TrimSpace(s.Name)
-	if name == "" {
-		return fmt.Errorf("standalone service name is required")
-	}
-	if s.Name != name {
-		return fmt.Errorf("standalone service name %q must not include leading or trailing whitespace", s.Name)
-	}
-	if s.Enabled && strings.TrimSpace(s.Image) == "" {
-		return fmt.Errorf("standalone service %q image is required when enabled", s.Name)
-	}
-	if s.EnvFile != "" && strings.TrimSpace(s.EnvFile) == "" {
-		return fmt.Errorf("standalone service %q env_file must be non-empty when set", s.Name)
+	if err := validateStandaloneServiceIdentity(s); err != nil {
+		return err
 	}
 	if err := validateStandaloneServicePorts(s); err != nil {
 		return err
@@ -115,8 +139,42 @@ func (s StandaloneService) Validate() error {
 	return nil
 }
 
+func validateStandaloneServiceIdentity(s StandaloneService) error {
+	name := strings.TrimSpace(s.Name)
+	if name == "" {
+		return fmt.Errorf("standalone service name is required")
+	}
+	if s.Name != name {
+		return fmt.Errorf("standalone service name %q must not include leading or trailing whitespace", s.Name)
+	}
+	if s.Enabled && strings.TrimSpace(s.Image) == "" && len(s.Containers) == 0 {
+		return fmt.Errorf("standalone service %q image or containers are required when enabled", s.Name)
+	}
+	if strings.TrimSpace(s.Image) != "" && len(s.Containers) > 0 {
+		return fmt.Errorf("standalone service %q cannot define both image and containers", s.Name)
+	}
+	containerNames := make(map[string]struct{}, len(s.Containers))
+	for _, container := range s.Containers {
+		if strings.TrimSpace(container.Name) == "" || strings.TrimSpace(container.Image) == "" {
+			return fmt.Errorf("standalone service %q containers require a name and image", s.Name)
+		}
+		if _, exists := containerNames[container.Name]; exists {
+			return fmt.Errorf("standalone service %q duplicate container %q", s.Name, container.Name)
+		}
+		containerNames[container.Name] = struct{}{}
+	}
+	if s.EnvFile != "" && strings.TrimSpace(s.EnvFile) == "" {
+		return fmt.Errorf("standalone service %q env_file must be non-empty when set", s.Name)
+	}
+	return nil
+}
+
 func validateStandaloneServicePorts(s StandaloneService) error {
 	seen := make(map[string]struct{}, len(s.Ports))
+	containerNames := make(map[string]struct{}, len(s.Containers))
+	for _, container := range s.Containers {
+		containerNames[container.Name] = struct{}{}
+	}
 	for i, port := range s.Ports {
 		name, err := validateStandaloneServicePort(s.Name, i, port)
 		if err != nil {
@@ -124,6 +182,11 @@ func validateStandaloneServicePorts(s StandaloneService) error {
 		}
 		if _, ok := seen[name]; ok {
 			return fmt.Errorf("standalone service %q duplicate port name %q", s.Name, name)
+		}
+		if len(containerNames) > 0 {
+			if _, ok := containerNames[port.ContainerName]; !ok {
+				return fmt.Errorf("standalone service %q port %q references unknown container %q", s.Name, name, port.ContainerName)
+			}
 		}
 		seen[name] = struct{}{}
 	}
@@ -141,8 +204,11 @@ func validateStandaloneServicePort(serviceName string, index int, port Standalon
 	if port.Container <= 0 || port.Container > 65535 {
 		return "", fmt.Errorf("standalone service %q port %q container port must be 1-65535", serviceName, name)
 	}
-	if port.Protocol != NetworkProtocolTCP && port.Protocol != NetworkProtocolUDP {
-		return "", fmt.Errorf("standalone service %q port %q protocol must be tcp or udp", serviceName, name)
+	if !port.Protocol.Valid() {
+		return "", fmt.Errorf("standalone service %q port %q protocol must be http, tcp, or udp", serviceName, name)
+	}
+	if port.Protocol == ServicePortProtocolUDP && port.TLS {
+		return "", fmt.Errorf("standalone service %q port %q cannot enable TLS with UDP", serviceName, name)
 	}
 	if port.Private && port.Public {
 		return "", fmt.Errorf("standalone service %q port %q cannot be both private and public", serviceName, name)
@@ -159,6 +225,29 @@ func validateStandaloneServicePort(serviceName string, index int, port Standalon
 		return "", err
 	}
 	return name, nil
+}
+
+// Valid reports whether the service port protocol is supported.
+func (p ServicePortProtocol) Valid() bool {
+	switch p {
+	case ServicePortProtocolHTTP, ServicePortProtocolTCP, ServicePortProtocolUDP:
+		return true
+	default:
+		return false
+	}
+}
+
+// NetworkProtocol returns the underlying container transport.
+func (p ServicePortProtocol) NetworkProtocol() NetworkProtocol {
+	if p == ServicePortProtocolUDP {
+		return NetworkProtocolUDP
+	}
+	return NetworkProtocolTCP
+}
+
+// IsHTTP reports whether Gordon's HTTP reverse proxy can use the port.
+func (p ServicePortProtocol) IsHTTP() bool {
+	return p == ServicePortProtocolHTTP
 }
 
 func validateStandaloneServiceTrustedCIDRs(serviceName, portName string, cidrs []string) error {

--- a/internal/domain/service_test.go
+++ b/internal/domain/service_test.go
@@ -23,7 +23,7 @@ func TestStandaloneServiceValidateRejectsPaddedNames(t *testing.T) {
 		Name:    "cache",
 		Image:   "redis:7",
 		Enabled: true,
-		Ports:   []StandaloneServicePort{{Name: " admin ", Container: 6379, Protocol: NetworkProtocolTCP}},
+		Ports:   []StandaloneServicePort{{Name: " admin ", Container: 6379, Protocol: ServicePortProtocolTCP}},
 	}
 	require.ErrorContains(t, svc.Validate(), "leading or trailing whitespace")
 }
@@ -39,30 +39,30 @@ func TestStandaloneServiceValidatePorts(t *testing.T) {
 		Image:   "game:latest",
 		Enabled: true,
 		Ports: []StandaloneServicePort{
-			{Name: "game", Container: 28015, Protocol: NetworkProtocolUDP, Publish: "127.0.0.1:38015"},
-			{Name: "rcon", Container: 28016, Protocol: NetworkProtocolTCP, Publish: "127.0.0.1:38016", Private: true},
+			{Name: "game", Container: 28015, Protocol: ServicePortProtocolUDP, Publish: "127.0.0.1:38015"},
+			{Name: "rcon", Container: 28016, Protocol: ServicePortProtocolTCP, Publish: "127.0.0.1:38016", Private: true},
 		},
 	}
 	require.NoError(t, valid.Validate())
 
 	duplicate := valid
-	duplicate.Ports = append(duplicate.Ports, StandaloneServicePort{Name: "game", Container: 28017, Protocol: NetworkProtocolUDP})
+	duplicate.Ports = append(duplicate.Ports, StandaloneServicePort{Name: "game", Container: 28017, Protocol: ServicePortProtocolUDP})
 	require.ErrorContains(t, duplicate.Validate(), "duplicate port")
 
 	badProtocol := valid
-	badProtocol.Ports = []StandaloneServicePort{{Name: "game", Container: 28015, Protocol: NetworkProtocol("sctp")}}
+	badProtocol.Ports = []StandaloneServicePort{{Name: "game", Container: 28015, Protocol: ServicePortProtocol("sctp")}}
 	require.ErrorContains(t, badProtocol.Validate(), "protocol")
 
 	badPublish := valid
-	badPublish.Ports = []StandaloneServicePort{{Name: "game", Container: 28015, Protocol: NetworkProtocolUDP, Publish: "127.0.0.1:not-a-port"}}
+	badPublish.Ports = []StandaloneServicePort{{Name: "game", Container: 28015, Protocol: ServicePortProtocolUDP, Publish: "127.0.0.1:not-a-port"}}
 	require.ErrorContains(t, badPublish.Validate(), "valid port")
 
 	conflictingVisibility := valid
-	conflictingVisibility.Ports = []StandaloneServicePort{{Name: "rcon", Container: 28016, Protocol: NetworkProtocolTCP, Private: true, Public: true}}
+	conflictingVisibility.Ports = []StandaloneServicePort{{Name: "rcon", Container: 28016, Protocol: ServicePortProtocolTCP, Private: true, Public: true}}
 	require.ErrorContains(t, conflictingVisibility.Validate(), "cannot be both private and public")
 
 	privateNonLoopback := valid
-	privateNonLoopback.Ports = []StandaloneServicePort{{Name: "rcon", Container: 28016, Protocol: NetworkProtocolTCP, Private: true, Publish: "0.0.0.0:28016"}}
+	privateNonLoopback.Ports = []StandaloneServicePort{{Name: "rcon", Container: 28016, Protocol: ServicePortProtocolTCP, Private: true, Publish: "0.0.0.0:28016"}}
 	require.ErrorContains(t, privateNonLoopback.Validate(), "must be loopback")
 }
 

--- a/internal/domain/service_test.go
+++ b/internal/domain/service_test.go
@@ -133,3 +133,39 @@ func TestStandaloneServiceValidateRejectsDuplicateVolumeTargets(t *testing.T) {
 	}
 	require.ErrorContains(t, svc.Validate(), "duplicate volume target")
 }
+
+func TestStandaloneServiceValidateNestedContainerConfiguration(t *testing.T) {
+	base := StandaloneService{
+		Name:    "app",
+		Enabled: true,
+		Containers: []StandaloneServiceContainer{{
+			Name:  "web",
+			Image: "app:latest",
+		}},
+	}
+
+	tests := []struct {
+		name        string
+		configure   func(*StandaloneServiceContainer)
+		wantErrText string
+	}{
+		{name: "blank env file", configure: func(c *StandaloneServiceContainer) { c.EnvFile = "   " }, wantErrText: "env_file"},
+		{name: "missing secret name", configure: func(c *StandaloneServiceContainer) { c.Secrets = []StandaloneServiceSecretRef{{Key: "TOKEN"}} }, wantErrText: "secret"},
+		{name: "relative volume target", configure: func(c *StandaloneServiceContainer) { c.Volumes = []StandaloneServiceVolume{{Target: "data"}} }, wantErrText: "absolute"},
+		{name: "log readiness missing path", configure: func(c *StandaloneServiceContainer) {
+			c.Readiness = StandaloneServiceReadiness{Type: StandaloneServiceReadinessLog, Contains: "ready"}
+		}, wantErrText: "path"},
+		{name: "log readiness missing contains", configure: func(c *StandaloneServiceContainer) {
+			c.Readiness = StandaloneServiceReadiness{Type: StandaloneServiceReadinessLog, Path: "/tmp/app.log"}
+		}, wantErrText: "contains"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := base
+			svc.Containers = append([]StandaloneServiceContainer(nil), base.Containers...)
+			tt.configure(&svc.Containers[0])
+			require.ErrorContains(t, svc.Validate(), tt.wantErrText)
+		})
+	}
+}

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -55,8 +55,9 @@ type Config struct {
 }
 
 type routeConfig struct {
-	Image string `toml:"image"`
-	HTTPS bool   `toml:"https"`
+	Service  string `toml:"service"`
+	PortName string `toml:"port"`
+	HTTPS    bool   `toml:"https"`
 }
 
 // Service implements the ConfigService interface.
@@ -285,7 +286,7 @@ func loadCanonicalRoutes(raw any) (map[string]routeConfig, error) {
 
 	for key, value := range routes {
 		if strings.HasPrefix(key, "http://") {
-			continue
+			return nil, fmt.Errorf("route key %q uses removed http:// syntax; use the plain hostname and set https = false when needed", key)
 		}
 
 		route, err := parseCanonicalRouteEntry(key, value)
@@ -297,27 +298,6 @@ func loadCanonicalRoutes(raw any) (map[string]routeConfig, error) {
 			return nil, fmt.Errorf("duplicate route key %q canonicalizes to %q", key, canonicalKey)
 		}
 		result[canonicalKey] = route
-	}
-
-	for key, value := range routes {
-		if !strings.HasPrefix(key, "http://") {
-			continue
-		}
-
-		domainName := strings.TrimPrefix(key, "http://")
-		canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
-		if !ok {
-			return nil, fmt.Errorf("invalid route key %q: %w", legacyRouteStorageKey(domainName), domain.ErrRouteDomainInvalid)
-		}
-		if _, exists := result[canonicalDomain]; exists {
-			continue
-		}
-
-		route, err := parseLegacyRouteEntry(domainName, value)
-		if err != nil {
-			return nil, err
-		}
-		result[canonicalDomain] = route
 	}
 
 	return result, nil
@@ -332,51 +312,39 @@ func parseCanonicalRouteEntry(domainName string, raw any) (routeConfig, error) {
 
 	switch value := raw.(type) {
 	case string:
-		if value == "" {
-			return routeConfig{}, fmt.Errorf("route %q has empty image", domainName)
-		}
-		return routeConfig{Image: value, HTTPS: true}, nil
+		return routeConfig{}, fmt.Errorf("route %q uses removed image-backed string syntax; define [services.<name>] and bind it with { service = \"<name>\", port = \"<port>\" }", domainName)
 	case map[string]any:
 		return parseRouteTable(domainName, value)
 	default:
-		return routeConfig{}, fmt.Errorf("route %q has unsupported value type %T", domainName, raw)
+		return routeConfig{}, fmt.Errorf("route %q must be a table with non-empty service and port fields, got %T", domainName, raw)
 	}
-}
-
-func parseLegacyRouteEntry(domainName string, raw any) (routeConfig, error) {
-	canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
-	if !ok {
-		return routeConfig{}, fmt.Errorf("invalid route key %q: %w", legacyRouteStorageKey(domainName), domain.ErrRouteDomainInvalid)
-	}
-	domainName = canonicalDomain
-
-	value, ok := raw.(string)
-	if !ok {
-		return routeConfig{}, fmt.Errorf("legacy route %q must be a string", legacyRouteStorageKey(domainName))
-	}
-	if value == "" {
-		return routeConfig{}, fmt.Errorf("legacy route %q has empty image", legacyRouteStorageKey(domainName))
-	}
-
-	return routeConfig{Image: value, HTTPS: false}, nil
 }
 
 func parseRouteTable(domainName string, raw map[string]any) (routeConfig, error) {
-	imageValue, ok := raw["image"].(string)
-	if !ok || imageValue == "" {
-		return routeConfig{}, fmt.Errorf("route %q has invalid image field", domainName)
+	if _, exists := raw["image"]; exists {
+		return routeConfig{}, fmt.Errorf("route %q uses removed image-backed syntax; define the image under [services.<name>] and bind this route with service and port", domainName)
+	}
+	if _, exists := raw["target"]; exists {
+		return routeConfig{}, fmt.Errorf("route %q uses removed target syntax; replace target with explicit service and port fields", domainName)
+	}
+	serviceName, serviceOK := raw["service"].(string)
+	portName, portOK := raw["port"].(string)
+	if !serviceOK || strings.TrimSpace(serviceName) == "" || !portOK || strings.TrimSpace(portName) == "" {
+		return routeConfig{}, fmt.Errorf("route %q must define non-empty service and port fields", domainName)
+	}
+	if serviceName != strings.TrimSpace(serviceName) || portName != strings.TrimSpace(portName) {
+		return routeConfig{}, fmt.Errorf("route %q service and port must not contain leading or trailing whitespace", domainName)
 	}
 
-	httpsValue, ok := raw["https"]
-	if !ok {
-		return routeConfig{Image: imageValue, HTTPS: true}, nil
+	https := true
+	if httpsValue, ok := raw["https"]; ok {
+		var valid bool
+		https, valid = httpsValue.(bool)
+		if !valid {
+			return routeConfig{}, fmt.Errorf("route %q has invalid https field", domainName)
+		}
 	}
-	https, ok := httpsValue.(bool)
-	if !ok {
-		return routeConfig{}, fmt.Errorf("route %q has invalid https field", domainName)
-	}
-
-	return routeConfig{Image: imageValue, HTTPS: https}, nil
+	return routeConfig{Service: serviceName, PortName: portName, HTTPS: https}, nil
 }
 
 // GetRoutes returns all configured routes.
@@ -386,12 +354,26 @@ func (s *Service) GetRoutes(_ context.Context) []domain.Route {
 
 	var routes []domain.Route
 	for domainName, route := range s.config.Routes {
-		if strings.HasPrefix(domainName, "http://") {
-			continue
-		}
-		routes = append(routes, domain.Route{Domain: domainName, Image: route.Image, HTTPS: route.HTTPS})
+		routes = append(routes, domain.Route{
+			Domain: domainName, Service: route.Service, PortName: route.PortName, HTTPS: route.HTTPS,
+		})
 	}
+	slices.SortFunc(routes, func(a, b domain.Route) int { return cmp.Compare(a.Domain, b.Domain) })
+	return routes
+}
 
+// GetServiceRoutes returns HTTP bindings to named Gordon-owned service ports.
+func (s *Service) GetServiceRoutes() []domain.HTTPServiceRoute {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	routes := make([]domain.HTTPServiceRoute, 0)
+	for domainName, route := range s.config.Routes {
+		routes = append(routes, domain.HTTPServiceRoute{
+			Domain: domainName, Service: route.Service, PortName: route.PortName, HTTPS: route.HTTPS,
+		})
+	}
+	slices.SortFunc(routes, func(a, b domain.HTTPServiceRoute) int { return cmp.Compare(a.Domain, b.Domain) })
 	return routes
 }
 
@@ -409,7 +391,9 @@ func (s *Service) GetRoute(_ context.Context, domainName string) (*domain.Route,
 		return nil, domain.ErrRouteNotFound
 	}
 
-	routeValue := domain.Route{Domain: domainName, Image: routeCfg.Image, HTTPS: routeCfg.HTTPS}
+	routeValue := domain.Route{
+		Domain: domainName, Service: routeCfg.Service, PortName: routeCfg.PortName, HTTPS: routeCfg.HTTPS,
+	}
 	route := &routeValue
 
 	return route, nil
@@ -422,17 +406,7 @@ func (s *Service) FindRoutesByImage(_ context.Context, imageName string) []domai
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var routes []domain.Route
-	for domainName, route := range s.config.Routes {
-		if strings.HasPrefix(domainName, "http://") {
-			continue
-		}
-		if matchesImageName(imageName, route.Image, s.config.RegistryDomain, s.config.LegacyRegistryDomains) {
-			routes = append(routes, domain.Route{Domain: domainName, Image: route.Image, HTTPS: route.HTTPS})
-		}
-	}
-
-	return routes
+	return nil
 }
 
 // FindAttachmentTargetsByImage returns all attachment targets whose image matches the given image name.
@@ -546,8 +520,11 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 		return domain.ErrRouteDomainInvalid
 	}
 	route.Domain = canonicalDomain
-	if route.Image == "" {
-		return domain.ErrRouteImageEmpty
+	if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
+		return fmt.Errorf("route %q requires non-empty service and port", route.Domain)
+	}
+	if route.Image != "" {
+		return fmt.Errorf("route %q cannot own an image; define the image under [services.%s]", route.Domain, route.Service)
 	}
 
 	// Store previous value for rollback
@@ -563,7 +540,7 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 	previousCanonicalRoute, canonicalExisted := currentConfig.Routes[route.Domain]
 	legacyKey := legacyRouteStorageKey(route.Domain)
 	_, legacyExisted := currentConfig.Routes[legacyKey]
-	newRoute := routeConfig{Image: route.Image, HTTPS: route.HTTPS}
+	newRoute := routeConfig{Service: route.Service, PortName: route.PortName, HTTPS: route.HTTPS}
 	if canonicalExisted && previousCanonicalRoute == newRoute && !legacyExisted {
 		s.mu.Unlock()
 		return nil
@@ -586,7 +563,7 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 	s.config.Routes = nextRoutes
 	s.mu.Unlock()
 
-	log.Info().Str("image", route.Image).Msg("route added to configuration")
+	log.Info().Str("service", route.Service).Str("port", route.PortName).Msg("route added to configuration")
 	return nil
 }
 
@@ -608,8 +585,11 @@ func (s *Service) UpdateRoute(ctx context.Context, route domain.Route) error {
 		return domain.ErrRouteDomainInvalid
 	}
 	route.Domain = canonicalDomain
-	if route.Image == "" {
-		return domain.ErrRouteImageEmpty
+	if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
+		return fmt.Errorf("route %q requires non-empty service and port", route.Domain)
+	}
+	if route.Image != "" {
+		return fmt.Errorf("route %q cannot own an image; define the image under [services.%s]", route.Domain, route.Service)
 	}
 
 	// Store previous value for rollback
@@ -624,7 +604,8 @@ func (s *Service) UpdateRoute(ctx context.Context, route domain.Route) error {
 	legacyKey := legacyRouteStorageKey(route.Domain)
 	nextRoutes := cloneRouteConfigs(currentConfig.Routes)
 	delete(nextRoutes, legacyKey)
-	updatedRoute.Image = route.Image
+	updatedRoute.Service = route.Service
+	updatedRoute.PortName = route.PortName
 	updatedRoute.HTTPS = route.HTTPS
 	nextRoutes[route.Domain] = updatedRoute
 
@@ -640,7 +621,7 @@ func (s *Service) UpdateRoute(ctx context.Context, route domain.Route) error {
 	s.config.Routes = nextRoutes
 	s.mu.Unlock()
 
-	log.Info().Str("image", route.Image).Msg("route updated")
+	log.Info().Str("service", route.Service).Str("port", route.PortName).Msg("route updated")
 	return nil
 }
 
@@ -908,35 +889,17 @@ func canonicalRoutesForSave(routes map[string]routeConfig, registryDomain string
 		return result, nil
 	}
 
-	canonicalizeRoute := func(route routeConfig) routeConfig {
-		route.Image = domain.CanonicalizeGordonImageRef(route.Image, registryDomain, legacyRegistryDomains)
-		return route
-	}
-
 	for key, route := range routes {
 		if strings.HasPrefix(key, "http://") {
-			continue
+			return nil, fmt.Errorf("route key %q uses removed http:// syntax", key)
 		}
 		if !domain.IsValidRouteDomain(key) {
 			return nil, fmt.Errorf("invalid route key %q: %w", key, domain.ErrRouteDomainInvalid)
 		}
-		result[key] = canonicalizeRoute(route)
-	}
-
-	for key, route := range routes {
-		if !strings.HasPrefix(key, "http://") {
-			continue
+		if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
+			return nil, fmt.Errorf("route %q requires non-empty service and port", key)
 		}
-
-		domainName := strings.TrimPrefix(key, "http://")
-		if !domain.IsValidRouteDomain(domainName) {
-			return nil, fmt.Errorf("invalid route key %q: %w", key, domain.ErrRouteDomainInvalid)
-		}
-		if _, exists := result[domainName]; exists {
-			continue
-		}
-		route.HTTPS = false
-		result[domainName] = canonicalizeRoute(route)
+		result[key] = route
 	}
 
 	return result, nil
@@ -958,8 +921,10 @@ func renderCanonicalRoutesSection(routes map[string]routeConfig) string {
 	for _, key := range keys {
 		route := routes[key]
 		b.WriteString(strconv.Quote(key))
-		b.WriteString(" = { image = ")
-		b.WriteString(strconv.Quote(route.Image))
+		b.WriteString(" = { service = ")
+		b.WriteString(strconv.Quote(route.Service))
+		b.WriteString(", port = ")
+		b.WriteString(strconv.Quote(route.PortName))
 		b.WriteString(", https = ")
 		if route.HTTPS {
 			b.WriteString("true")

--- a/internal/usecase/config/service.go
+++ b/internal/usecase/config/service.go
@@ -347,19 +347,10 @@ func parseRouteTable(domainName string, raw map[string]any) (routeConfig, error)
 	return routeConfig{Service: serviceName, PortName: portName, HTTPS: https}, nil
 }
 
-// GetRoutes returns all configured routes.
+// GetRoutes returns container-owned routes. Keyed configuration defines none;
+// service bindings are exposed exclusively through GetServiceRoutes.
 func (s *Service) GetRoutes(_ context.Context) []domain.Route {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var routes []domain.Route
-	for domainName, route := range s.config.Routes {
-		routes = append(routes, domain.Route{
-			Domain: domainName, Service: route.Service, PortName: route.PortName, HTTPS: route.HTTPS,
-		})
-	}
-	slices.SortFunc(routes, func(a, b domain.Route) int { return cmp.Compare(a.Domain, b.Domain) })
-	return routes
+	return nil
 }
 
 // GetServiceRoutes returns HTTP bindings to named Gordon-owned service ports.
@@ -520,8 +511,8 @@ func (s *Service) AddRoute(ctx context.Context, route domain.Route) error {
 		return domain.ErrRouteDomainInvalid
 	}
 	route.Domain = canonicalDomain
-	if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
-		return fmt.Errorf("route %q requires non-empty service and port", route.Domain)
+	if err := validateRouteServiceReference(route.Domain, route.Service, route.PortName); err != nil {
+		return err
 	}
 	if route.Image != "" {
 		return fmt.Errorf("route %q cannot own an image; define the image under [services.%s]", route.Domain, route.Service)
@@ -585,8 +576,8 @@ func (s *Service) UpdateRoute(ctx context.Context, route domain.Route) error {
 		return domain.ErrRouteDomainInvalid
 	}
 	route.Domain = canonicalDomain
-	if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
-		return fmt.Errorf("route %q requires non-empty service and port", route.Domain)
+	if err := validateRouteServiceReference(route.Domain, route.Service, route.PortName); err != nil {
+		return err
 	}
 	if route.Image != "" {
 		return fmt.Errorf("route %q cannot own an image; define the image under [services.%s]", route.Domain, route.Service)
@@ -896,13 +887,25 @@ func canonicalRoutesForSave(routes map[string]routeConfig, registryDomain string
 		if !domain.IsValidRouteDomain(key) {
 			return nil, fmt.Errorf("invalid route key %q: %w", key, domain.ErrRouteDomainInvalid)
 		}
-		if strings.TrimSpace(route.Service) == "" || strings.TrimSpace(route.PortName) == "" {
-			return nil, fmt.Errorf("route %q requires non-empty service and port", key)
+		if err := validateRouteServiceReference(key, route.Service, route.PortName); err != nil {
+			return nil, err
 		}
 		result[key] = route
 	}
 
 	return result, nil
+}
+
+func validateRouteServiceReference(domainName, serviceName, portName string) error {
+	trimmedService := strings.TrimSpace(serviceName)
+	trimmedPort := strings.TrimSpace(portName)
+	if trimmedService == "" || trimmedPort == "" {
+		return fmt.Errorf("route %q requires non-empty service and port", domainName)
+	}
+	if serviceName != trimmedService || portName != trimmedPort {
+		return fmt.Errorf("route %q service and port must not contain leading or trailing whitespace", domainName)
+	}
+	return nil
 }
 
 func renderCanonicalRoutesSection(routes map[string]routeConfig) string {

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -52,8 +52,8 @@ func setupServiceWithCoexistingLegacyRoute(t *testing.T, canonicalImage, legacyI
 	if svc.config.Routes == nil {
 		svc.config.Routes = make(map[string]routeConfig)
 	}
-	svc.config.Routes["app.example.com"] = routeConfig{Image: canonicalImage, HTTPS: true}
-	svc.config.Routes["http://app.example.com"] = routeConfig{Image: legacyImage, HTTPS: false}
+	svc.config.Routes["app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: true}
+	svc.config.Routes["http://app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: false}
 	svc.mu.Unlock()
 
 	return svc, ctx
@@ -74,8 +74,8 @@ func TestService_Load(t *testing.T) {
 	v.Set("volumes.auto_create", true)
 	v.Set("volumes.prefix", "gordon")
 	v.Set("volumes.preserve", false)
-	v.Set("routes", map[string]interface{}{
-		"app.example.com": "myapp:latest",
+	v.Set("routes", map[string]any{
+		"app.example.com": map[string]any{"service": "app", "port": "web"},
 	})
 
 	eventBus := mocks.NewMockEventPublisher(t)
@@ -103,7 +103,7 @@ func TestService_Load_CanonicalInlineRoute(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "gordon.toml")
 	err := os.WriteFile(configFile, []byte(`[routes]
-"insecure.example.com" = { image = "myapp:latest", https = false }
+"insecure.example.com" = { service = "app", port = "web", https = false }
 `), 0600)
 	require.NoError(t, err)
 
@@ -120,7 +120,8 @@ func TestService_Load_CanonicalInlineRoute(t *testing.T) {
 
 	route, err := svc.GetRoute(ctx, "insecure.example.com")
 	require.NoError(t, err)
-	assert.Equal(t, "myapp:latest", route.Image)
+	assert.Equal(t, "app", route.Service)
+	assert.Equal(t, "web", route.PortName)
 	assert.False(t, route.HTTPS)
 }
 
@@ -128,7 +129,7 @@ func TestService_Load_CanonicalInlineRouteDefaultsHTTPS(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "gordon.toml")
 	err := os.WriteFile(configFile, []byte(`[routes]
-"secure.example.com" = { image = "myapp:latest" }
+"secure.example.com" = { service = "app", port = "web" }
 `), 0600)
 	require.NoError(t, err)
 
@@ -145,7 +146,8 @@ func TestService_Load_CanonicalInlineRouteDefaultsHTTPS(t *testing.T) {
 
 	route, err := svc.GetRoute(ctx, "secure.example.com")
 	require.NoError(t, err)
-	assert.Equal(t, "myapp:latest", route.Image)
+	assert.Equal(t, "app", route.Service)
+	assert.Equal(t, "web", route.PortName)
 	assert.True(t, route.HTTPS)
 }
 
@@ -153,7 +155,7 @@ func TestService_Reload_InvalidRouteKeyPreservesPreviousState(t *testing.T) {
 	tmpDir := t.TempDir()
 	configFile := filepath.Join(tmpDir, "gordon.toml")
 	initialConfig := `[routes]
-"app.example.com" = "myapp:v1"
+"app.example.com" = { service = "app", port = "web" }
 `
 	err := os.WriteFile(configFile, []byte(initialConfig), 0600)
 	require.NoError(t, err)
@@ -206,8 +208,8 @@ func TestService_FindRoutesByImage_DeduplicatesCanonicalAndLegacyEntries(t *test
 	_ = svc.Load(ctx)
 	svc.mu.Lock()
 	svc.config.Routes = make(map[string]routeConfig)
-	svc.config.Routes["app.example.com"] = routeConfig{Image: "registry.example.com/myapp:v2", HTTPS: true}
-	svc.config.Routes["http://app.example.com"] = routeConfig{Image: "myapp:v1", HTTPS: false}
+	svc.config.Routes["app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: true}
+	svc.config.Routes["http://app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: false}
 	svc.mu.Unlock()
 
 	routes := svc.FindRoutesByImage(ctx, "myapp")
@@ -220,24 +222,15 @@ func TestService_FindRoutesByImage_DeduplicatesCanonicalAndLegacyEntries(t *test
 
 func TestCanonicalRoutesForSave(t *testing.T) {
 	routes := map[string]routeConfig{
-		"legacy.example.com":             {Image: "old-registry.example.com/app:latest", HTTPS: true},
-		"current.example.com":            {Image: "registry.example.com/current:v1", HTTPS: true},
-		"bare.example.com":               {Image: "worker:v2", HTTPS: true},
-		"external.example.com":           {Image: "docker.io/library/nginx:latest", HTTPS: true},
-		"http://legacy-http.example.com": {Image: "old-registry.example.com:5000/http:v3", HTTPS: true},
+		"app.example.com":      {Service: "app", PortName: "web", HTTPS: true},
+		"worker.example.com":   {Service: "worker", PortName: "http", HTTPS: true},
+		"insecure.example.com": {Service: "legacy", PortName: "web", HTTPS: false},
 	}
 
 	savedRoutes, err := canonicalRoutesForSave(routes, "registry.example.com", []string{"old-registry.example.com", "old-registry.example.com:5000"})
 	require.NoError(t, err)
 
-	assert.Equal(t, routeConfig{Image: "registry.example.com/app:latest", HTTPS: true}, requireRoute(t, savedRoutes, "legacy.example.com"))
-	assert.Equal(t, routeConfig{Image: "registry.example.com/current:v1", HTTPS: true}, requireRoute(t, savedRoutes, "current.example.com"))
-	assert.Equal(t, routeConfig{Image: "worker:v2", HTTPS: true}, requireRoute(t, savedRoutes, "bare.example.com"))
-	assert.Equal(t, routeConfig{Image: "docker.io/library/nginx:latest", HTTPS: true}, requireRoute(t, savedRoutes, "external.example.com"))
-	assert.Equal(t, routeConfig{Image: "registry.example.com/http:v3", HTTPS: false}, requireRoute(t, savedRoutes, "legacy-http.example.com"))
-
-	assert.Equal(t, "old-registry.example.com/app:latest", routes["legacy.example.com"].Image)
-	assert.Equal(t, "old-registry.example.com:5000/http:v3", routes["http://legacy-http.example.com"].Image)
+	assert.Equal(t, routes, savedRoutes)
 }
 
 func TestService_AddRoute_StoresHTTPSFalseInCanonicalForm(t *testing.T) {
@@ -254,11 +247,12 @@ func TestService_AddRoute_StoresHTTPSFalseInCanonicalForm(t *testing.T) {
 
 	_ = svc.Load(ctx)
 
-	err = svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Image: "newapp:latest", HTTPS: false})
+	err = svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Service: "app", PortName: "web", HTTPS: false})
 	require.NoError(t, err)
 
 	routeCfg := requireRoute(t, svc.GetConfig().Routes, "new.example.com")
-	assert.Equal(t, "newapp:latest", routeCfg.Image)
+	assert.Equal(t, "app", routeCfg.Service)
+	assert.Equal(t, "web", routeCfg.PortName)
 	assert.False(t, routeCfg.HTTPS)
 }
 
@@ -298,46 +292,6 @@ legacy_registry_domains = ["old-registry.example.com"]
 	assert.Contains(t, text, `"new.example.com" = { image = "new:v1", https = false }`)
 	assert.NotContains(t, text, "http://insecure.example.com")
 	assert.Contains(t, text, "[routes]")
-}
-
-func TestService_SaveCanonicalizesRouteImages(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "gordon.toml")
-	initialConfig := `[server]
-gordon_domain = "registry.example.com"
-legacy_registry_domains = ["old-registry.example.com", "old-registry.example.com:5000"]
-
-[routes]
-"legacy.example.com" = "old-registry.example.com/app:latest"
-"legacy-port.example.com" = "old-registry.example.com:5000/api:v2"
-"current.example.com" = "registry.example.com/web:v3"
-"bare.example.com" = "worker:v4"
-"external.example.com" = "docker.io/library/nginx:latest"
-`
-	err := os.WriteFile(configFile, []byte(initialConfig), 0600)
-	require.NoError(t, err)
-
-	v := viper.New()
-	v.SetConfigFile(configFile)
-	require.NoError(t, v.ReadInConfig())
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
-	ctx := testContext()
-
-	require.NoError(t, svc.Load(ctx))
-	assert.Equal(t, "old-registry.example.com/app:latest", requireRoute(t, svc.GetConfig().Routes, "legacy.example.com").Image)
-
-	require.NoError(t, svc.Save(ctx))
-
-	content, err := os.ReadFile(configFile)
-	require.NoError(t, err)
-	text := string(content)
-	assert.Contains(t, text, `"legacy.example.com" = { image = "registry.example.com/app:latest", https = true }`)
-	assert.Contains(t, text, `"legacy-port.example.com" = { image = "registry.example.com/api:v2", https = true }`)
-	assert.Contains(t, text, `"current.example.com" = { image = "registry.example.com/web:v3", https = true }`)
-	assert.Contains(t, text, `"bare.example.com" = { image = "worker:v4", https = true }`)
-	assert.Contains(t, text, `"external.example.com" = { image = "docker.io/library/nginx:latest", https = true }`)
 }
 
 func TestCanonicalAttachmentsForSave(t *testing.T) {
@@ -443,7 +397,7 @@ func TestService_Reload(t *testing.T) {
 port = 8080
 
 [routes]
-"app.example.com" = "myapp:v1"
+"app.example.com" = { service = "app", port = "web" }
 `
 		err := os.WriteFile(configFile, []byte(initialConfig), 0600)
 		require.NoError(t, err)
@@ -462,7 +416,8 @@ port = 8080
 		require.NoError(t, err)
 		assert.Equal(t, 8080, svc.GetServerPort())
 		route := requireRoute(t, svc.GetConfig().Routes, "app.example.com")
-		assert.Equal(t, "myapp:v1", route.Image)
+		assert.Equal(t, "app", route.Service)
+		assert.Equal(t, "web", route.PortName)
 		assert.True(t, route.HTTPS)
 
 		// Modify config file on disk
@@ -470,8 +425,8 @@ port = 8080
 port = 9090
 
 [routes]
-"app.example.com" = "myapp:v2"
-"new.example.com" = "newapp:latest"
+"app.example.com" = { service = "app-v2", port = "web" }
+"new.example.com" = { service = "new-app", port = "web" }
 `
 		err = os.WriteFile(configFile, []byte(updatedConfig), 0600)
 		require.NoError(t, err)
@@ -482,10 +437,12 @@ port = 9090
 
 		assert.Equal(t, 9090, svc.GetServerPort())
 		route = requireRoute(t, svc.GetConfig().Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", route.Image)
+		assert.Equal(t, "app-v2", route.Service)
+		assert.Equal(t, "web", route.PortName)
 		assert.True(t, route.HTTPS)
 		route = requireRoute(t, svc.GetConfig().Routes, "new.example.com")
-		assert.Equal(t, "newapp:latest", route.Image)
+		assert.Equal(t, "new-app", route.Service)
+		assert.Equal(t, "web", route.PortName)
 		assert.True(t, route.HTTPS)
 	})
 
@@ -581,6 +538,20 @@ func TestService_GetRoutes(t *testing.T) {
 
 	assert.Equal(t, "insecureapp:latest", routeMap["insecure.example"].Image)
 	assert.False(t, routeMap["insecure.example"].HTTPS)
+}
+
+func TestService_GetRoutesSeparatesServiceTargetsFromImageBackedRoutes(t *testing.T) {
+	v := viper.New()
+	v.Set("routes", map[string]interface{}{
+		"app.example.com":    map[string]any{"target": "service:app:web"},
+		"static.example.com": map[string]any{"image": "static:latest"},
+	})
+
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	require.NoError(t, svc.Load(testContext()))
+
+	require.Equal(t, []domain.Route{{Domain: "static.example.com", Image: "static:latest", HTTPS: true}}, svc.GetRoutes(testContext()))
+	require.Equal(t, []domain.HTTPServiceRoute{{Domain: "app.example.com", Service: "app", PortName: "web", HTTPS: true}}, svc.GetServiceRoutes())
 }
 
 func TestService_GetRoute(t *testing.T) {
@@ -734,7 +705,7 @@ func TestService_AddRoute(t *testing.T) {
 		// Verify route was added
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "new.example.com")
-		assert.Equal(t, "newapp:latest", routeCfg.Image)
+		assert.Equal(t, "newapp:latest", routeCfg.Service)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
@@ -761,7 +732,7 @@ func TestService_AddRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:latest", routeCfg.Image,
+		assert.Equal(t, "myapp:latest", routeCfg.Service,
 			"zero-value route should store under plain domain key")
 		assert.False(t, routeCfg.HTTPS)
 		_, hasHTTPKey := config.Routes["http://app.example.com"]
@@ -797,7 +768,7 @@ func TestService_AddRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "secure.example.com")
-		assert.Equal(t, "myapp:latest", routeCfg.Image,
+		assert.Equal(t, "myapp:latest", routeCfg.Service,
 			"HTTPS=true route should store under plain domain key")
 		assert.True(t, routeCfg.HTTPS)
 	})
@@ -836,7 +807,7 @@ func TestService_AddRoute(t *testing.T) {
 
 		assert.Equal(t, before.ModTime(), after.ModTime())
 		routeCfg := requireRoute(t, svc.GetConfig().Routes, "new.example.com")
-		assert.Equal(t, "newapp:latest", routeCfg.Image)
+		assert.Equal(t, "newapp:latest", routeCfg.Service)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
@@ -947,7 +918,7 @@ func TestService_AddRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Image,
+		assert.Equal(t, "myapp:v2", routeCfg.Service,
 			"canonical route should be updated")
 		assert.True(t, routeCfg.HTTPS)
 		_, exists := config.Routes["http://app.example.com"]
@@ -987,7 +958,7 @@ func TestService_UpdateRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Image)
+		assert.Equal(t, "myapp:v2", routeCfg.Service)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
@@ -1019,7 +990,7 @@ func TestService_UpdateRoute(t *testing.T) {
 		require.NoError(t, err)
 
 		routeCfg := requireRoute(t, svc.GetConfig().Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Image)
+		assert.Equal(t, "myapp:v2", routeCfg.Service)
 		assert.False(t, routeCfg.HTTPS)
 
 		content, err := os.ReadFile(configFile)
@@ -1142,7 +1113,7 @@ func TestService_UpdateRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "insecure.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Image,
+		assert.Equal(t, "myapp:v2", routeCfg.Service,
 			"insecure route update should preserve the plain hostname key")
 		assert.False(t, routeCfg.HTTPS)
 	})
@@ -1164,7 +1135,7 @@ func TestService_UpdateRoute(t *testing.T) {
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Image,
+		assert.Equal(t, "myapp:v2", routeCfg.Service,
 			"canonical route should be updated")
 		assert.True(t, routeCfg.HTTPS)
 		_, exists := config.Routes["http://app.example.com"]
@@ -1281,7 +1252,7 @@ func TestService_Save_WrapsInvalidRouteDomainError(t *testing.T) {
 		require.NoError(t, svc.Load(ctx))
 
 		svc.mu.Lock()
-		svc.config.Routes["localhost"] = routeConfig{Image: "myapp:latest", HTTPS: true}
+		svc.config.Routes["localhost"] = routeConfig{Service: "app", PortName: "web", HTTPS: true}
 		svc.mu.Unlock()
 
 		err = svc.Save(ctx)
@@ -1304,7 +1275,7 @@ func TestService_Save_WrapsInvalidRouteDomainError(t *testing.T) {
 		require.NoError(t, svc.Load(ctx))
 
 		svc.mu.Lock()
-		svc.config.Routes["http://localhost"] = routeConfig{Image: "myapp:latest", HTTPS: false}
+		svc.config.Routes["http://localhost"] = routeConfig{Service: "app", PortName: "web", HTTPS: false}
 		svc.mu.Unlock()
 
 		err = svc.Save(ctx)
@@ -2434,10 +2405,10 @@ backend = ["app.example.com"]
 		savedRoutes, err := loadCanonicalRoutes(v2.Get("routes"))
 		require.NoError(t, err)
 		routeCfg := requireRoute(t, savedRoutes, "new.example.com")
-		assert.Equal(t, "newapp:latest", routeCfg.Image)
+		assert.Equal(t, "newapp:latest", routeCfg.Service)
 		assert.False(t, routeCfg.HTTPS)
 		routeCfg = requireRoute(t, savedRoutes, "app.example.com")
-		assert.Equal(t, "reg.example.com/myapp:latest", routeCfg.Image)
+		assert.Equal(t, "reg.example.com/myapp:latest", routeCfg.Service)
 		assert.True(t, routeCfg.HTTPS)
 
 		matches, err := filepath.Glob(configFile + ".bak.*")

--- a/internal/usecase/config/service_test.go
+++ b/internal/usecase/config/service_test.go
@@ -28,37 +28,6 @@ func requireRoute(t *testing.T, routes map[string]routeConfig, domainName string
 	return route
 }
 
-func setupServiceWithCoexistingLegacyRoute(t *testing.T, canonicalImage, legacyImage string) (*Service, context.Context) {
-	t.Helper()
-
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "gordon.toml")
-	err := os.WriteFile(configFile, []byte(fmt.Sprintf("[routes]\n\"app.example.com\" = %q\n\"http://app.example.com\" = %q\n", canonicalImage, legacyImage)), 0600)
-	require.NoError(t, err)
-
-	v := viper.New()
-	v.SetConfigFile(configFile)
-	v.Set("routes", map[string]any{
-		"app.example.com":        canonicalImage,
-		"http://app.example.com": legacyImage,
-	})
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
-	ctx := testContext()
-	require.NoError(t, svc.Load(ctx))
-
-	svc.mu.Lock()
-	if svc.config.Routes == nil {
-		svc.config.Routes = make(map[string]routeConfig)
-	}
-	svc.config.Routes["app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: true}
-	svc.config.Routes["http://app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: false}
-	svc.mu.Unlock()
-
-	return svc, ctx
-}
-
 func TestService_Load(t *testing.T) {
 	v := viper.New()
 	v.Set("server.port", 8080)
@@ -182,42 +151,9 @@ func TestService_Reload_InvalidRouteKeyPreservesPreviousState(t *testing.T) {
 
 	route, getErr := svc.GetRoute(ctx, "app.example.com")
 	require.NoError(t, getErr)
-	assert.Equal(t, "myapp:v1", route.Image)
+	assert.Equal(t, "app", route.Service)
+	assert.Equal(t, "web", route.PortName)
 	assert.True(t, route.HTTPS)
-}
-
-func TestService_GetRoutes_DeduplicatesCanonicalAndLegacyEntries(t *testing.T) {
-	svc, ctx := setupServiceWithCoexistingLegacyRoute(t, "canonical:v2", "legacy:v1")
-
-	routes := svc.GetRoutes(ctx)
-
-	require.Len(t, routes, 1)
-	assert.Equal(t, "app.example.com", routes[0].Domain)
-	assert.Equal(t, "canonical:v2", routes[0].Image)
-	assert.True(t, routes[0].HTTPS)
-}
-
-func TestService_FindRoutesByImage_DeduplicatesCanonicalAndLegacyEntries(t *testing.T) {
-	v := viper.New()
-	v.Set("server.registry_domain", "registry.example.com")
-	v.Set("routes", map[string]any{})
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
-	ctx := testContext()
-
-	_ = svc.Load(ctx)
-	svc.mu.Lock()
-	svc.config.Routes = make(map[string]routeConfig)
-	svc.config.Routes["app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: true}
-	svc.config.Routes["http://app.example.com"] = routeConfig{Service: "app", PortName: "web", HTTPS: false}
-	svc.mu.Unlock()
-
-	routes := svc.FindRoutesByImage(ctx, "myapp")
-
-	require.Len(t, routes, 1)
-	assert.Equal(t, "app.example.com", routes[0].Domain)
-	assert.Equal(t, "registry.example.com/myapp:v2", routes[0].Image)
-	assert.True(t, routes[0].HTTPS)
 }
 
 func TestCanonicalRoutesForSave(t *testing.T) {
@@ -256,42 +192,51 @@ func TestService_AddRoute_StoresHTTPSFalseInCanonicalForm(t *testing.T) {
 	assert.False(t, routeCfg.HTTPS)
 }
 
-func TestService_AddRoute_RewritesRoutesToCanonicalInlineTables(t *testing.T) {
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "gordon.toml")
-	initialConfig := `[server]
-gordon_domain = "registry.example.com"
-legacy_registry_domains = ["old-registry.example.com"]
+func TestService_RouteWritesRejectPaddedServiceReferences(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "gordon.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600))
+	v := viper.New()
+	v.SetConfigFile(configFile)
+	require.NoError(t, v.ReadInConfig())
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-[routes]
-"secure.example.com" = "old-registry.example.com/secure:v1"
-"http://insecure.example.com" = "old-registry.example.com/insecure:v1"
+	err := svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Service: " app", PortName: "web"})
+	require.ErrorContains(t, err, "leading or trailing whitespace")
+	err = svc.UpdateRoute(ctx, domain.Route{Domain: "app.example.com", Service: "app", PortName: "web "})
+	require.ErrorContains(t, err, "leading or trailing whitespace")
+
+	_, err = canonicalRoutesForSave(map[string]routeConfig{
+		"app.example.com": {Service: " app ", PortName: "web", HTTPS: true},
+	}, "", nil)
+	require.ErrorContains(t, err, "leading or trailing whitespace")
+}
+
+func TestService_AddRoute_RewritesRoutesToCanonicalInlineTables(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "gordon.toml")
+	initialConfig := `[routes]
+"secure.example.com" = { service = "app", port = "web", https = true }
 `
-	err := os.WriteFile(configFile, []byte(initialConfig), 0600)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configFile, []byte(initialConfig), 0600))
 
 	v := viper.New()
 	v.SetConfigFile(configFile)
 	require.NoError(t, v.ReadInConfig())
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-	err = svc.Load(ctx)
-	require.NoError(t, err)
-
-	err = svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Image: "new:v1"})
+	err := svc.AddRoute(ctx, domain.Route{Domain: "new.example.com", Service: "worker", PortName: "http"})
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(configFile)
 	require.NoError(t, err)
 	text := string(content)
-	assert.Contains(t, text, `"secure.example.com" = { image = "registry.example.com/secure:v1", https = true }`)
-	assert.Contains(t, text, `"insecure.example.com" = { image = "registry.example.com/insecure:v1", https = false }`)
-	assert.Contains(t, text, `"new.example.com" = { image = "new:v1", https = false }`)
-	assert.NotContains(t, text, "http://insecure.example.com")
-	assert.Contains(t, text, "[routes]")
+	assert.Contains(t, text, `"secure.example.com" = { service = "app", port = "web", https = true }`)
+	assert.Contains(t, text, `"new.example.com" = { service = "worker", port = "http", https = false }`)
 }
 
 func TestCanonicalAttachmentsForSave(t *testing.T) {
@@ -506,94 +451,62 @@ port = 9090
 	})
 }
 
-func TestService_GetRoutes(t *testing.T) {
+func TestService_GetRoutesExcludesServiceBindings(t *testing.T) {
 	v := viper.New()
-	v.Set("routes", map[string]interface{}{
-		"app1.example.com":        "myapp:latest",
-		"app2.example.com":        "otherapp:v2",
-		"http://insecure.example": "insecureapp:latest",
+	v.Set("routes", map[string]any{
+		"app1.example.com": map[string]any{"service": "app1", "port": "web"},
+		"app2.example.com": map[string]any{"service": "app2", "port": "http", "https": false},
 	})
 
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-	_ = svc.Load(ctx)
-
-	routes := svc.GetRoutes(ctx)
-
-	assert.Len(t, routes, 3)
-
-	// Check routes (order is not guaranteed)
-	routeMap := make(map[string]domain.Route)
-	for _, r := range routes {
-		routeMap[r.Domain] = r
-	}
-
-	assert.Equal(t, "myapp:latest", routeMap["app1.example.com"].Image)
-	assert.True(t, routeMap["app1.example.com"].HTTPS)
-
-	assert.Equal(t, "otherapp:v2", routeMap["app2.example.com"].Image)
-	assert.True(t, routeMap["app2.example.com"].HTTPS)
-
-	assert.Equal(t, "insecureapp:latest", routeMap["insecure.example"].Image)
-	assert.False(t, routeMap["insecure.example"].HTTPS)
+	require.Empty(t, svc.GetRoutes(ctx))
+	require.Equal(t, []domain.HTTPServiceRoute{
+		{Domain: "app1.example.com", Service: "app1", PortName: "web", HTTPS: true},
+		{Domain: "app2.example.com", Service: "app2", PortName: "http", HTTPS: false},
+	}, svc.GetServiceRoutes())
 }
 
-func TestService_GetRoutesSeparatesServiceTargetsFromImageBackedRoutes(t *testing.T) {
+func TestService_GetServiceRoutesReturnsCanonicalBindings(t *testing.T) {
 	v := viper.New()
-	v.Set("routes", map[string]interface{}{
-		"app.example.com":    map[string]any{"target": "service:app:web"},
-		"static.example.com": map[string]any{"image": "static:latest"},
+	v.Set("routes", map[string]any{
+		"App.Example.com": map[string]any{"service": "app", "port": "web"},
 	})
 
 	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	require.NoError(t, svc.Load(testContext()))
 
-	require.Equal(t, []domain.Route{{Domain: "static.example.com", Image: "static:latest", HTTPS: true}}, svc.GetRoutes(testContext()))
 	require.Equal(t, []domain.HTTPServiceRoute{{Domain: "app.example.com", Service: "app", PortName: "web", HTTPS: true}}, svc.GetServiceRoutes())
 }
 
 func TestService_GetRoute(t *testing.T) {
 	v := viper.New()
-	v.Set("routes", map[string]interface{}{
-		"app.example.com":         "myapp:latest",
-		"http://insecure.example": "insecureapp:latest",
+	v.Set("routes", map[string]any{
+		"app.example.com": map[string]any{"service": "app", "port": "web", "https": false},
 	})
 
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-	_ = svc.Load(ctx)
+	route, err := svc.GetRoute(ctx, "APP.EXAMPLE.COM")
+	require.NoError(t, err)
+	assert.Equal(t, "app.example.com", route.Domain)
+	assert.Equal(t, "app", route.Service)
+	assert.Equal(t, "web", route.PortName)
+	assert.False(t, route.HTTPS)
 
-	t.Run("existing route", func(t *testing.T) {
-		route, err := svc.GetRoute(ctx, "app.example.com")
-		require.NoError(t, err)
-		assert.Equal(t, "app.example.com", route.Domain)
-		assert.Equal(t, "myapp:latest", route.Image)
-		assert.True(t, route.HTTPS)
-	})
-
-	t.Run("legacy http route found via fallback", func(t *testing.T) {
-		route, err := svc.GetRoute(ctx, "insecure.example")
-		require.NoError(t, err)
-		assert.Equal(t, "insecure.example", route.Domain)
-		assert.Equal(t, "insecureapp:latest", route.Image)
-		assert.False(t, route.HTTPS)
-	})
-
-	t.Run("non-existent route", func(t *testing.T) {
-		route, err := svc.GetRoute(ctx, "notfound.example.com")
-		assert.ErrorIs(t, err, domain.ErrRouteNotFound)
-		assert.Nil(t, route)
-	})
+	route, err = svc.GetRoute(ctx, "notfound.example.com")
+	assert.ErrorIs(t, err, domain.ErrRouteNotFound)
+	assert.Nil(t, route)
 }
 
 func TestLoadCanonicalRoutes_RejectsDuplicateCanonicalRouteKeys(t *testing.T) {
 	_, err := loadCanonicalRoutes(map[string]any{
-		"App.Example.com": "app:v1",
-		"app.example.com": "app:v2",
+		"App.Example.com": map[string]any{"service": "app", "port": "web"},
+		"app.example.com": map[string]any{"service": "app", "port": "admin"},
 	})
 
 	require.Error(t, err)
@@ -603,7 +516,7 @@ func TestLoadCanonicalRoutes_RejectsDuplicateCanonicalRouteKeys(t *testing.T) {
 func TestService_Load_RejectsExternalRouteConflictingWithRoute(t *testing.T) {
 	v := viper.New()
 	v.Set("routes", map[string]any{
-		"App.Example.com": "app:latest",
+		"App.Example.com": map[string]any{"service": "app", "port": "web"},
 	})
 	v.Set("external_routes", map[string]any{
 		"app.example.com": "203.0.113.10:5000",
@@ -647,7 +560,7 @@ func TestService_AddRoute_RejectsExternalRouteConflict(t *testing.T) {
 	ctx := testContext()
 	require.NoError(t, svc.Load(ctx))
 
-	err := svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Image: "app:latest"})
+	err := svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Service: "app", PortName: "web"})
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, domain.ErrRouteConflict)
@@ -663,16 +576,16 @@ func TestService_AddRoute_CanonicalizesDomainCaseAndRejectsInvalidAuthority(t *t
 	ctx := testContext()
 	require.NoError(t, svc.Load(ctx))
 
-	require.NoError(t, svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Image: "app:latest", HTTPS: true}))
+	require.NoError(t, svc.AddRoute(ctx, domain.Route{Domain: "App.Example.com", Service: "app", PortName: "web", HTTPS: true}))
 	route, err := svc.GetRoute(ctx, "app.example.com")
 	require.NoError(t, err)
 	assert.Equal(t, "app.example.com", route.Domain)
 	_, err = svc.GetRoute(ctx, "APP.EXAMPLE.COM")
 	require.NoError(t, err)
 
-	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com:8080", Image: "app:latest"})
+	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com:8080", Service: "app", PortName: "web"})
 	assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
-	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com.", Image: "app:latest"})
+	err = svc.AddRoute(ctx, domain.Route{Domain: "bad.example.com.", Service: "app", PortName: "web"})
 	assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
 }
 
@@ -693,9 +606,10 @@ func TestService_AddRoute(t *testing.T) {
 		_ = svc.Load(ctx)
 
 		route := domain.Route{
-			Domain: "new.example.com",
-			Image:  "newapp:latest",
-			HTTPS:  true,
+			Domain:   "new.example.com",
+			Service:  "app",
+			PortName: "web",
+			HTTPS:    true,
 		}
 
 		err = svc.AddRoute(ctx, route)
@@ -705,7 +619,8 @@ func TestService_AddRoute(t *testing.T) {
 		// Verify route was added
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "new.example.com")
-		assert.Equal(t, "newapp:latest", routeCfg.Service)
+		assert.Equal(t, "app", routeCfg.Service)
+		assert.Equal(t, "web", routeCfg.PortName)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
@@ -722,26 +637,20 @@ func TestService_AddRoute(t *testing.T) {
 		ctx := testContext()
 		_ = svc.Load(ctx)
 
-		// Zero-value HTTPS field (false) should be preserved
-		route := domain.Route{
-			Domain: "app.example.com",
-			Image:  "myapp:latest",
-		}
+		// Zero-value HTTPS field (false) should be preserved.
+		route := domain.Route{Domain: "app.example.com", Service: "app", PortName: "web"}
 		err = svc.AddRoute(ctx, route)
 		require.NoError(t, err)
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:latest", routeCfg.Service,
-			"zero-value route should store under plain domain key")
+		assert.Equal(t, "app", routeCfg.Service)
+		assert.Equal(t, "web", routeCfg.PortName)
 		assert.False(t, routeCfg.HTTPS)
-		_, hasHTTPKey := config.Routes["http://app.example.com"]
-		assert.False(t, hasHTTPKey, "zero-value route should NOT get http:// prefix")
 
-		// Verify it round-trips as HTTPS=false via GetRoutes
-		routes := svc.GetRoutes(ctx)
+		routes := svc.GetServiceRoutes()
 		require.Len(t, routes, 1)
-		assert.False(t, routes[0].HTTPS, "zero-value route should be treated as HTTP")
+		assert.False(t, routes[0].HTTPS)
 	})
 
 	t.Run("HTTPS explicitly true stores under plain domain key", func(t *testing.T) {
@@ -757,23 +666,19 @@ func TestService_AddRoute(t *testing.T) {
 		ctx := testContext()
 		_ = svc.Load(ctx)
 
-		// Explicitly set HTTPS: true — should store under plain domain key
-		route := domain.Route{
-			Domain: "secure.example.com",
-			Image:  "myapp:latest",
-			HTTPS:  true,
-		}
+		// Explicitly set HTTPS: true — should store under the plain domain key.
+		route := domain.Route{Domain: "secure.example.com", Service: "app", PortName: "web", HTTPS: true}
 		err = svc.AddRoute(ctx, route)
 		require.NoError(t, err)
 
 		config := svc.GetConfig()
 		routeCfg := requireRoute(t, config.Routes, "secure.example.com")
-		assert.Equal(t, "myapp:latest", routeCfg.Service,
-			"HTTPS=true route should store under plain domain key")
+		assert.Equal(t, "app", routeCfg.Service)
+		assert.Equal(t, "web", routeCfg.PortName)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
-	t.Run("idempotent same domain and image saves once", func(t *testing.T) {
+	t.Run("idempotent same binding saves once", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configFile := filepath.Join(tmpDir, "gordon.toml")
 		err := os.WriteFile(configFile, []byte("[routes]\n"), 0600)
@@ -788,9 +693,7 @@ func TestService_AddRoute(t *testing.T) {
 		_ = svc.Load(ctx)
 
 		route := domain.Route{
-			Domain: "new.example.com",
-			Image:  "newapp:latest",
-			HTTPS:  true,
+			Domain: "new.example.com", Service: "app", PortName: "web", HTTPS: true,
 		}
 
 		err = svc.AddRoute(ctx, route)
@@ -807,7 +710,8 @@ func TestService_AddRoute(t *testing.T) {
 
 		assert.Equal(t, before.ModTime(), after.ModTime())
 		routeCfg := requireRoute(t, svc.GetConfig().Routes, "new.example.com")
-		assert.Equal(t, "newapp:latest", routeCfg.Service)
+		assert.Equal(t, "app", routeCfg.Service)
+		assert.Equal(t, "web", routeCfg.PortName)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
@@ -826,19 +730,11 @@ func TestService_AddRoute(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrRouteDomainEmpty)
 	})
 
-	t.Run("empty image", func(t *testing.T) {
-		v := viper.New()
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
+	t.Run("empty service reference", func(t *testing.T) {
+		svc := NewService(viper.New(), mocks.NewMockEventPublisher(t))
 
-		route := domain.Route{
-			Domain: "example.com",
-			Image:  "",
-		}
-
-		err := svc.AddRoute(ctx, route)
-		assert.ErrorIs(t, err, domain.ErrRouteImageEmpty)
+		err := svc.AddRoute(testContext(), domain.Route{Domain: "example.com"})
+		assert.ErrorContains(t, err, "requires non-empty service and port")
 	})
 
 	t.Run("invalid domain - IP address", func(t *testing.T) {
@@ -901,101 +797,54 @@ func TestService_AddRoute(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
 	})
 
-	t.Run("reconciles coexisting legacy http key", func(t *testing.T) {
-		svc, ctx := setupServiceWithCoexistingLegacyRoute(t, "myapp:v1", "myapp:old")
-		preConfig := svc.GetConfig()
-		requireRoute(t, preConfig.Routes, "app.example.com")
-		requireRoute(t, preConfig.Routes, "http://app.example.com")
-
-		route := domain.Route{
-			Domain: "app.example.com",
-			Image:  "myapp:v2",
-			HTTPS:  true,
-		}
-
-		err := svc.AddRoute(ctx, route)
-		assert.NoError(t, err)
-
-		config := svc.GetConfig()
-		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Service,
-			"canonical route should be updated")
-		assert.True(t, routeCfg.HTTPS)
-		_, exists := config.Routes["http://app.example.com"]
-		assert.False(t, exists, "legacy http route key should be removed during reconciliation")
-	})
 }
 
 func TestService_UpdateRoute(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		// Create temp config file for Save() to work
-		tmpDir := t.TempDir()
-		configFile := filepath.Join(tmpDir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[routes]\n\"app.example.com\" = \"myapp:v1\"\n"), 0600)
-		require.NoError(t, err)
-
+		configFile := filepath.Join(t.TempDir(), "gordon.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600))
 		v := viper.New()
 		v.SetConfigFile(configFile)
-		v.Set("routes", map[string]any{
-			"app.example.com": "myapp:v1",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
+		require.NoError(t, v.ReadInConfig())
+		svc := NewService(v, mocks.NewMockEventPublisher(t))
 		ctx := testContext()
+		require.NoError(t, svc.Load(ctx))
 
-		_ = svc.Load(ctx)
+		err := svc.UpdateRoute(ctx, domain.Route{
+			Domain: "app.example.com", Service: "worker", PortName: "http", HTTPS: true,
+		})
+		require.NoError(t, err)
 
-		route := domain.Route{
-			Domain: "app.example.com",
-			Image:  "myapp:v2",
-			HTTPS:  true,
-		}
-
-		err = svc.UpdateRoute(ctx, route)
-
-		assert.NoError(t, err)
-
-		config := svc.GetConfig()
-		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Service)
+		routeCfg := requireRoute(t, svc.GetConfig().Routes, "app.example.com")
+		assert.Equal(t, "worker", routeCfg.Service)
+		assert.Equal(t, "http", routeCfg.PortName)
 		assert.True(t, routeCfg.HTTPS)
 	})
 
 	t.Run("updates https setting", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		configFile := filepath.Join(tmpDir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[routes]\n\"app.example.com\" = \"myapp:v1\"\n"), 0600)
-		require.NoError(t, err)
-
+		configFile := filepath.Join(t.TempDir(), "gordon.toml")
+		require.NoError(t, os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600))
 		v := viper.New()
 		v.SetConfigFile(configFile)
-		v.Set("routes", map[string]any{
-			"app.example.com": "myapp:v1",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
+		require.NoError(t, v.ReadInConfig())
+		svc := NewService(v, mocks.NewMockEventPublisher(t))
 		ctx := testContext()
+		require.NoError(t, svc.Load(ctx))
 
-		_ = svc.Load(ctx)
-
-		route := domain.Route{
-			Domain: "app.example.com",
-			Image:  "myapp:v2",
-			HTTPS:  false,
-		}
-
-		err = svc.UpdateRoute(ctx, route)
+		err := svc.UpdateRoute(ctx, domain.Route{
+			Domain: "app.example.com", Service: "app", PortName: "web", HTTPS: false,
+		})
 		require.NoError(t, err)
 
 		routeCfg := requireRoute(t, svc.GetConfig().Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Service)
 		assert.False(t, routeCfg.HTTPS)
-
 		content, err := os.ReadFile(configFile)
 		require.NoError(t, err)
-		assert.Contains(t, string(content), `"app.example.com" = { image = "myapp:v2", https = false }`)
+		assert.Contains(t, string(content), `"app.example.com" = { service = "app", port = "web", https = false }`)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -1006,10 +855,7 @@ func TestService_UpdateRoute(t *testing.T) {
 
 		_ = svc.Load(ctx)
 
-		route := domain.Route{
-			Domain: "nonexistent.example.com",
-			Image:  "myapp:latest",
-		}
+		route := domain.Route{Domain: "nonexistent.example.com", Service: "app", PortName: "web"}
 
 		err := svc.UpdateRoute(ctx, route)
 		assert.ErrorIs(t, err, domain.ErrRouteNotFound)
@@ -1030,19 +876,10 @@ func TestService_UpdateRoute(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrRouteDomainEmpty)
 	})
 
-	t.Run("empty image", func(t *testing.T) {
-		v := viper.New()
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-
-		route := domain.Route{
-			Domain: "example.com",
-			Image:  "",
-		}
-
-		err := svc.UpdateRoute(ctx, route)
-		assert.ErrorIs(t, err, domain.ErrRouteImageEmpty)
+	t.Run("empty service reference", func(t *testing.T) {
+		svc := NewService(viper.New(), mocks.NewMockEventPublisher(t))
+		err := svc.UpdateRoute(testContext(), domain.Route{Domain: "example.com"})
+		assert.ErrorContains(t, err, "requires non-empty service and port")
 	})
 
 	t.Run("invalid domain - IP address", func(t *testing.T) {
@@ -1085,84 +922,21 @@ func TestService_UpdateRoute(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
 	})
 
-	t.Run("insecure route found via http prefix fallback", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		configFile := filepath.Join(tmpDir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[routes]\n\"http://insecure.example.com\" = \"myapp:v1\"\n"), 0600)
-		require.NoError(t, err)
-
-		v := viper.New()
-		v.SetConfigFile(configFile)
-		v.Set("routes", map[string]any{
-			"http://insecure.example.com": "myapp:v1",
-		})
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		// Caller uses clean domain for update
-		route := domain.Route{
-			Domain: "insecure.example.com",
-			Image:  "myapp:v2",
-			HTTPS:  false,
-		}
-
-		err = svc.UpdateRoute(ctx, route)
-		assert.NoError(t, err, "UpdateRoute should find insecure route via http:// fallback")
-
-		config := svc.GetConfig()
-		routeCfg := requireRoute(t, config.Routes, "insecure.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Service,
-			"insecure route update should preserve the plain hostname key")
-		assert.False(t, routeCfg.HTTPS)
-	})
-
-	t.Run("reconciles coexisting legacy http key", func(t *testing.T) {
-		svc, ctx := setupServiceWithCoexistingLegacyRoute(t, "myapp:v1", "myapp:old")
-		preConfig := svc.GetConfig()
-		requireRoute(t, preConfig.Routes, "app.example.com")
-		requireRoute(t, preConfig.Routes, "http://app.example.com")
-
-		route := domain.Route{
-			Domain: "app.example.com",
-			Image:  "myapp:v2",
-			HTTPS:  true,
-		}
-
-		err := svc.UpdateRoute(ctx, route)
-		assert.NoError(t, err)
-
-		config := svc.GetConfig()
-		routeCfg := requireRoute(t, config.Routes, "app.example.com")
-		assert.Equal(t, "myapp:v2", routeCfg.Service,
-			"canonical route should be updated")
-		assert.True(t, routeCfg.HTTPS)
-		_, exists := config.Routes["http://app.example.com"]
-		assert.False(t, exists, "legacy http route key should be removed during reconciliation")
-	})
 }
 
 func TestService_RemoveRoute(t *testing.T) {
-	// Create temp config file for Save() to work
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "gordon.toml")
-	err := os.WriteFile(configFile, []byte("[routes]\n\"app.example.com\" = \"myapp:latest\"\n"), 0600)
-	require.NoError(t, err)
-
+	configFile := filepath.Join(t.TempDir(), "gordon.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600))
 	v := viper.New()
 	v.SetConfigFile(configFile)
-	v.Set("routes", map[string]interface{}{
-		"app.example.com": "myapp:latest",
-	})
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
+	require.NoError(t, v.ReadInConfig())
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
 	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-	_ = svc.Load(ctx)
-
-	err = svc.RemoveRoute(ctx, "app.example.com")
+	err := svc.RemoveRoute(ctx, "app.example.com")
 
 	assert.NoError(t, err)
 
@@ -1194,52 +968,13 @@ func TestService_RemoveRoute_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrRouteNotFound)
 }
 
-func TestService_RemoveRoute_InsecureFallback(t *testing.T) {
-	// Setup: insecure route stored with http:// prefix
-	tmpDir := t.TempDir()
-	configFile := filepath.Join(tmpDir, "gordon.toml")
-	err := os.WriteFile(configFile, []byte("[routes]\n\"http://insecure.example.com\" = \"myapp:latest\"\n"), 0600)
-	require.NoError(t, err)
-
-	v := viper.New()
-	v.SetConfigFile(configFile)
-	v.Set("routes", map[string]interface{}{
-		"http://insecure.example.com": "myapp:latest",
-	})
-
-	eventBus := mocks.NewMockEventPublisher(t)
-	svc := NewService(v, eventBus)
-	ctx := testContext()
-
-	_ = svc.Load(ctx)
-
-	// Caller passes plain domain (not the storage key)
-	err = svc.RemoveRoute(ctx, "insecure.example.com")
-	assert.NoError(t, err, "RemoveRoute should find insecure route via http:// fallback")
-
-	config := svc.GetConfig()
-	_, exists := config.Routes["insecure.example.com"]
-	assert.False(t, exists, "insecure route should be removed")
-}
-
-func TestService_RemoveRoute_ReconcilesCoexistingLegacyKey(t *testing.T) {
-	svc, ctx := setupServiceWithCoexistingLegacyRoute(t, "myapp:latest", "myapp:old")
-
-	err := svc.RemoveRoute(ctx, "app.example.com")
-	assert.NoError(t, err)
-
-	config := svc.GetConfig()
-	_, exists := config.Routes["app.example.com"]
-	assert.False(t, exists, "canonical route should be removed")
-	_, exists = config.Routes["http://app.example.com"]
-	assert.False(t, exists, "legacy http route key should be removed during reconciliation")
-}
-
 func TestService_Save_WrapsInvalidRouteDomainError(t *testing.T) {
 	t.Run("canonical key", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configFile := filepath.Join(tmpDir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[routes]\n\"app.example.com\" = \"myapp:latest\"\n"), 0600)
+		err := os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600)
 		require.NoError(t, err)
 
 		v := viper.New()
@@ -1259,10 +994,12 @@ func TestService_Save_WrapsInvalidRouteDomainError(t *testing.T) {
 		assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
 	})
 
-	t.Run("legacy key", func(t *testing.T) {
+	t.Run("removed http key", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configFile := filepath.Join(tmpDir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[routes]\n\"app.example.com\" = \"myapp:latest\"\n"), 0600)
+		err := os.WriteFile(configFile, []byte(`[routes]
+"app.example.com" = { service = "app", port = "web" }
+`), 0600)
 		require.NoError(t, err)
 
 		v := viper.New()
@@ -1279,7 +1016,7 @@ func TestService_Save_WrapsInvalidRouteDomainError(t *testing.T) {
 		svc.mu.Unlock()
 
 		err = svc.Save(ctx)
-		assert.ErrorIs(t, err, domain.ErrRouteDomainInvalid)
+		assert.ErrorContains(t, err, "uses removed http:// syntax")
 	})
 }
 
@@ -1986,200 +1723,16 @@ func TestNormalizeBootstrapImage(t *testing.T) {
 	}
 }
 
-func TestService_FindRoutesByImage(t *testing.T) {
-	t.Run("exact match with tag", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp:latest")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-		assert.Equal(t, "myapp:latest", routes[0].Image)
+func TestService_FindRoutesByImageReturnsNoServiceBindings(t *testing.T) {
+	v := viper.New()
+	v.Set("routes", map[string]any{
+		"app.example.com": map[string]any{"service": "app", "port": "web"},
 	})
+	svc := NewService(v, mocks.NewMockEventPublisher(t))
+	ctx := testContext()
+	require.NoError(t, svc.Load(ctx))
 
-	t.Run("bare name matches route with tag", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-	})
-
-	t.Run("bare name matches route with version tag", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "myapp:v2.0.0",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-	})
-
-	t.Run("tag mismatch does not match", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "myapp:v1",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp:v2")
-		assert.Empty(t, routes)
-	})
-
-	t.Run("no match", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "otherapp")
-		assert.Empty(t, routes)
-	})
-
-	t.Run("strips registry prefix before matching", func(t *testing.T) {
-		v := viper.New()
-		v.Set("server.registry_domain", "reg.example.com")
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "reg.example.com/myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-	})
-
-	t.Run("strips registry prefix from input too", func(t *testing.T) {
-		v := viper.New()
-		v.Set("server.registry_domain", "reg.example.com")
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "reg.example.com/myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "reg.example.com/myapp:latest")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-	})
-
-	t.Run("matches current image when route stores legacy registry host", func(t *testing.T) {
-		v := viper.New()
-		v.Set("server.gordon_domain", "new-registry.example.com")
-		v.Set("server.legacy_registry_domains", []string{"old-registry.example.com"})
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "old-registry.example.com/myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		require.NoError(t, svc.Load(ctx))
-
-		routes := svc.FindRoutesByImage(ctx, "new-registry.example.com/myapp:latest")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "app.example.com", routes[0].Domain)
-	})
-
-	t.Run("multiple routes for same image", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app1.example.com":  "myapp:latest",
-			"app2.example.com":  "myapp:latest",
-			"other.example.com": "otherapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 2)
-
-		domains := []string{routes[0].Domain, routes[1].Domain}
-		assert.ElementsMatch(t, []string{"app1.example.com", "app2.example.com"}, domains)
-	})
-
-	t.Run("case insensitive match", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"app.example.com": "MyApp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 1)
-	})
-
-	t.Run("http prefix route sets HTTPS false", func(t *testing.T) {
-		v := viper.New()
-		v.Set("routes", map[string]interface{}{
-			"http://insecure.example.com": "myapp:latest",
-		})
-
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Len(t, routes, 1)
-		assert.Equal(t, "insecure.example.com", routes[0].Domain)
-		assert.False(t, routes[0].HTTPS)
-	})
-
-	t.Run("empty routes", func(t *testing.T) {
-		v := viper.New()
-		eventBus := mocks.NewMockEventPublisher(t)
-		svc := NewService(v, eventBus)
-		ctx := testContext()
-		_ = svc.Load(ctx)
-
-		routes := svc.FindRoutesByImage(ctx, "myapp")
-		assert.Empty(t, routes)
-	})
+	assert.Empty(t, svc.FindRoutesByImage(ctx, "app:latest"))
 }
 
 func TestService_FindAttachmentTargetsByImage(t *testing.T) {
@@ -2283,7 +1836,7 @@ func TestSavePreservesAllConfigFields(t *testing.T) {
 	t.Run("does not write predictable tmp path", func(t *testing.T) {
 		dir := t.TempDir()
 		configFile := filepath.Join(dir, "gordon.toml")
-		err := os.WriteFile(configFile, []byte("[server]\nport = 8080\n\n[routes]\n\"app.example.com\" = \"myapp:latest\"\n"), 0600)
+		err := os.WriteFile(configFile, []byte("[server]\nport = 8080\n\n[routes]\n\"app.example.com\" = { service = \"app\", port = \"web\" }\n"), 0600)
 		require.NoError(t, err)
 
 		v := viper.New()
@@ -2349,7 +1902,7 @@ schedule = "daily"
 storage_dir = "~/.gordon/backups"
 
 [routes]
-"app.example.com" = "reg.example.com/myapp:latest"
+"app.example.com" = { service = "app", port = "web" }
 
 [attachments]
 "app.example.com" = ["postgres:15"]
@@ -2551,8 +2104,8 @@ username = "testadmin"
 token_secret = "testsecret123"
 
 [routes]
-"pitlane.example.com" = "reg.example.com/pitlane:latest"
-"other.example.com" = "reg.example.com/other:latest"
+"pitlane.example.com" = { service = "pitlane", port = "web" }
+"other.example.com" = { service = "other", port = "web" }
 `
 		err := os.WriteFile(configFile, []byte(initialConfig), 0600)
 		require.NoError(t, err)
@@ -2597,7 +2150,7 @@ username = "admin"
 token_secret = "supersecretvalue"
 
 [routes]
-"app.example.com" = "myapp:latest"
+"app.example.com" = { service = "app", port = "web" }
 
 [network_groups]
 frontend = ["app1.example.com", "app2.example.com"]
@@ -2656,7 +2209,7 @@ frontend = ["app1.example.com", "app2.example.com"]
 port = 8080
 
 [routes]
-"app.example.com" = "myapp:latest"
+"app.example.com" = { service = "app", port = "web" }
 
 [external_routes]
 "reg.example.com" = "localhost:5000"

--- a/internal/usecase/pki/service.go
+++ b/internal/usecase/pki/service.go
@@ -203,7 +203,22 @@ func (s *Service) isDomainAllowed(ctx context.Context, domainName string) bool {
 	if _, ok := s.routes.GetExternalRoutes()[domainName]; ok {
 		return true
 	}
+	for _, route := range configuredServiceRoutes(s.routes) {
+		if route.HTTPS && route.Domain == domainName {
+			return true
+		}
+	}
 	return false
+}
+
+func configuredServiceRoutes(source out.RouteChecker) []domain.HTTPServiceRoute {
+	provider, ok := source.(interface {
+		GetServiceRoutes() []domain.HTTPServiceRoute
+	})
+	if !ok {
+		return nil
+	}
+	return provider.GetServiceRoutes()
 }
 
 func canonicalDomainSet(domains []string) map[string]struct{} {
@@ -256,9 +271,10 @@ func (s *Service) sweepExpiredCerts(ctx context.Context) {
 	// Fetch routes once for all cache entries.
 	routes := s.routes.GetRoutes(ctx)
 	extRoutes := s.routes.GetExternalRoutes()
+	serviceRoutes := configuredServiceRoutes(s.routes)
 
 	s.allowedMu.RLock()
-	allowed := make(map[string]struct{}, len(routes)+len(extRoutes)+len(s.allowedDomains))
+	allowed := make(map[string]struct{}, len(routes)+len(extRoutes)+len(serviceRoutes)+len(s.allowedDomains))
 	for domain := range s.allowedDomains {
 		allowed[domain] = struct{}{}
 	}
@@ -268,6 +284,11 @@ func (s *Service) sweepExpiredCerts(ctx context.Context) {
 	}
 	for d := range extRoutes {
 		allowed[d] = struct{}{}
+	}
+	for _, route := range serviceRoutes {
+		if route.HTTPS {
+			allowed[route.Domain] = struct{}{}
+		}
 	}
 
 	swept := 0

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -93,8 +93,12 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 	})
 	log := zerowrap.FromCtx(ctx)
 
-	// Check cache first
+	// Reconciled service targets take precedence over the legacy runtime cache.
 	s.mu.RLock()
+	if target, exists := s.serviceTargets[domainName]; exists {
+		s.mu.RUnlock()
+		return cloneProxyTarget(target), nil
+	}
 	if target, exists := s.targets[domainName]; exists {
 		s.mu.RUnlock()
 		log.Debug().
@@ -103,10 +107,6 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 			Str("container_id", target.ContainerID).
 			Msg("using cached proxy target")
 		return target, nil
-	}
-	if target, exists := s.serviceTargets[domainName]; exists {
-		s.mu.RUnlock()
-		return cloneProxyTarget(target), nil
 	}
 	s.mu.RUnlock()
 

--- a/internal/usecase/proxy/service.go
+++ b/internal/usecase/proxy/service.go
@@ -36,15 +36,17 @@ type Config struct {
 
 // Service implements the ProxyService interface.
 type Service struct {
-	runtime          out.ContainerRuntime
-	containerSvc     in.ContainerService
-	configSvc        in.ConfigService
-	config           Config
-	targets          map[string]*domain.ProxyTarget
-	mu               sync.RWMutex
-	inFlight         map[string]int
-	inFlightMu       sync.Mutex
-	registryInFlight atomic.Int64 // active registry proxy requests, for graceful drain
+	runtime               out.ContainerRuntime
+	containerSvc          in.ContainerService
+	configSvc             in.ConfigService
+	config                Config
+	targets               map[string]*domain.ProxyTarget
+	serviceTargets        map[string]*domain.ProxyTarget
+	pendingServiceTargets map[string]*domain.ProxyTarget
+	mu                    sync.RWMutex
+	inFlight              map[string]int
+	inFlightMu            sync.Mutex
+	registryInFlight      atomic.Int64 // active registry proxy requests, for graceful drain
 }
 
 // NewService creates a new proxy service.
@@ -55,12 +57,14 @@ func NewService(
 	config Config,
 ) *Service {
 	return &Service{
-		runtime:      runtime,
-		containerSvc: containerSvc,
-		configSvc:    configSvc,
-		config:       config,
-		targets:      make(map[string]*domain.ProxyTarget),
-		inFlight:     make(map[string]int),
+		runtime:               runtime,
+		containerSvc:          containerSvc,
+		configSvc:             configSvc,
+		config:                config,
+		targets:               make(map[string]*domain.ProxyTarget),
+		serviceTargets:        make(map[string]*domain.ProxyTarget),
+		pendingServiceTargets: make(map[string]*domain.ProxyTarget),
+		inFlight:              make(map[string]int),
 	}
 }
 
@@ -99,6 +103,10 @@ func (s *Service) GetTarget(ctx context.Context, domainName string) (target *dom
 			Str("container_id", target.ContainerID).
 			Msg("using cached proxy target")
 		return target, nil
+	}
+	if target, exists := s.serviceTargets[domainName]; exists {
+		s.mu.RUnlock()
+		return cloneProxyTarget(target), nil
 	}
 	s.mu.RUnlock()
 
@@ -233,6 +241,51 @@ func (s *Service) resolveExternalRoute(_ context.Context, domainName, targetAddr
 		Int("port", port).
 		Msg("using external route target")
 	return t, nil
+}
+
+// StageServiceTargets validates service targets without making them live.
+func (s *Service) StageServiceTargets(targets map[string]*domain.ProxyTarget) error {
+	next := make(map[string]*domain.ProxyTarget, len(targets))
+	for domainName, target := range targets {
+		canonicalDomain, ok := domain.CanonicalRouteDomain(domainName)
+		if !ok || target == nil || target.Host == "" || target.Port < 1 || target.Port > 65535 {
+			return fmt.Errorf("invalid service target for %q", domainName)
+		}
+		prepared := cloneProxyTarget(target)
+		prepared.RouteHost = canonicalDomain
+		next[canonicalDomain] = prepared
+	}
+
+	s.mu.Lock()
+	s.pendingServiceTargets = next
+	s.mu.Unlock()
+	return nil
+}
+
+// CommitStagedServiceTargets atomically publishes the staged service targets.
+func (s *Service) CommitStagedServiceTargets() {
+	s.mu.Lock()
+	s.serviceTargets = s.pendingServiceTargets
+	s.pendingServiceTargets = make(map[string]*domain.ProxyTarget)
+	s.mu.Unlock()
+}
+
+// ReconcileServiceTargets validates and immediately publishes service targets.
+func (s *Service) ReconcileServiceTargets(targets map[string]*domain.ProxyTarget) error {
+	if err := s.StageServiceTargets(targets); err != nil {
+		return err
+	}
+	s.CommitStagedServiceTargets()
+	return nil
+}
+
+func cloneProxyTarget(target *domain.ProxyTarget) *domain.ProxyTarget {
+	if target == nil {
+		return nil
+	}
+	copy := *target
+	copy.TrustedCIDRs = append([]string(nil), target.TrustedCIDRs...)
+	return &copy
 }
 
 // RegisterTarget registers a new proxy target for a domain.

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -61,6 +61,18 @@ func TestService_GetTarget_UsesReconciledServiceTarget(t *testing.T) {
 	require.Equal(t, target.Port, result.Port)
 }
 
+func TestService_GetTarget_ReconciledServiceTargetOverridesCachedTarget(t *testing.T) {
+	svc := NewService(nil, nil, nil, Config{})
+	svc.targets["app.example.com"] = &domain.ProxyTarget{Host: "127.0.0.1", Port: 10080}
+	reconciled := &domain.ProxyTarget{Host: "127.0.0.1", Port: 18080, Scheme: "http"}
+	require.NoError(t, svc.ReconcileServiceTargets(map[string]*domain.ProxyTarget{"app.example.com": reconciled}))
+
+	result, err := svc.GetTarget(testContext(), "app.example.com")
+
+	require.NoError(t, err)
+	require.Equal(t, reconciled.Port, result.Port)
+}
+
 func TestService_GetTarget_CanonicalizesHostForLookup(t *testing.T) {
 	runtime := outmocks.NewMockContainerRuntime(t)
 	containerSvc := inmocks.NewMockContainerService(t)

--- a/internal/usecase/proxy/service_test.go
+++ b/internal/usecase/proxy/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bnema/zerowrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	inmocks "github.com/bnema/gordon/internal/boundaries/in/mocks"
 	outmocks "github.com/bnema/gordon/internal/boundaries/out/mocks"
@@ -45,6 +46,19 @@ func TestService_GetTarget_FromCache(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, cachedTarget, result)
+}
+
+func TestService_GetTarget_UsesReconciledServiceTarget(t *testing.T) {
+	svc := NewService(nil, nil, nil, Config{})
+	target := &domain.ProxyTarget{Host: "127.0.0.1", Port: 18080, Scheme: "http"}
+	require.NoError(t, svc.ReconcileServiceTargets(map[string]*domain.ProxyTarget{"app.example.com": target}))
+
+	result, err := svc.GetTarget(testContext(), "App.Example.com")
+
+	require.NoError(t, err)
+	require.Equal(t, "app.example.com", result.RouteHost)
+	require.Equal(t, target.Host, result.Host)
+	require.Equal(t, target.Port, result.Port)
 }
 
 func TestService_GetTarget_CanonicalizesHostForLookup(t *testing.T) {

--- a/internal/usecase/publictls/service.go
+++ b/internal/usecase/publictls/service.go
@@ -201,7 +201,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	// DeriveCertificateTargets fails (e.g. broken DNS-01 zone resolver).
 	routes := s.deps.Routes.GetRoutes(ctx)
 	external := s.deps.Routes.GetExternalRoutes()
-	hosts := routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts)
+	httpServiceRoutes := serviceRoutes(s.deps.Routes)
+	hosts := routeHostsWithServiceRoutes(routes, external, httpServiceRoutes, s.additionalHosts)
 
 	// Build required hosts set from route hosts (before target derivation).
 	required := canonicalHostSet(hosts)
@@ -213,12 +214,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	clearRouteErrorsLocked(s.routeErr, required)
 	s.mu.Unlock()
 
-	// Derive desired targets.
-	targets, err := DeriveCertificateTargets(ctx, effective.Mode,
-		routes, external,
-		s.additionalHosts,
-		s.deps.ZoneResolver,
-	)
+	// Derive desired targets from the same complete host set used for authorization.
+	targets, err := deriveCertificateTargetsFromHosts(ctx, effective.Mode, hosts, s.deps.ZoneResolver)
 	if err != nil {
 		s.mu.Lock()
 		setRouteErrorsLocked(s.routeErr, required, fmt.Sprintf("derive certificate targets: %v", err))

--- a/internal/usecase/publictls/service.go
+++ b/internal/usecase/publictls/service.go
@@ -106,7 +106,7 @@ func (s *Service) Load(ctx context.Context) error {
 	if s.deps.Routes != nil {
 		routes := s.deps.Routes.GetRoutes(ctx)
 		external := s.deps.Routes.GetExternalRoutes()
-		required = canonicalHostSet(routeHosts(routes, external, s.additionalHosts))
+		required = canonicalHostSet(routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts))
 	}
 
 	s.mu.Lock()
@@ -145,7 +145,7 @@ func (s *Service) SetAdditionalHosts(ctx context.Context, hosts []string) {
 	if s.deps.Routes != nil {
 		routes := s.deps.Routes.GetRoutes(ctx)
 		external := s.deps.Routes.GetExternalRoutes()
-		required = canonicalHostSet(routeHosts(routes, external, s.additionalHosts))
+		required = canonicalHostSet(routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts))
 	}
 
 	s.mu.Lock()
@@ -201,7 +201,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	// DeriveCertificateTargets fails (e.g. broken DNS-01 zone resolver).
 	routes := s.deps.Routes.GetRoutes(ctx)
 	external := s.deps.Routes.GetExternalRoutes()
-	hosts := routeHosts(routes, external, s.additionalHosts)
+	hosts := routeHostsWithServiceRoutes(routes, external, serviceRoutes(s.deps.Routes), s.additionalHosts)
 
 	// Build required hosts set from route hosts (before target derivation).
 	required := canonicalHostSet(hosts)

--- a/internal/usecase/publictls/service_test.go
+++ b/internal/usecase/publictls/service_test.go
@@ -34,9 +34,10 @@ import (
 // callers may modify the returned data; a hand-rolled fake ensures each
 // GetRoutes/GetExternalRoutes call returns a defensive copy.
 type fakeRoutes struct {
-	mu       sync.Mutex
-	routes   []domain.Route
-	external map[string]string
+	mu            sync.Mutex
+	routes        []domain.Route
+	serviceRoutes []domain.HTTPServiceRoute
+	external      map[string]string
 }
 
 func (f *fakeRoutes) GetRoutes(_ context.Context) []domain.Route {
@@ -53,6 +54,12 @@ func (f *fakeRoutes) GetExternalRoutes() map[string]string {
 	externalCopy := make(map[string]string, len(f.external))
 	maps.Copy(externalCopy, f.external)
 	return externalCopy
+}
+
+func (f *fakeRoutes) GetServiceRoutes() []domain.HTTPServiceRoute {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]domain.HTTPServiceRoute(nil), f.serviceRoutes...)
 }
 
 type mockIssuerRecorder struct {
@@ -680,6 +687,28 @@ func TestServiceReconcileObtainsMissingHTTP01Cert(t *testing.T) {
 	assert.Equal(t, []string{"app.example.com"}, stored[0].Names)
 	assert.False(t, stored[0].NotAfter.IsZero())
 	assert.NotEmpty(t, stored[0].Certificate.Certificate)
+}
+
+func TestServiceReconcileObtainsCertificateForHTTPSServiceRoute(t *testing.T) {
+	ctx := context.Background()
+	routes := &fakeRoutes{serviceRoutes: []domain.HTTPServiceRoute{{
+		Domain: "app.example.com", Service: "app", PortName: "web", HTTPS: true,
+	}}}
+	issuer, recorder := newMockPublicCertificateIssuer(t, nil, nil)
+	store, _ := newMockCertificateStore(t)
+	cfg := Config{Enabled: true, Email: "admin@example.com", Challenge: "http-01"}
+	svc := NewService(cfg, ServiceDeps{
+		Config: cfg, Routes: routes, Issuer: issuer, Store: store,
+		Challenges: NewHTTP01Challenges(),
+		Effective:  EffectiveChallenge{Mode: domain.ACMEChallengeHTTP01},
+	})
+
+	require.NoError(t, svc.Load(ctx))
+	require.NoError(t, svc.Reconcile(ctx))
+
+	orders := recorder.Orders()
+	require.Len(t, orders, 1)
+	require.Equal(t, []string{"app.example.com"}, orders[0].Names)
 }
 
 func TestServiceReconcile_SerializesConcurrentRuns(t *testing.T) {

--- a/internal/usecase/publictls/status.go
+++ b/internal/usecase/publictls/status.go
@@ -129,6 +129,15 @@ func collectRouteDomains(ctx context.Context, routes RouteSource) []string {
 			}
 		}
 	}
+	for _, route := range serviceRoutes(routes) {
+		canonical, ok := domain.CanonicalRouteDomain(route.Domain)
+		if ok && route.HTTPS {
+			if _, exists := routeSet[canonical]; !exists {
+				routeSet[canonical] = struct{}{}
+				domains = append(domains, canonical)
+			}
+		}
+	}
 	return domains
 }
 

--- a/internal/usecase/publictls/targets.go
+++ b/internal/usecase/publictls/targets.go
@@ -42,6 +42,10 @@ func DeriveCertificateTargets(
 // routeHosts collects all unique canonical hosts from routes and external keys,
 // sorted alphabetically. Trailing dots are stripped before canonicalization.
 func routeHosts(routes []domain.Route, external map[string]string, additionalHosts []string) []string {
+	return routeHostsWithServiceRoutes(routes, external, nil, additionalHosts)
+}
+
+func routeHostsWithServiceRoutes(routes []domain.Route, external map[string]string, serviceRoutes []domain.HTTPServiceRoute, additionalHosts []string) []string {
 	seen := make(map[string]struct{})
 	var hosts []string
 
@@ -63,12 +67,27 @@ func routeHosts(routes []domain.Route, external map[string]string, additionalHos
 	for h := range external {
 		addHost(h)
 	}
+	for _, route := range serviceRoutes {
+		if route.HTTPS {
+			addHost(route.Domain)
+		}
+	}
 	for _, h := range additionalHosts {
 		addHost(h)
 	}
 
 	sort.Strings(hosts)
 	return hosts
+}
+
+func serviceRoutes(source RouteSource) []domain.HTTPServiceRoute {
+	provider, ok := source.(interface {
+		GetServiceRoutes() []domain.HTTPServiceRoute
+	})
+	if !ok {
+		return nil
+	}
+	return provider.GetServiceRoutes()
 }
 
 // deriveHTTP01Targets creates one target per host for HTTP-01 challenge.

--- a/internal/usecase/publictls/targets.go
+++ b/internal/usecase/publictls/targets.go
@@ -28,7 +28,15 @@ func DeriveCertificateTargets(
 	resolver out.CloudflareZoneResolver,
 ) ([]CertificateTarget, error) {
 	hosts := routeHosts(routes, external, additionalHosts)
+	return deriveCertificateTargetsFromHosts(ctx, mode, hosts, resolver)
+}
 
+func deriveCertificateTargetsFromHosts(
+	ctx context.Context,
+	mode domain.ACMEChallengeMode,
+	hosts []string,
+	resolver out.CloudflareZoneResolver,
+) ([]CertificateTarget, error) {
 	switch mode {
 	case domain.ACMEChallengeHTTP01:
 		return deriveHTTP01Targets(hosts), nil

--- a/internal/usecase/services/config.go
+++ b/internal/usecase/services/config.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -9,26 +10,36 @@ import (
 )
 
 type Config struct {
-	Name      string            `mapstructure:"name"`
+	Image      string                     `mapstructure:"image"`
+	Containers map[string]ContainerConfig `mapstructure:"containers"`
+	Enabled    *bool                      `mapstructure:"enabled"`
+	Env        []string                   `mapstructure:"env"`
+	EnvFile    string                     `mapstructure:"env_file"`
+	Secrets    []SecretRefConfig          `mapstructure:"secrets"`
+	Readiness  ReadinessConfig            `mapstructure:"readiness"`
+	Cleanup    CleanupConfig              `mapstructure:"cleanup"`
+	Ports      map[string]PortConfig      `mapstructure:"ports"`
+	Volumes    []VolumeConfig             `mapstructure:"volumes"`
+}
+
+type ContainerConfig struct {
 	Image     string            `mapstructure:"image"`
-	Enabled   bool              `mapstructure:"enabled"`
 	Env       []string          `mapstructure:"env"`
 	EnvFile   string            `mapstructure:"env_file"`
 	Secrets   []SecretRefConfig `mapstructure:"secrets"`
 	Readiness ReadinessConfig   `mapstructure:"readiness"`
-	Cleanup   CleanupConfig     `mapstructure:"cleanup"`
-	Ports     []PortConfig      `mapstructure:"ports"`
 	Volumes   []VolumeConfig    `mapstructure:"volumes"`
 }
 
 type PortConfig struct {
-	Name         string                 `mapstructure:"name"`
-	Container    int                    `mapstructure:"container"`
-	Protocol     domain.NetworkProtocol `mapstructure:"protocol"`
-	Publish      string                 `mapstructure:"publish"`
-	Private      bool                   `mapstructure:"private"`
-	Public       bool                   `mapstructure:"public"`
-	TrustedCIDRs []string               `mapstructure:"trusted_cidrs"`
+	ContainerName string                     `mapstructure:"container"`
+	Container     int                        `mapstructure:"port"`
+	Protocol      domain.ServicePortProtocol `mapstructure:"protocol"`
+	TLS           bool                       `mapstructure:"tls"`
+	Publish       string                     `mapstructure:"publish"`
+	Private       bool                       `mapstructure:"private"`
+	Public        bool                       `mapstructure:"public"`
+	TrustedCIDRs  []string                   `mapstructure:"trusted_cidrs"`
 }
 
 type VolumeConfig struct {
@@ -61,31 +72,36 @@ type CleanupConfig struct {
 	RemoveContainer *bool `mapstructure:"remove_container"`
 }
 
-func ToDomain(configs []Config) ([]domain.StandaloneService, error) {
+func ToDomain(configs map[string]Config) ([]domain.StandaloneService, error) {
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	services := make([]domain.StandaloneService, 0, len(configs))
-	seenNames := make(map[string]struct{}, len(configs))
 	seenRuntimeNames := make(map[string]string, len(configs))
-	for i, cfg := range configs {
-		svc, err := cfg.ToDomain()
+	for _, name := range names {
+		svc, err := configs[name].ToDomain(name)
 		if err != nil {
-			return nil, fmt.Errorf("service config %d: %w", i, err)
-		}
-		name := strings.TrimSpace(svc.Name)
-		if _, ok := seenNames[name]; ok {
-			return nil, fmt.Errorf("service config %d: duplicate service name %q", i, name)
+			return nil, fmt.Errorf("service %q: %w", name, err)
 		}
 		runtimeName := serviceRuntimeIdentifier(name)
 		if previous, ok := seenRuntimeNames[runtimeName]; ok {
-			return nil, fmt.Errorf("service config %d: duplicate service name %q normalizes to same runtime identifier as %q", i, name, previous)
+			return nil, fmt.Errorf("service %q normalizes to same runtime identifier as %q", name, previous)
 		}
-		seenNames[name] = struct{}{}
 		seenRuntimeNames[runtimeName] = name
 		services = append(services, svc)
 	}
 	return services, nil
 }
 
-func (c Config) ToDomain() (domain.StandaloneService, error) {
+func (c Config) ToDomain(name string) (domain.StandaloneService, error) {
+	for portName, port := range c.Ports {
+		if port.Publish != "" {
+			return domain.StandaloneService{}, fmt.Errorf("port %q uses removed publish setting; Gordon assigns routed backend ports automatically", portName)
+		}
+	}
 	if err := c.Cleanup.validate(); err != nil {
 		return domain.StandaloneService{}, err
 	}
@@ -93,17 +109,22 @@ func (c Config) ToDomain() (domain.StandaloneService, error) {
 	if err != nil {
 		return domain.StandaloneService{}, err
 	}
+	containers, err := containersToDomain(c.Containers)
+	if err != nil {
+		return domain.StandaloneService{}, err
+	}
 	svc := domain.StandaloneService{
-		Name:      c.Name,
-		Image:     c.Image,
-		Enabled:   c.Enabled,
-		Env:       append([]string(nil), c.Env...),
-		EnvFile:   c.EnvFile,
-		Secrets:   secretRefsToDomain(c.Secrets),
-		Readiness: readiness,
-		Cleanup:   c.Cleanup.toDomain(),
-		Ports:     portsToDomain(c.Ports),
-		Volumes:   volumesToDomain(c.Volumes),
+		Name:       name,
+		Image:      c.Image,
+		Containers: containers,
+		Enabled:    c.enabled(),
+		Env:        append([]string(nil), c.Env...),
+		EnvFile:    c.EnvFile,
+		Secrets:    secretRefsToDomain(c.Secrets),
+		Readiness:  readiness,
+		Cleanup:    c.Cleanup.toDomain(),
+		Ports:      portsToDomain(c.Ports),
+		Volumes:    volumesToDomain(c.Volumes),
 	}
 	if err := svc.Validate(); err != nil {
 		return domain.StandaloneService{}, err
@@ -111,16 +132,24 @@ func (c Config) ToDomain() (domain.StandaloneService, error) {
 	return svc, nil
 }
 
+func (c Config) enabled() bool {
+	return c.Enabled == nil || *c.Enabled
+}
+
 func (c Config) readinessToDomain() (domain.StandaloneServiceReadiness, error) {
-	readinessType := c.Readiness.Type
+	return readinessConfigToDomain(c.Readiness)
+}
+
+func readinessConfigToDomain(config ReadinessConfig) (domain.StandaloneServiceReadiness, error) {
+	readinessType := config.Type
 	if readinessType == "" {
 		readinessType = domain.StandaloneServiceReadinessNone
 	}
-	readiness := domain.StandaloneServiceReadiness{Type: readinessType, Path: c.Readiness.Path, Contains: c.Readiness.Contains}
-	if c.Readiness.Timeout != "" {
-		timeout, err := time.ParseDuration(c.Readiness.Timeout)
+	readiness := domain.StandaloneServiceReadiness{Type: readinessType, Path: config.Path, Contains: config.Contains}
+	if config.Timeout != "" {
+		timeout, err := time.ParseDuration(config.Timeout)
 		if err != nil {
-			return domain.StandaloneServiceReadiness{}, fmt.Errorf("readiness timeout %q is invalid: %w", c.Readiness.Timeout, err)
+			return domain.StandaloneServiceReadiness{}, fmt.Errorf("readiness timeout %q is invalid: %w", config.Timeout, err)
 		}
 		if timeout <= 0 {
 			return domain.StandaloneServiceReadiness{}, fmt.Errorf("readiness timeout must be positive when set")
@@ -152,20 +181,55 @@ func (c CleanupConfig) validate() error {
 	return nil
 }
 
-func portsToDomain(configs []PortConfig) []domain.StandaloneServicePort {
+func portsToDomain(configs map[string]PortConfig) []domain.StandaloneServicePort {
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	ports := make([]domain.StandaloneServicePort, 0, len(configs))
-	for _, cfg := range configs {
+	for _, name := range names {
+		cfg := configs[name]
+		protocol := cfg.Protocol
+		if protocol == "" {
+			protocol = domain.ServicePortProtocolTCP
+		}
 		ports = append(ports, domain.StandaloneServicePort{
-			Name:         cfg.Name,
-			Container:    cfg.Container,
-			Protocol:     cfg.Protocol,
-			Publish:      cfg.Publish,
-			Private:      cfg.Private,
-			Public:       cfg.Public,
-			TrustedCIDRs: append([]string(nil), cfg.TrustedCIDRs...),
+			Name:          name,
+			ContainerName: cfg.ContainerName,
+			Container:     cfg.Container,
+			Protocol:      protocol,
+			TLS:           cfg.TLS,
+			Publish:       cfg.Publish,
+			Private:       cfg.Private,
+			Public:        cfg.Public,
+			TrustedCIDRs:  append([]string(nil), cfg.TrustedCIDRs...),
 		})
 	}
 	return ports
+}
+
+func containersToDomain(configs map[string]ContainerConfig) ([]domain.StandaloneServiceContainer, error) {
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	containers := make([]domain.StandaloneServiceContainer, 0, len(configs))
+	for _, name := range names {
+		cfg := configs[name]
+		readiness, err := readinessConfigToDomain(cfg.Readiness)
+		if err != nil {
+			return nil, fmt.Errorf("container %q: %w", name, err)
+		}
+		containers = append(containers, domain.StandaloneServiceContainer{
+			Name: name, Image: cfg.Image, Env: append([]string(nil), cfg.Env...), EnvFile: cfg.EnvFile,
+			Secrets: secretRefsToDomain(cfg.Secrets), Readiness: readiness, Volumes: volumesToDomain(cfg.Volumes),
+		})
+	}
+	return containers, nil
 }
 
 func volumesToDomain(configs []VolumeConfig) []domain.StandaloneServiceVolume {

--- a/internal/usecase/services/config_test.go
+++ b/internal/usecase/services/config_test.go
@@ -9,21 +9,32 @@ import (
 	"github.com/bnema/gordon/internal/domain"
 )
 
-func TestToDomainRejectsDuplicateServiceNames(t *testing.T) {
-	configs := []Config{
-		{Name: "cache", Image: "redis:7", Enabled: true},
-		{Name: "cache", Image: "redis:7", Enabled: true},
+func TestToDomainUsesKeyedServiceAndPortNames(t *testing.T) {
+	configs := map[string]Config{
+		"app": {
+			Image: "app:latest",
+			Ports: map[string]PortConfig{
+				"web":  {Container: 8080},
+				"game": {Container: 9000, Protocol: domain.ServicePortProtocolUDP},
+			},
+		},
 	}
 
-	_, err := ToDomain(configs)
+	services, err := ToDomain(configs)
 
-	require.ErrorContains(t, err, "duplicate service name")
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+	assert.Equal(t, "app", services[0].Name)
+	assert.Equal(t, []domain.StandaloneServicePort{
+		{Name: "game", Container: 9000, Protocol: domain.ServicePortProtocolUDP},
+		{Name: "web", Container: 8080, Protocol: domain.ServicePortProtocolTCP},
+	}, services[0].Ports)
 }
 
 func TestToDomainRejectsServiceNamesWithDuplicateRuntimeIdentifier(t *testing.T) {
-	configs := []Config{
-		{Name: "cache.api", Image: "redis:7", Enabled: true},
-		{Name: "cache_api", Image: "redis:7", Enabled: true},
+	configs := map[string]Config{
+		"cache.api": {Image: "redis:7"},
+		"cache_api": {Image: "redis:7"},
 	}
 
 	_, err := ToDomain(configs)
@@ -35,16 +46,14 @@ func TestConfigToDomainRejectsNonPositiveReadinessTimeout(t *testing.T) {
 	for _, timeout := range []string{"0s", "-1s"} {
 		t.Run(timeout, func(t *testing.T) {
 			cfg := Config{
-				Name:    "cache",
-				Image:   "redis:7",
-				Enabled: true,
+				Image: "redis:7",
 				Readiness: ReadinessConfig{
 					Type:    domain.StandaloneServiceReadinessTCP,
 					Timeout: timeout,
 				},
 			}
 
-			_, err := cfg.ToDomain()
+			_, err := cfg.ToDomain("cache")
 
 			require.ErrorContains(t, err, "readiness timeout")
 			require.ErrorContains(t, err, "positive")
@@ -56,33 +65,29 @@ func TestConfigToDomainRejectsExplicitNoCleanupAction(t *testing.T) {
 	preserveVolumes := false
 	removeContainer := false
 	cfg := Config{
-		Name:    "cache",
 		Image:   "redis:7",
-		Enabled: true,
 		Cleanup: CleanupConfig{PreserveVolumes: &preserveVolumes, RemoveContainer: &removeContainer},
 	}
 
-	_, err := cfg.ToDomain()
+	_, err := cfg.ToDomain("cache")
 
 	require.ErrorContains(t, err, "preserve_volumes=false")
 	require.ErrorContains(t, err, "remove_container=false")
 }
 
-func TestConfigToDomainMapsExplicitPublicPorts(t *testing.T) {
+func TestConfigToDomainMapsExplicitPortPolicy(t *testing.T) {
 	cfg := Config{
-		Name:    "game",
-		Image:   "game:latest",
-		Enabled: true,
-		Ports: []PortConfig{{
-			Name:      "rcon",
-			Container: 28016,
-			Protocol:  domain.NetworkProtocolTCP,
-			Publish:   "127.0.0.1:38016",
-			Public:    true,
-		}},
+		Image: "game:latest",
+		Ports: map[string]PortConfig{
+			"rcon": {
+				Container: 28016,
+				Protocol:  domain.ServicePortProtocolTCP,
+				Public:    true,
+			},
+		},
 	}
 
-	svc, err := cfg.ToDomain()
+	svc, err := cfg.ToDomain("game")
 
 	require.NoError(t, err)
 	require.Len(t, svc.Ports, 1)

--- a/internal/usecase/services/service.go
+++ b/internal/usecase/services/service.go
@@ -46,15 +46,20 @@ func NewServiceWithVolumePrefix(runtime out.ContainerRuntime, volumePrefix strin
 }
 
 func (s *Service) Reconcile(ctx context.Context, configured []domain.StandaloneService) error {
+	workloads, networks := normalizeServiceWorkloads(configured)
+	if err := s.ensureServiceNetworks(ctx, networks); err != nil {
+		return err
+	}
 	containers, err := s.runtime.ListContainers(ctx, true)
 	if err != nil {
 		return fmt.Errorf("list standalone service containers: %w", err)
 	}
 	existing := managedServiceContainers(containers)
-	configuredNames := make(map[string]struct{}, len(configured))
-	for _, svc := range configured {
-		configuredNames[svc.Name] = struct{}{}
-		if err := s.reconcileOne(ctx, svc, existing[svc.Name]); err != nil {
+	configuredNames := make(map[string]struct{}, len(workloads))
+	for _, svc := range workloads {
+		key := serviceWorkloadKey(svc.Name, svc.ContainerName)
+		configuredNames[key] = struct{}{}
+		if err := s.reconcileOne(ctx, svc, existing[key]); err != nil {
 			return err
 		}
 	}
@@ -64,6 +69,51 @@ func (s *Service) Reconcile(ctx context.Context, configured []domain.StandaloneS
 		}
 		if err := s.stopRemoved(ctx, name, containers); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) ResolvePorts(ctx context.Context, configured []domain.StandaloneService) ([]domain.ServicePortBackend, error) {
+	containers, err := s.runtime.ListContainers(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("list service containers for port resolution: %w", err)
+	}
+	existing := managedServiceContainers(containers)
+	backends := make([]domain.ServicePortBackend, 0)
+	for _, svc := range configured {
+		if !svc.Enabled {
+			continue
+		}
+		for _, port := range svc.Ports {
+			component := port.ContainerName
+			candidates := existing[serviceWorkloadKey(svc.Name, component)]
+			container := runningServiceContainer(candidates)
+			if container == nil {
+				return nil, fmt.Errorf("service %q port %q has no running container", svc.Name, port.Name)
+			}
+			hostPort, err := s.runtime.GetContainerPublishedPort(ctx, container.ID, port.Container, port.Protocol.NetworkProtocol())
+			if err != nil {
+				return nil, fmt.Errorf("resolve service %q port %q: %w", svc.Name, port.Name, err)
+			}
+			backends = append(backends, domain.ServicePortBackend{
+				Service: svc.Name, PortName: port.Name, Host: "127.0.0.1", Port: hostPort, Protocol: port.Protocol, TLS: port.TLS,
+			})
+		}
+	}
+	sort.Slice(backends, func(i, j int) bool {
+		if backends[i].Service == backends[j].Service {
+			return backends[i].PortName < backends[j].PortName
+		}
+		return backends[i].Service < backends[j].Service
+	})
+	return backends, nil
+}
+
+func runningServiceContainer(containers []*domain.Container) *domain.Container {
+	for _, container := range containers {
+		if containerStatus(container) == domain.ContainerStatusRunning {
+			return container
 		}
 	}
 	return nil
@@ -81,6 +131,7 @@ func (s *Service) Status(ctx context.Context) ([]domain.StandaloneServiceStatus,
 		}
 		statuses = append(statuses, domain.StandaloneServiceStatus{
 			Name:          container.Labels[domain.LabelServiceName],
+			ComponentName: container.Labels[domain.LabelServiceContainer],
 			ContainerID:   container.ID,
 			ContainerName: container.Name,
 			Status:        containerStatus(container),
@@ -130,6 +181,11 @@ func (s *Service) reconcileOne(ctx context.Context, svc domain.StandaloneService
 	if containerStatus(current) != domain.ContainerStatusRunning {
 		if err := s.runtime.StartContainer(ctx, current.ID); err != nil {
 			return fmt.Errorf("start standalone service %q container: %w", svc.Name, err)
+		}
+	}
+	if svc.Readiness.Type == domain.StandaloneServiceReadinessTCP {
+		if err := s.resolveTCPReadinessPort(ctx, current.ID, &svc); err != nil {
+			return err
 		}
 	}
 	if err := s.waitReadiness(ctx, current.ID, svc); err != nil {
@@ -249,10 +305,31 @@ func (s *Service) createAndStart(ctx context.Context, svc domain.StandaloneServi
 	if err := s.runtime.StartContainer(ctx, container.ID); err != nil {
 		return fmt.Errorf("start standalone service %q container: %w", svc.Name, err)
 	}
+	if svc.Readiness.Type == domain.StandaloneServiceReadinessTCP {
+		if err := s.resolveTCPReadinessPort(ctx, container.ID, &svc); err != nil {
+			return err
+		}
+	}
 	if err := s.waitReadiness(ctx, container.ID, svc); err != nil {
 		return err
 	}
 	return nil
+}
+
+func (s *Service) resolveTCPReadinessPort(ctx context.Context, containerID string, svc *domain.StandaloneService) error {
+	for i := range svc.Ports {
+		port := &svc.Ports[i]
+		if port.Protocol.NetworkProtocol() != domain.NetworkProtocolTCP {
+			continue
+		}
+		hostPort, err := s.runtime.GetContainerPublishedPort(ctx, containerID, port.Container, domain.NetworkProtocolTCP)
+		if err != nil {
+			return fmt.Errorf("resolve service %q readiness port %q: %w", svc.Name, port.Name, err)
+		}
+		port.Publish = net.JoinHostPort("127.0.0.1", strconv.Itoa(hostPort))
+		return nil
+	}
+	return fmt.Errorf("standalone service %q tcp readiness requires a declared TCP port", svc.Name)
 }
 
 func (s *Service) containerConfig(ctx context.Context, svc domain.StandaloneService, hash string, env []string) (*domain.ContainerConfig, error) {
@@ -264,7 +341,7 @@ func (s *Service) containerConfig(ctx context.Context, svc domain.StandaloneServ
 			return nil, fmt.Errorf("inspect standalone service %q image volumes: %w", svc.Name, err)
 		}
 	}
-	mounts := ResolveVolumeMounts(s.volumePrefix, svc.Name, svc.Volumes, imageVolumes)
+	mounts := ResolveVolumeMounts(s.volumePrefix, serviceWorkloadKey(svc.Name, svc.ContainerName), svc.Volumes, imageVolumes)
 	volumes := make(map[string]string)
 	readOnlyVolumes := make(map[string]string)
 	managedVolumes := make([]string, 0)
@@ -284,14 +361,16 @@ func (s *Service) containerConfig(ctx context.Context, svc domain.StandaloneServ
 	}
 	return &domain.ContainerConfig{
 		Image:           svc.Image,
-		Name:            serviceContainerName(svc.Name),
+		Name:            serviceContainerName(svc.Name, svc.ContainerName),
 		Env:             env,
 		PortPublishes:   publishes,
-		Labels:          serviceLabels(svc.Name, hash, normalizeCleanup(svc.Cleanup), managedVolumes),
+		Labels:          serviceLabels(svc.Name, svc.ContainerName, hash, normalizeCleanup(svc.Cleanup), managedVolumes),
 		AutoRemove:      false,
 		RestartPolicy:   domain.RestartPolicyAlways,
 		Volumes:         emptyToNil(volumes),
 		ReadOnlyVolumes: emptyToNil(readOnlyVolumes),
+		NetworkMode:     svc.NetworkName,
+		Aliases:         componentAliases(svc.ContainerName),
 	}, nil
 }
 
@@ -305,17 +384,19 @@ func managedServiceContainers(containers []*domain.Container) map[string][]*doma
 		if name == "" {
 			continue
 		}
-		managed[name] = append(managed[name], container)
+		key := serviceWorkloadKey(name, container.Labels[domain.LabelServiceContainer])
+		managed[key] = append(managed[key], container)
 	}
 	return managed
 }
 
-func serviceLabels(name, hash string, cleanup domain.StandaloneServiceCleanup, managedVolumes []string) map[string]string {
+func serviceLabels(name, component, hash string, cleanup domain.StandaloneServiceCleanup, managedVolumes []string) map[string]string {
 	sort.Strings(managedVolumes)
 	return map[string]string{
 		domain.LabelManaged:                       "true",
 		domain.LabelService:                       "true",
 		domain.LabelServiceName:                   name,
+		domain.LabelServiceContainer:              component,
 		domain.LabelServiceConfigHash:             hash,
 		domain.LabelServiceManagedVolumes:         strings.Join(managedVolumes, ","),
 		domain.LabelServiceCleanupPreserveVolumes: strconv.FormatBool(cleanup.PreserveVolumes),
@@ -326,19 +407,8 @@ func serviceLabels(name, hash string, cleanup domain.StandaloneServiceCleanup, m
 func portPublishes(svc domain.StandaloneService) ([]domain.ContainerPortPublish, error) {
 	publishes := make([]domain.ContainerPortPublish, 0, len(svc.Ports))
 	for _, port := range svc.Ports {
-		if port.Publish == "" {
-			continue
-		}
-		host, hostPort, err := net.SplitHostPort(port.Publish)
-		if err != nil {
-			return nil, fmt.Errorf("parse standalone service %q port %q publish: %w", svc.Name, port.Name, err)
-		}
-		hostPortNumber, err := strconv.Atoi(hostPort)
-		if err != nil {
-			return nil, fmt.Errorf("parse standalone service %q port %q publish port: %w", svc.Name, port.Name, err)
-		}
 		publishes = append(publishes, domain.ContainerPortPublish{
-			HostIP: host, HostPort: hostPortNumber, ContainerPort: port.Container, Protocol: port.Protocol,
+			HostIP: "127.0.0.1", HostPort: 0, ContainerPort: port.Container, Protocol: port.Protocol.NetworkProtocol(),
 		})
 	}
 	return publishes, nil
@@ -504,7 +574,7 @@ func waitTCPReadiness(ctx context.Context, svc domain.StandaloneService) error {
 
 func tcpReadinessAddress(svc domain.StandaloneService) (string, error) {
 	for _, port := range svc.Ports {
-		if port.Protocol != domain.NetworkProtocolTCP || port.Publish == "" {
+		if port.Protocol.NetworkProtocol() != domain.NetworkProtocolTCP || port.Publish == "" {
 			continue
 		}
 		host, hostPort, err := net.SplitHostPort(port.Publish)
@@ -601,6 +671,77 @@ func (s *Service) logContains(ctx context.Context, containerID, path, contains s
 	return false, fmt.Errorf("%w: limit is %d bytes", domain.ErrReadinessLogSizeExceeded, maxReadinessLogSize)
 }
 
+func normalizeServiceWorkloads(configured []domain.StandaloneService) ([]domain.StandaloneService, map[string]string) {
+	workloads := make([]domain.StandaloneService, 0, len(configured))
+	networks := make(map[string]string)
+	for _, svc := range configured {
+		if len(svc.Containers) == 0 {
+			workloads = append(workloads, svc)
+			continue
+		}
+		networkName := serviceNetworkName(svc.Name)
+		if svc.Enabled {
+			networks[svc.Name] = networkName
+		}
+		for _, component := range svc.Containers {
+			workload := svc
+			workload.Containers = nil
+			workload.Image = component.Image
+			workload.ContainerName = component.Name
+			workload.NetworkName = networkName
+			workload.Env = append(append([]string(nil), svc.Env...), component.Env...)
+			if component.EnvFile != "" {
+				workload.EnvFile = component.EnvFile
+			}
+			workload.Secrets = append(append([]domain.StandaloneServiceSecretRef(nil), svc.Secrets...), component.Secrets...)
+			if component.Readiness.Type != "" {
+				workload.Readiness = component.Readiness
+			}
+			workload.Volumes = append([]domain.StandaloneServiceVolume(nil), component.Volumes...)
+			workload.Ports = portsForComponent(svc.Ports, component.Name)
+			workloads = append(workloads, workload)
+		}
+	}
+	return workloads, networks
+}
+
+func portsForComponent(ports []domain.StandaloneServicePort, component string) []domain.StandaloneServicePort {
+	result := make([]domain.StandaloneServicePort, 0)
+	for _, port := range ports {
+		if port.ContainerName != component {
+			continue
+		}
+		port.ContainerName = ""
+		result = append(result, port)
+	}
+	return result
+}
+
+func (s *Service) ensureServiceNetworks(ctx context.Context, networks map[string]string) error {
+	if len(networks) == 0 {
+		return nil
+	}
+	existing, err := s.runtime.ListNetworks(ctx)
+	if err != nil {
+		return fmt.Errorf("list service networks: %w", err)
+	}
+	byName := make(map[string]struct{}, len(existing))
+	for _, network := range existing {
+		byName[network.Name] = struct{}{}
+	}
+	for serviceName, networkName := range networks {
+		if _, ok := byName[networkName]; ok {
+			continue
+		}
+		if err := s.runtime.CreateNetwork(ctx, networkName, domain.NetworkConfig{
+			Driver: "bridge", Labels: map[string]string{domain.LabelManaged: "true", domain.LabelServiceName: serviceName},
+		}); err != nil {
+			return fmt.Errorf("create private network for service %q: %w", serviceName, err)
+		}
+	}
+	return nil
+}
+
 func normalizeCleanup(cleanup domain.StandaloneServiceCleanup) domain.StandaloneServiceCleanup {
 	if !cleanup.PreserveVolumes && !cleanup.RemoveContainer {
 		return domain.StandaloneServiceCleanup{PreserveVolumes: true, RemoveContainer: true}
@@ -628,8 +769,34 @@ func containerStatus(container *domain.Container) domain.ContainerStatus {
 	return domain.ContainerStatusUnknown
 }
 
-func serviceContainerName(name string) string {
-	return "gordon-service-" + strings.NewReplacer(".", "-", "_", "-", "/", "-").Replace(name)
+func serviceContainerName(name string, components ...string) string {
+	base := "gordon-service-" + sanitizeServiceRuntimeName(name)
+	if len(components) == 0 || components[0] == "" {
+		return base
+	}
+	return base + "-" + sanitizeServiceRuntimeName(components[0])
+}
+
+func serviceNetworkName(name string) string {
+	return "gordon-service-" + sanitizeServiceRuntimeName(name)
+}
+
+func sanitizeServiceRuntimeName(name string) string {
+	return strings.NewReplacer(".", "-", "_", "-", "/", "-").Replace(name)
+}
+
+func serviceWorkloadKey(name, component string) string {
+	if component == "" {
+		return name
+	}
+	return name + "/" + component
+}
+
+func componentAliases(component string) []string {
+	if component == "" {
+		return nil
+	}
+	return []string{component}
 }
 
 func emptyToNil(values map[string]string) map[string]string {

--- a/internal/usecase/services/service_test.go
+++ b/internal/usecase/services/service_test.go
@@ -45,7 +45,7 @@ func TestService_ReconcileCreatesMissingEnabledService(t *testing.T) {
 	assert.Equal(t, "true", created.Labels[domain.LabelServiceCleanupRemoveContainer])
 	assert.NotEmpty(t, created.Labels[domain.LabelServiceConfigHash])
 	assert.Equal(t, "gordon-service-game-data", created.Labels[domain.LabelServiceManagedVolumes])
-	assert.Equal(t, []domain.ContainerPortPublish{{HostIP: "127.0.0.1", HostPort: 38015, ContainerPort: 28015, Protocol: domain.NetworkProtocolUDP}}, created.PortPublishes)
+	assert.Equal(t, []domain.ContainerPortPublish{{HostIP: "127.0.0.1", HostPort: 0, ContainerPort: 28015, Protocol: domain.NetworkProtocolUDP}}, created.PortPublishes)
 	assert.Equal(t, map[string]string{"/data": "gordon-service-game-data"}, created.Volumes)
 }
 
@@ -345,7 +345,7 @@ func TestServiceEnvUsesExplicitProviderSecretPaths(t *testing.T) {
 
 func TestTCPReadinessAddressMapsIPv6WildcardToIPv6Loopback(t *testing.T) {
 	svc := sampleService()
-	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.NetworkProtocolTCP, Publish: "[::]:38016"}}
+	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.ServicePortProtocolTCP, Publish: "[::]:38016"}}
 
 	address, err := tcpReadinessAddress(svc)
 
@@ -367,7 +367,7 @@ func TestWaitTCPReadinessDialsResolvedLoopbackPublish(t *testing.T) {
 	}()
 	svc := sampleService()
 	svc.Readiness = domain.StandaloneServiceReadiness{Type: domain.StandaloneServiceReadinessTCP, Timeout: time.Second}
-	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.NetworkProtocolTCP, Publish: listener.Addr().String()}}
+	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.ServicePortProtocolTCP, Publish: listener.Addr().String()}}
 
 	err = NewService(nil).waitReadiness(context.Background(), "container-1", svc)
 
@@ -416,7 +416,7 @@ func TestLogContainsReturnsSentinelAtSizeLimit(t *testing.T) {
 func TestWaitReadinessHonorsContextTimeout(t *testing.T) {
 	svc := sampleService()
 	svc.Readiness = domain.StandaloneServiceReadiness{Type: domain.StandaloneServiceReadinessTCP}
-	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:1"}}
+	svc.Ports = []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.ServicePortProtocolTCP, Publish: "127.0.0.1:1"}}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 
@@ -454,7 +454,7 @@ func sampleService() domain.StandaloneService {
 		Enabled: true,
 		Env:     []string{"PUBLIC=value"},
 		Cleanup: domain.StandaloneServiceCleanup{PreserveVolumes: true, RemoveContainer: true},
-		Ports:   []domain.StandaloneServicePort{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolUDP, Publish: "127.0.0.1:38015"}},
+		Ports:   []domain.StandaloneServicePort{{Name: "game", Container: 28015, Protocol: domain.ServicePortProtocolUDP, Publish: "127.0.0.1:38015"}},
 	}
 }
 

--- a/internal/usecase/traffic/builder.go
+++ b/internal/usecase/traffic/builder.go
@@ -98,6 +98,22 @@ func Build(input Input) (domain.TrafficGraph, error) {
 	return plan.Graph, nil
 }
 
+// Validate checks the complete traffic configuration without requiring live
+// service backends or mutating runtime state.
+func Validate(input Input) error {
+	input.ServiceBackends = make([]domain.ServicePortBackend, 0)
+	for _, service := range input.Services {
+		for _, port := range service.Ports {
+			input.ServiceBackends = append(input.ServiceBackends, domain.ServicePortBackend{
+				Service: service.Name, PortName: port.Name, Host: "127.0.0.1",
+				Port: port.Container, Protocol: port.Protocol, TLS: port.TLS,
+			})
+		}
+	}
+	_, err := BuildPlan(input)
+	return err
+}
+
 // BuildPlan validates routing and resolves HTTP bindings to Gordon-owned service ports.
 func BuildPlan(input Input) (Plan, error) {
 	b := builder{input: input, services: map[string]domain.TrafficService{}, serviceTargets: map[string]*domain.ProxyTarget{}}

--- a/internal/usecase/traffic/builder.go
+++ b/internal/usecase/traffic/builder.go
@@ -20,8 +20,10 @@ type Input struct {
 	Traffic         Config
 	Routes          []domain.Route
 	ExternalRoutes  map[string]string
+	ServiceRoutes   []domain.HTTPServiceRoute
 	NetworkServices []NetworkServiceConfig
 	Services        []domain.StandaloneService
+	ServiceBackends []domain.ServicePortBackend
 }
 
 type EntryPointConfig struct {
@@ -60,11 +62,13 @@ type TLSConfig struct {
 }
 
 type RouterConfig struct {
-	Name       string `mapstructure:"name"`
-	EntryPoint string `mapstructure:"entrypoint"`
-	Host       string `mapstructure:"host"`
-	SNI        string `mapstructure:"sni"`
-	Service    string `mapstructure:"service"`
+	Name           string `mapstructure:"name"`
+	EntryPoint     string `mapstructure:"entrypoint"`
+	Host           string `mapstructure:"host"`
+	SNI            string `mapstructure:"sni"`
+	Service        string `mapstructure:"service"`
+	NetworkService string `mapstructure:"network_service"`
+	Port           string `mapstructure:"port"`
 }
 
 type NetworkServiceConfig struct {
@@ -78,33 +82,51 @@ type PortConfig struct {
 	Protocol  domain.NetworkProtocol `mapstructure:"protocol"`
 }
 
+// Plan is the validated routing configuration shared by the traffic manager and HTTP proxy.
+type Plan struct {
+	Graph          domain.TrafficGraph
+	ServiceTargets map[string]*domain.ProxyTarget
+}
+
 // Build builds and validates a TrafficGraph snapshot. Managed route services are
 // intentionally backend-less because their concrete container endpoints are resolved at runtime.
 func Build(input Input) (domain.TrafficGraph, error) {
-	b := builder{input: input, services: map[string]domain.TrafficService{}}
+	plan, err := BuildPlan(input)
+	if err != nil {
+		return domain.TrafficGraph{}, err
+	}
+	return plan.Graph, nil
+}
+
+// BuildPlan validates routing and resolves HTTP bindings to Gordon-owned service ports.
+func BuildPlan(input Input) (Plan, error) {
+	b := builder{input: input, services: map[string]domain.TrafficService{}, serviceTargets: map[string]*domain.ProxyTarget{}}
 	graph := domain.TrafficGraph{}
 
 	options, err := buildOptions(input.Traffic)
 	if err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("build traffic options: %w", err)
+		return Plan{}, fmt.Errorf("build traffic options: %w", err)
 	}
 	if err := validateNetworkServices(input.NetworkServices); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate network services: %w", err)
+		return Plan{}, fmt.Errorf("validate network services: %w", err)
 	}
 	if err := validateStandaloneServices(input.Services); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate standalone services: %w", err)
+		return Plan{}, fmt.Errorf("validate standalone services: %w", err)
 	}
 	graph.Options = options
 	graph.EntryPoints = b.buildEntryPoints()
 
 	if err := b.addHTTPRoutes(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add HTTP routes: %w", err)
+		return Plan{}, fmt.Errorf("add HTTP routes: %w", err)
 	}
 	if err := b.addExternalRoutes(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add external routes: %w", err)
+		return Plan{}, fmt.Errorf("add external routes: %w", err)
+	}
+	if err := b.addHTTPServiceRoutes(); err != nil {
+		return Plan{}, fmt.Errorf("add HTTP service routes: %w", err)
 	}
 	if err := b.addExplicitRouters(&graph); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("add explicit traffic routers: %w", err)
+		return Plan{}, fmt.Errorf("add explicit traffic routers: %w", err)
 	}
 
 	graph.Services = make([]domain.TrafficService, 0, len(b.services))
@@ -113,14 +135,15 @@ func Build(input Input) (domain.TrafficGraph, error) {
 	}
 	sort.Slice(graph.Services, func(i, j int) bool { return graph.Services[i].Name < graph.Services[j].Name })
 	if err := graph.Validate(); err != nil {
-		return domain.TrafficGraph{}, fmt.Errorf("validate traffic graph: %w", err)
+		return Plan{}, fmt.Errorf("validate traffic graph: %w", err)
 	}
-	return graph, nil
+	return Plan{Graph: graph, ServiceTargets: b.serviceTargets}, nil
 }
 
 type builder struct {
-	input    Input
-	services map[string]domain.TrafficService
+	input          Input
+	services       map[string]domain.TrafficService
+	serviceTargets map[string]*domain.ProxyTarget
 }
 
 func (b *builder) buildEntryPoints() []domain.EntryPoint {
@@ -156,6 +179,55 @@ func (b *builder) addHTTPRoutes(graph *domain.TrafficGraph) error {
 		graph.Routers = append(graph.Routers, domain.TrafficRouter{Name: "route:" + route.Domain, EntryPoint: entryPoint, Protocol: domain.RouterProtocolHTTP, Rule: domain.TrafficRule{Host: route.Domain}, Service: serviceName})
 	}
 	return nil
+}
+
+func (b *builder) addHTTPServiceRoutes() error {
+	routes := append([]domain.HTTPServiceRoute(nil), b.input.ServiceRoutes...)
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Domain < routes[j].Domain })
+	for _, route := range routes {
+		canonicalDomain, ok := domain.CanonicalRouteDomain(route.Domain)
+		if !ok {
+			return fmt.Errorf("invalid service route domain %q", route.Domain)
+		}
+		if _, exists := b.serviceTargets[canonicalDomain]; exists {
+			return fmt.Errorf("duplicate service route domain %q", canonicalDomain)
+		}
+		target, err := b.resolveHTTPServiceTarget(route, canonicalDomain)
+		if err != nil {
+			return fmt.Errorf("service route %q: %w", route.Domain, err)
+		}
+		b.serviceTargets[canonicalDomain] = target
+	}
+	return nil
+}
+
+func (b *builder) resolveHTTPServiceTarget(route domain.HTTPServiceRoute, canonicalDomain string) (*domain.ProxyTarget, error) {
+	svc, ok := b.standaloneService(route.Service)
+	if !ok || !svc.Enabled {
+		return nil, fmt.Errorf("unknown service %q", route.Service)
+	}
+	port, ok := standaloneServicePort(svc, route.PortName)
+	if !ok {
+		return nil, fmt.Errorf("unknown port %q on service %q", route.PortName, route.Service)
+	}
+	if !port.Protocol.IsHTTP() {
+		return nil, fmt.Errorf("service %q port %q protocol %s cannot handle an HTTP route", route.Service, route.PortName, port.Protocol)
+	}
+	if isPrivateStandalonePort(port) && len(port.TrustedCIDRs) == 0 {
+		return nil, fmt.Errorf("private service %q port %q requires non-empty trusted_cidrs", route.Service, route.PortName)
+	}
+	backend, ok := b.serviceBackend(route.Service, route.PortName)
+	if !ok {
+		return nil, fmt.Errorf("service %q port %q has no resolved runtime backend", route.Service, route.PortName)
+	}
+	target := &domain.ProxyTarget{Host: backend.Host, Port: backend.Port, Scheme: "http", RouteHost: canonicalDomain}
+	if port.TLS {
+		target.Scheme = "https"
+	}
+	if isPrivateStandalonePort(port) {
+		target.TrustedCIDRs = append([]string(nil), port.TrustedCIDRs...)
+	}
+	return target, nil
 }
 
 func (b *builder) addExternalRoutes(graph *domain.TrafficGraph) error {
@@ -224,73 +296,92 @@ func (b *builder) addL4Routers(graph *domain.TrafficGraph, routers []RouterConfi
 	ordered := append([]RouterConfig{}, routers...)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
 	for _, cfg := range ordered {
-		service, err := b.resolveService(cfg, backendProtocol)
+		service, err := b.resolveService(cfg, protocol, backendProtocol)
 		if err != nil {
 			return fmt.Errorf("router %q: %w", cfg.Name, err)
 		}
 		b.addService(service)
-		graph.Routers = append(graph.Routers, domain.TrafficRouter{Name: cfg.Name, EntryPoint: cfg.EntryPoint, Protocol: protocol, Rule: domain.TrafficRule{Host: cfg.Host, SNI: cfg.SNI}, Service: cfg.Service})
+		graph.Routers = append(graph.Routers, domain.TrafficRouter{Name: cfg.Name, EntryPoint: cfg.EntryPoint, Protocol: protocol, Rule: domain.TrafficRule{Host: cfg.Host, SNI: cfg.SNI}, Service: service.Name})
 	}
 	return nil
 }
 
-func (b *builder) resolveService(router RouterConfig, protocol domain.NetworkProtocol) (domain.TrafficService, error) {
-	ref, err := domain.ParseTrafficServiceRef(router.Service)
-	if err != nil {
-		return domain.TrafficService{}, err
+func (b *builder) resolveService(router RouterConfig, routerProtocol domain.RouterProtocol, networkProtocol domain.NetworkProtocol) (domain.TrafficService, error) {
+	if strings.Contains(router.Service, ":") {
+		return domain.TrafficService{}, fmt.Errorf("service reference %q uses removed typed-ref syntax; set service and port separately", router.Service)
 	}
-	switch ref.Kind {
-	case domain.TrafficServiceRefNetworkService:
-		return b.resolveNetworkService(router.Service, ref, protocol)
-	case domain.TrafficServiceRefService:
-		return b.resolveStandaloneService(router, ref, protocol)
-	case domain.TrafficServiceRefStatic:
-		return domain.TrafficService{}, fmt.Errorf("static service ref %q is unsupported", router.Service)
-	default:
-		return domain.TrafficService{}, fmt.Errorf("service ref %q must be network_service:<name>:<port-name> or service:<name>:<port-name>", router.Service)
+	if strings.TrimSpace(router.Port) == "" {
+		return domain.TrafficService{}, fmt.Errorf("port is required")
 	}
+	if router.Service != "" && router.NetworkService != "" {
+		return domain.TrafficService{}, fmt.Errorf("define exactly one of service or network_service")
+	}
+	if router.Service != "" {
+		return b.resolveStandaloneService(router, router.Service, router.Port, routerProtocol)
+	}
+	if router.NetworkService != "" {
+		return b.resolveNetworkService(router.NetworkService, router.Port, networkProtocol)
+	}
+	return domain.TrafficService{}, fmt.Errorf("service or network_service is required")
 }
 
-func (b *builder) resolveNetworkService(refValue string, ref domain.TrafficServiceRef, protocol domain.NetworkProtocol) (domain.TrafficService, error) {
-	ns, ok := b.networkService(ref.Name)
+func (b *builder) resolveNetworkService(name, portName string, protocol domain.NetworkProtocol) (domain.TrafficService, error) {
+	ns, ok := b.networkService(name)
 	if !ok {
-		return domain.TrafficService{}, fmt.Errorf("unknown network service %q", ref.Name)
+		return domain.TrafficService{}, fmt.Errorf("unknown network service %q", name)
 	}
-	port, ok := networkServicePort(ns, ref.PortName)
+	port, ok := networkServicePort(ns, portName)
 	if !ok {
-		return domain.TrafficService{}, fmt.Errorf("unknown port %q on network service %q", ref.PortName, ref.Name)
+		return domain.TrafficService{}, fmt.Errorf("unknown port %q on network service %q", portName, name)
 	}
 	if port.Container < 1 || port.Container > 65535 {
-		return domain.TrafficService{}, fmt.Errorf("invalid port %d on network service %q port %q", port.Container, ref.Name, ref.PortName)
+		return domain.TrafficService{}, fmt.Errorf("invalid port %d on network service %q port %q", port.Container, name, portName)
 	}
 	if port.Protocol != protocol {
-		return domain.TrafficService{}, fmt.Errorf("network service %q port %q protocol %s does not match router protocol %s", ref.Name, ref.PortName, port.Protocol, protocol)
+		return domain.TrafficService{}, fmt.Errorf("network service %q port %q protocol %s does not match router protocol %s", name, portName, port.Protocol, protocol)
 	}
-	return domain.TrafficService{Name: refValue, Backends: []domain.TrafficBackend{{Name: ref.Name + ":" + ref.PortName, Host: ref.Name, Port: port.Container, Protocol: port.Protocol}}}, nil
+	serviceName := "network_service:" + name + ":" + portName
+	return domain.TrafficService{Name: serviceName, Backends: []domain.TrafficBackend{{Name: name + ":" + portName, Host: name, Port: port.Container, Protocol: port.Protocol}}}, nil
 }
 
-func (b *builder) resolveStandaloneService(router RouterConfig, ref domain.TrafficServiceRef, protocol domain.NetworkProtocol) (domain.TrafficService, error) {
-	svc, ok := b.standaloneService(ref.Name)
+func (b *builder) resolveStandaloneService(router RouterConfig, name, portName string, routerProtocol domain.RouterProtocol) (domain.TrafficService, error) {
+	svc, ok := b.standaloneService(name)
 	if !ok || !svc.Enabled {
-		return domain.TrafficService{}, fmt.Errorf("unknown service %q", ref.Name)
+		return domain.TrafficService{}, fmt.Errorf("unknown service %q", name)
 	}
-	port, ok := standaloneServicePort(svc, ref.PortName)
+	port, ok := standaloneServicePort(svc, portName)
 	if !ok {
-		return domain.TrafficService{}, fmt.Errorf("unknown port %q on service %q", ref.PortName, ref.Name)
+		return domain.TrafficService{}, fmt.Errorf("unknown port %q on service %q", portName, name)
 	}
-	if port.Protocol != protocol {
-		return domain.TrafficService{}, fmt.Errorf("service %q port %q protocol %s does not match router protocol %s", ref.Name, ref.PortName, port.Protocol, protocol)
+	expectedProtocol := serviceProtocolForRouter(routerProtocol)
+	if port.Protocol != expectedProtocol {
+		return domain.TrafficService{}, fmt.Errorf("service %q port %q protocol %s does not match router protocol %s", name, portName, port.Protocol, routerProtocol)
+	}
+	if routerProtocol == domain.RouterProtocolTLSPassthrough && !port.TLS {
+		return domain.TrafficService{}, fmt.Errorf("service %q port %q must set tls = true for TLS passthrough", name, portName)
 	}
 	if isPrivateStandalonePort(port) {
 		if err := b.validatePrivateStandalonePortRoute(router, svc, port); err != nil {
 			return domain.TrafficService{}, err
 		}
 	}
-	host, backendPort, err := parseBackendAddress(port.Publish)
-	if err != nil {
-		return domain.TrafficService{}, fmt.Errorf("service %q port %q publish address %q is invalid: %w", ref.Name, ref.PortName, port.Publish, err)
+	backend, ok := b.serviceBackend(name, portName)
+	if !ok {
+		return domain.TrafficService{}, fmt.Errorf("service %q port %q has no resolved runtime backend", name, portName)
 	}
-	return domain.TrafficService{Name: router.Service, Backends: []domain.TrafficBackend{{Name: ref.Name + ":" + ref.PortName, Host: host, Port: backendPort, Protocol: port.Protocol}}}, nil
+	serviceName := "service:" + name + ":" + portName
+	return domain.TrafficService{Name: serviceName, Backends: []domain.TrafficBackend{{Name: name + ":" + portName, Host: backend.Host, Port: backend.Port, Protocol: port.Protocol.NetworkProtocol()}}}, nil
+}
+
+func serviceProtocolForRouter(protocol domain.RouterProtocol) domain.ServicePortProtocol {
+	switch protocol {
+	case domain.RouterProtocolUDP:
+		return domain.ServicePortProtocolUDP
+	case domain.RouterProtocolTLSPassthrough:
+		return domain.ServicePortProtocolTCP
+	default:
+		return domain.ServicePortProtocolTCP
+	}
 }
 
 func validateStandaloneServices(services []domain.StandaloneService) error {
@@ -363,6 +454,15 @@ func (b *builder) networkService(name string) (NetworkServiceConfig, bool) {
 		}
 	}
 	return NetworkServiceConfig{}, false
+}
+
+func (b *builder) serviceBackend(serviceName, portName string) (domain.ServicePortBackend, bool) {
+	for _, backend := range b.input.ServiceBackends {
+		if backend.Service == serviceName && backend.PortName == portName {
+			return backend, true
+		}
+	}
+	return domain.ServicePortBackend{}, false
 }
 
 func (b *builder) standaloneService(name string) (domain.StandaloneService, bool) {

--- a/internal/usecase/traffic/builder_test.go
+++ b/internal/usecase/traffic/builder_test.go
@@ -68,7 +68,7 @@ func TestBuildRawFallbackConfigMapsToEntryPoint(t *testing.T) {
 			RawFallbackTrustedCIDRs: []string{"100.64.0.0/10"},
 			AllowPublicRawFallback:  true,
 		}},
-		Traffic:         Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "ssh-fallback", EntryPoint: "edge", Service: "network_service:ssh:ssh"}}}},
+		Traffic:         Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "ssh-fallback", EntryPoint: "edge", NetworkService: "ssh", Port: "ssh"}}}},
 		NetworkServices: []NetworkServiceConfig{{Name: "ssh", Ports: []PortConfig{{Name: "ssh", Container: 22, Protocol: domain.NetworkProtocolTCP}}}},
 	})
 	require.NoError(t, err)
@@ -116,9 +116,9 @@ func TestBuildExplicitTCPUDPTLSRouterResolution(t *testing.T) {
 			"tls-db":  {Address: ":15432", Protocol: domain.EntryPointProtocolTLSMux},
 		},
 		Traffic: Config{
-			TCP: TCPConfig{Routers: []RouterConfig{{Name: "db", EntryPoint: "tcp-db", Service: "network_service:postgres:sql"}}},
-			UDP: UDPConfig{Routers: []RouterConfig{{Name: "dns", EntryPoint: "udp-dns", Service: "network_service:coredns:dns"}}},
-			TLS: TLSConfig{Routers: []RouterConfig{{Name: "tlsdb", EntryPoint: "tls-db", SNI: "db.example.com", Service: "network_service:postgres:sql"}}},
+			TCP: TCPConfig{Routers: []RouterConfig{{Name: "db", EntryPoint: "tcp-db", NetworkService: "postgres", Port: "sql"}}},
+			UDP: UDPConfig{Routers: []RouterConfig{{Name: "dns", EntryPoint: "udp-dns", NetworkService: "coredns", Port: "dns"}}},
+			TLS: TLSConfig{Routers: []RouterConfig{{Name: "tlsdb", EntryPoint: "tls-db", SNI: "db.example.com", NetworkService: "postgres", Port: "sql"}}},
 		},
 		NetworkServices: []NetworkServiceConfig{
 			{Name: "postgres", Ports: []PortConfig{{Name: "sql", Container: 5432, Protocol: domain.NetworkProtocolTCP}}},
@@ -144,7 +144,7 @@ func TestBuildRejectsTLSHTTPRouteConflict(t *testing.T) {
 	_, err := Build(Input{
 		EntryPoints:     map[string]EntryPointConfig{"edge": {Address: ":443", Protocol: domain.EntryPointProtocolSmartTCP}},
 		Routes:          []domain.Route{{Domain: "app.example.com", HTTPS: true}},
-		Traffic:         Config{TLS: TLSConfig{Routers: []RouterConfig{{Name: "passthrough", EntryPoint: "edge", SNI: "app.example.com", Service: "network_service:app:https"}}}},
+		Traffic:         Config{TLS: TLSConfig{Routers: []RouterConfig{{Name: "passthrough", EntryPoint: "edge", SNI: "app.example.com", NetworkService: "app", Port: "https"}}}},
 		NetworkServices: []NetworkServiceConfig{{Name: "app", Ports: []PortConfig{{Name: "https", Container: 443, Protocol: domain.NetworkProtocolTCP}}}},
 	})
 	require.ErrorContains(t, err, "http host conflicts")
@@ -210,79 +210,72 @@ func TestBuildRejectsAmbiguousNetworkServices(t *testing.T) {
 func TestBuildResolvesStandaloneServiceBackend(t *testing.T) {
 	graph, err := Build(Input{
 		EntryPoints: map[string]EntryPointConfig{"udp": {Address: ":28015", Protocol: domain.EntryPointProtocolUDP}},
-		Traffic:     Config{UDP: UDPConfig{Routers: []RouterConfig{{Name: "rust-game", EntryPoint: "udp", Service: "service:rust:game"}}}},
+		Traffic:     Config{UDP: UDPConfig{Routers: []RouterConfig{{Name: "gameplay", EntryPoint: "udp", Service: "game", Port: "gameplay"}}}},
 		Services: []domain.StandaloneService{{
-			Name:    "rust",
-			Image:   "localhost/rust:latest",
+			Name:    "game",
+			Image:   "localhost/game-server:latest",
 			Enabled: true,
-			Ports:   []domain.StandaloneServicePort{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolUDP, Publish: "127.0.0.1:38015"}},
+			Ports:   []domain.StandaloneServicePort{{Name: "gameplay", Container: 28015, Protocol: domain.ServicePortProtocolUDP}},
 		}},
+		ServiceBackends: []domain.ServicePortBackend{{Service: "game", PortName: "gameplay", Host: "127.0.0.1", Port: 38015, Protocol: domain.ServicePortProtocolUDP}},
 	})
 	require.NoError(t, err)
-	require.Contains(t, graph.Services, domain.TrafficService{Name: "service:rust:game", Backends: []domain.TrafficBackend{{Name: "rust:game", Host: "127.0.0.1", Port: 38015, Protocol: domain.NetworkProtocolUDP}}})
+	require.Contains(t, graph.Services, domain.TrafficService{Name: "service:game:gameplay", Backends: []domain.TrafficBackend{{Name: "game:gameplay", Host: "127.0.0.1", Port: 38015, Protocol: domain.NetworkProtocolUDP}}})
 }
 
 func TestBuildRejectsInvalidStandaloneServiceRefs(t *testing.T) {
 	base := Input{
 		EntryPoints: map[string]EntryPointConfig{"tcp": {Address: ":1234", Protocol: domain.EntryPointProtocolTCP}},
 		Services: []domain.StandaloneService{{
-			Name:    "rust",
-			Image:   "localhost/rust:latest",
+			Name:    "game",
+			Image:   "localhost/game-server:latest",
 			Enabled: true,
-			Ports:   []domain.StandaloneServicePort{{Name: "game", Container: 28015, Protocol: domain.NetworkProtocolUDP, Publish: "127.0.0.1:38015"}, {Name: "rcon", Container: 28016, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:38016", Private: true, TrustedCIDRs: []string{"100.64.0.0/10"}}},
+			Ports:   []domain.StandaloneServicePort{{Name: "gameplay", Container: 28015, Protocol: domain.ServicePortProtocolUDP}, {Name: "admin", Container: 28016, Protocol: domain.ServicePortProtocolTCP, Private: true, TrustedCIDRs: []string{"100.64.0.0/10"}}},
 		}},
+		ServiceBackends: []domain.ServicePortBackend{
+			{Service: "game", PortName: "gameplay", Host: "127.0.0.1", Port: 38015, Protocol: domain.ServicePortProtocolUDP},
+			{Service: "game", PortName: "admin", Host: "127.0.0.1", Port: 38016, Protocol: domain.ServicePortProtocolTCP},
+		},
 	}
 
 	t.Run("unknown service", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:missing:rcon"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "missing", Port: "admin"}}}}
 		_, err := Build(input)
 		require.ErrorContains(t, err, "router \"bad\": unknown service \"missing\"")
 	})
 
 	t.Run("unknown port", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:rust:missing"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "game", Port: "missing"}}}}
 		_, err := Build(input)
-		require.ErrorContains(t, err, "unknown port \"missing\" on service \"rust\"")
+		require.ErrorContains(t, err, "unknown port \"missing\" on service \"game\"")
 	})
 
 	t.Run("disabled service", func(t *testing.T) {
 		input := base
 		input.Services = append([]domain.StandaloneService(nil), base.Services...)
 		input.Services[0].Enabled = false
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:rust:rcon"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "game", Port: "admin"}}}}
 		_, err := Build(input)
-		require.ErrorContains(t, err, "unknown service \"rust\"")
+		require.ErrorContains(t, err, "unknown service \"game\"")
 	})
 
 	t.Run("protocol mismatch", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:rust:game"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "game", Port: "gameplay"}}}}
 		_, err := Build(input)
-		require.ErrorContains(t, err, "service \"rust\" port \"game\" protocol udp does not match router protocol tcp")
+		require.ErrorContains(t, err, "service \"game\" port \"gameplay\" protocol udp does not match router protocol tcp")
 	})
 
-	t.Run("missing publish", func(t *testing.T) {
+	t.Run("missing runtime backend", func(t *testing.T) {
 		input := base
-		input.EntryPoints = map[string]EntryPointConfig{"tcp": {Address: ":1234", Protocol: domain.EntryPointProtocolTCP, TrustedCIDRs: []string{"100.64.0.0/10"}}}
-		input.Services = append([]domain.StandaloneService(nil), base.Services...)
-		input.Services[0].Ports = append([]domain.StandaloneServicePort(nil), base.Services[0].Ports...)
-		input.Services[0].Ports[1].Publish = ""
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:rust:rcon"}}}}
+		input.ServiceBackends = nil
+		input.Services[0].Ports[1].Private = false
+		input.Services[0].Ports[1].Public = true
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "game", Port: "admin"}}}}
 		_, err := Build(input)
-		require.ErrorContains(t, err, "service \"rust\" port \"rcon\" publish address")
-	})
-
-	t.Run("invalid publish", func(t *testing.T) {
-		input := base
-		input.EntryPoints = map[string]EntryPointConfig{"tcp": {Address: ":1234", Protocol: domain.EntryPointProtocolTCP, TrustedCIDRs: []string{"100.64.0.0/10"}}}
-		input.Services = append([]domain.StandaloneService(nil), base.Services...)
-		input.Services[0].Ports = append([]domain.StandaloneServicePort(nil), base.Services[0].Ports...)
-		input.Services[0].Ports[1].Publish = "127.0.0.1:notaport"
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "service:rust:rcon"}}}}
-		_, err := Build(input)
-		require.ErrorContains(t, err, "publish address")
+		require.ErrorContains(t, err, "has no resolved runtime backend")
 	})
 }
 
@@ -290,14 +283,14 @@ func TestBuildWrapsStandaloneServiceValidationErrorsWithServiceName(t *testing.T
 	_, err := Build(Input{
 		EntryPoints: map[string]EntryPointConfig{"tcp": {Address: ":1234", Protocol: domain.EntryPointProtocolTCP}},
 		Services: []domain.StandaloneService{{
-			Name:    "rust",
-			Image:   "localhost/rust:latest",
+			Name:    "game",
+			Image:   "localhost/game-server:latest",
 			Enabled: true,
-			Ports:   []domain.StandaloneServicePort{{Name: " admin ", Container: 28016, Protocol: domain.NetworkProtocolTCP}},
+			Ports:   []domain.StandaloneServicePort{{Name: " admin ", Container: 28016, Protocol: domain.ServicePortProtocolTCP}},
 		}},
 	})
 
-	require.ErrorContains(t, err, "standalone service \"rust\"")
+	require.ErrorContains(t, err, "standalone service \"game\"")
 	require.ErrorContains(t, err, "leading or trailing whitespace")
 }
 
@@ -305,13 +298,14 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 	base := func() Input {
 		return Input{
 			EntryPoints: map[string]EntryPointConfig{"tcp": {Address: ":28016", Protocol: domain.EntryPointProtocolTCP, TrustedCIDRs: []string{"100.64.0.0/10"}}},
-			Traffic:     Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "rust-rcon", EntryPoint: "tcp", Service: "service:rust:rcon"}}}},
+			Traffic:     Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "game-admin", EntryPoint: "tcp", Service: "game", Port: "admin"}}}},
 			Services: []domain.StandaloneService{{
-				Name:    "rust",
-				Image:   "localhost/rust:latest",
+				Name:    "game",
+				Image:   "localhost/game-server:latest",
 				Enabled: true,
-				Ports:   []domain.StandaloneServicePort{{Name: "rcon", Container: 28016, Protocol: domain.NetworkProtocolTCP, Publish: "127.0.0.1:38016", TrustedCIDRs: []string{"100.64.0.0/10"}}},
+				Ports:   []domain.StandaloneServicePort{{Name: "admin", Container: 28016, Protocol: domain.ServicePortProtocolTCP, Private: true, TrustedCIDRs: []string{"100.64.0.0/10"}}},
 			}},
+			ServiceBackends: []domain.ServicePortBackend{{Service: "game", PortName: "admin", Host: "127.0.0.1", Port: 38016, Protocol: domain.ServicePortProtocolTCP}},
 		}
 	}
 
@@ -337,10 +331,11 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 
 	t.Run("explicit private non-rcon rejects service port without trusted cidrs", func(t *testing.T) {
 		input := base()
-		input.Services[0].Ports[0].Name = "admin"
+		input.Services[0].Ports[0].Name = "management"
 		input.Services[0].Ports[0].Private = true
 		input.Services[0].Ports[0].TrustedCIDRs = nil
-		input.Traffic.TCP.Routers[0].Service = "service:rust:admin"
+		input.Traffic.TCP.Routers[0].Port = "management"
+		input.ServiceBackends[0].PortName = "management"
 		_, err := Build(input)
 		require.ErrorContains(t, err, "requires non-empty service port trusted_cidrs")
 	})
@@ -366,9 +361,10 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("explicit public rcon is allowed without trusted cidrs", func(t *testing.T) {
+	t.Run("explicit public admin is allowed without trusted cidrs", func(t *testing.T) {
 		input := base()
 		input.EntryPoints = map[string]EntryPointConfig{"tcp": {Address: ":28016", Protocol: domain.EntryPointProtocolTCP}}
+		input.Services[0].Ports[0].Private = false
 		input.Services[0].Ports[0].Public = true
 		input.Services[0].Ports[0].TrustedCIDRs = nil
 		_, err := Build(input)
@@ -378,14 +374,30 @@ func TestBuildEnforcesPrivateStandaloneServicePortRouting(t *testing.T) {
 	t.Run("explicit public non-rcon is allowed without trusted cidrs", func(t *testing.T) {
 		input := base()
 		input.EntryPoints = map[string]EntryPointConfig{"tcp": {Address: ":28016", Protocol: domain.EntryPointProtocolTCP}}
-		input.Services[0].Ports[0].Name = "admin"
+		input.Services[0].Ports[0].Name = "management"
 		input.Services[0].Ports[0].Private = false
 		input.Services[0].Ports[0].Public = true
 		input.Services[0].Ports[0].TrustedCIDRs = nil
-		input.Traffic.TCP.Routers[0].Service = "service:rust:admin"
+		input.Traffic.TCP.Routers[0].Port = "management"
+		input.ServiceBackends[0].PortName = "management"
 		_, err := Build(input)
 		require.NoError(t, err)
 	})
+}
+
+func TestBuildPlanResolvesHTTPServiceRouteWithoutRouteContainer(t *testing.T) {
+	plan, err := BuildPlan(Input{
+		ServiceRoutes: []domain.HTTPServiceRoute{{Domain: "Play.Example.com", Service: "game", PortName: "web"}},
+		Services: []domain.StandaloneService{{
+			Name: "game", Enabled: true, Image: "example/game-server:latest",
+			Ports: []domain.StandaloneServicePort{{Name: "web", Container: 8080, Protocol: domain.ServicePortProtocolHTTP}},
+		}},
+		ServiceBackends: []domain.ServicePortBackend{{Service: "game", PortName: "web", Host: "127.0.0.1", Port: 18080, Protocol: domain.ServicePortProtocolHTTP}},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, plan.Graph.Routers, "service routes are HTTP proxy targets, not traffic-manager routers")
+	require.Equal(t, &domain.ProxyTarget{Host: "127.0.0.1", Port: 18080, Scheme: "http", RouteHost: "play.example.com"}, plan.ServiceTargets["play.example.com"])
 }
 
 func TestBuildRejectsInvalidServiceRefs(t *testing.T) {
@@ -396,21 +408,21 @@ func TestBuildRejectsInvalidServiceRefs(t *testing.T) {
 
 	t.Run("unknown service", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "network_service:missing:tcp"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", NetworkService: "missing", Port: "tcp"}}}}
 		_, err := Build(input)
 		require.ErrorContains(t, err, "unknown network service")
 	})
 
 	t.Run("unknown port", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "network_service:svc:missing"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", NetworkService: "svc", Port: "missing"}}}}
 		_, err := Build(input)
 		require.ErrorContains(t, err, "unknown port")
 	})
 
 	t.Run("protocol mismatch", func(t *testing.T) {
 		input := base
-		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", Service: "network_service:svc:udp"}}}}
+		input.Traffic = Config{TCP: TCPConfig{Routers: []RouterConfig{{Name: "bad", EntryPoint: "tcp", NetworkService: "svc", Port: "udp"}}}}
 		_, err := Build(input)
 		require.ErrorContains(t, err, "does not match")
 	})


### PR DESCRIPTION
## Summary

- replace route-owned deployments with keyed Gordon-managed services
- support compact single-container and keyed multi-container service definitions
- bind HTTP and L4 traffic through explicit service and port fields
- model backend TLS independently with `tls = true`
- add private service networks, stable component aliases, and Gordon-managed backend port resolution
- reject removed service arrays, image-backed routes, typed target references, and manual service publication with migration errors

## Canonical model

```toml
[services.app]
image = "app:latest"
ports = { web = "8080/http" }

[routes]
"app.example.com" = { service = "app", port = "web" }
```

```toml
[services.shop.containers]
web = "shop-web:latest"
postgres = "postgres:18"
valkey = "valkey/valkey:latest"

[services.shop.ports]
web = "web:3000/http"
```

Internal-only ports such as `postgres:5432` and `valkey:6379` are not declared.

## Current draft status

This is an active breaking migration branch. Do not merge yet. Legacy-positive config tests, CLI/API lifecycle ownership, push/bootstrap/auto-route behavior, and final end-to-end verification are still being migrated.

Current lint: `golangci-lint run ./...` passes with the Go 1.27-built linter.

Tracks #241 and #243. Supersedes #242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added service-backed routes that map hostnames to named service ports.
  * Added support for multi-container services and HTTP, TCP, UDP, and TLS traffic.
  * Added backend TLS, TLS passthrough, readiness settings, environment variables, volumes, and service networking.
  * HTTPS service routes now participate in certificate authorization and renewal.
  * Private service routes can restrict access to trusted IP ranges.

* **Configuration**
  * Service definitions now use name-keyed tables and named ports.
  * Added migration guidance for the new route and service configuration format.
  * Legacy image-backed route and array-based service syntax is no longer supported.

* **Bug Fixes**
  * Untrusted requests to restricted private routes now receive `403 Forbidden`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->