### PR TITLE
docs(v3): define alpha architecture

### DIFF
--- a/.agent-reviews/redteam.md
+++ b/.agent-reviews/redteam.md
@@ -1,0 +1,49 @@
+# Architecture red-team log
+
+## 2026-09-04 — Gordon component lifecycle
+
+### Builder decision
+
+One Gordon installation has one distribution identity binding source/version, host-binary SHA-256, component-image OCI digest, and persistent-format versions. A distribution provides one host binary and one digest-pinned component image containing the same Gordon binary. The image runs as four isolated roles: `control`, `runtime`, `edge`, and `registry`.
+
+The installed host binary owns desired installation state, generated Quadlets, installation-level lifecycle commands, and identity/readiness verification. Quadlet translates container declarations into units, systemd supervises the units, and rootless Podman runs the containers. Gordon is not a fifth resident supervisor.
+
+Alpha 1 supports fresh install and same-generation recovery only. Mixed generations may exist during a future update only as an unhealthy transitional state. Component replacement, rollback or roll-forward, persistent-format compatibility, interruption recovery, and generated-Quadlet drift policy require a focused lifecycle ADR before any component update support.
+
+### Evidence
+
+- Updated `docs/v3/design.md` deployment topology, lifecycle ownership, alpha installer flow, Alpha 1 scope, and remaining decisions.
+- Updated `docs/v3/adr-001-v3-foundation.md` decision drivers, lifecycle decision, consequences, risks, validation requirements, and follow-up decisions.
+- `git diff --check` passes.
+- Markdown fences are balanced.
+
+### Critic pass
+
+Senior review `568a43bf-aa10-49e3-8d0b-30caf08fbd5a` found one blocking and four high-impact objections:
+
+- update states and recovery were underspecified;
+- version text did not cryptographically identify both artifacts;
+- shell bootstrap and Gordon lifecycle ownership overlapped;
+- rollback ignored persistent-format compatibility;
+- workload reconciliation did not normatively exclude Gordon-owned resources.
+
+### Resolutions
+
+- Limited Alpha 1 to fresh install and same-generation recovery; component update remains blocked on a lifecycle ADR.
+- Added explicit transitional mixed-generation semantics and readiness states.
+- Bound distribution identity to source/version, binary hash, image digest, and persistent-format versions; tagged manifests are signed and Quadlets pin the digest.
+- Reduced the shell to obtaining the binary and invoking Gordon's locked, journaled, idempotent installer.
+- Added preconditions for schema compatibility, backup, rollback or roll-forward, and interruption recovery.
+- Reserved and labelled Gordon-owned resources, excluded them from workload reconciliation/GC, and narrowed the edge-network exception.
+- Added user-systemd lingering and generated-Quadlet drift requirements.
+
+### Accepted risks
+
+- Branch, commit, and local source installations are unauthenticated alpha inputs.
+- Initial `curl | sh` delivery trusts HTTPS unless the installer is obtained and verified through a separately trusted channel.
+- Alpha 1 offers no component update or rollback.
+- Runtime retains full-engine authority and one narrow edge-network attachment exception, both requiring the documented Alpha 1 proof.
+
+### Final verdict
+
+After two correction rounds, senior reviewer `568a43bf-aa10-49e3-8d0b-30caf08fbd5a` returned **VALIDATED** with no remaining blocking or high-impact objection.

--- a/docs/v3/adr-001-v3-foundation.md
+++ b/docs/v3/adr-001-v3-foundation.md
@@ -1,0 +1,244 @@
+# ADR-001: Rebuild Gordon v3 around isolated local components and declarative apps
+
+- Status: Accepted; not yet implemented
+- Date: 2026-09-04
+- Decision owners: Gordon maintainers
+- Related: [V3 design](./design.md), issue #245, PR #244
+- Supersedes: the implementation archived on branch `v3-deprecated`
+
+## Context
+
+Gordon v2 runs registry, reverse proxy, administration, secret handling, and container-runtime access in one process and under one host identity. A remote-code-execution vulnerability in any Internet-facing path can therefore expose every file readable by that identity, application secrets, and the Docker- or Podman-compatible runtime socket.
+
+The first v3 implementation attempted to address this by splitting Gordon into `control`, `runtime`, `edge`, and `registry` roles. It combined that security boundary with gRPC and protobuf contracts, component tokens, distributed snapshots, durable events, a compatibility harness, automatic component launching, checkpointed migration, zero-downtime cutover, and runtime handoff.
+
+That branch grew to hundreds of divergent commits and more than eighty thousand added lines across 424 changed files. It builds, but the complete deployed system proved difficult to operate, debug, and maintain. At the same time, Gordon's public workload model remained route-centric and was being redesigned separately in issue #245 and PR #244.
+
+A second big-bang refactor would repeat the same failure. Keeping the v2 monolith would leave the primary security risk unresolved.
+
+## Decision drivers
+
+1. A compromise of edge or registry must not expose application secrets or the Podman socket.
+2. V3 should be substantially simpler than the archived implementation.
+3. Configuration ownership must be explicit and deterministic.
+4. Public routes must not own workload lifecycle.
+5. Runtime deployments must use immutable OCI identities.
+6. The system must remain usable when one control component restarts.
+7. Every incremental change on `v3-alpha` must leave an installable, testable system.
+8. V3 may break compatibility and omit v2 features rather than preserve accidental complexity.
+
+## Decision
+
+### Start again from main
+
+The former `v3` branch is archived as `v3-deprecated`. The new `v3-alpha` branch starts from `main`. Code is not merged or cherry-picked wholesale from the archived implementation. Individual invariants and test scenarios may be reimplemented when they fit the new design.
+
+V3 is fresh-install only. It does not parse v2 configuration, preserve v2 CLI aliases, or provide automatic, live, or offline v2 migration.
+
+### Use four isolated containers on one host
+
+Gordon runs `control`, `runtime`, `edge`, and `registry` as separate rootless Podman containers with distinct container namespaces, mounts, networks, and data ownership. They do not share a Podman pod.
+
+All components initially run under one trusted host account and rootless Podman engine; container UIDs are not separate host security principals. Only runtime receives the rootless Podman socket, which grants full authority over that engine, including Gordon's containers. Host-account or runtime compromise defeats the component boundaries and is an accepted alpha risk. Docker, rootful engines, multi-host operation, and clustering are outside v3 scope.
+
+Systemd and Quadlet own component lifecycle. Gordon does not launch, migrate, replace, or hand off its own components.
+
+### Use local capability sockets
+
+Components communicate through role-specific Unix sockets using HTTP and strict JSON DTOs. Each socket exposes only the operations needed by its mounted consumer. Internal gRPC, protobuf, bearer tokens, and generic component RPC surfaces are not used.
+
+Control opens no TCP administration port by default. Local clients use its Unix socket. Remote clients forward that socket through SSH. A public HTTPS control endpoint is deferred pending a separate threat-model ADR; enabling one would make control Internet-facing and explicitly forfeit the primary containment guarantee. Plaintext HTTP is unsupported.
+
+### Separate public components from the trusted core
+
+Edge terminates public application HTTP/HTTPS. It receives only a sanitized, generation-controlled routing projection. It has no app secrets, Podman access, or desired-state mutation API.
+
+Registry is publicly reachable for authenticated OCI operations. Edge selects registry traffic by SNI and forwards the encrypted TCP stream without terminating TLS. Registry owns its TLS identity and a durable push-event outbox, but has no general configuration or runtime API. Auto-deploy deliberately grants registry bounded authority to trigger a release for one configured repository-and-tag target. Without artifact verification rooted outside registry, registry compromise can deploy arbitrary content to that opted-in service; this is accepted for alpha.
+
+Control and runtime form the trusted core. Control owns desired state and deployment decisions. Runtime owns actual Podman state and persisted secret values.
+
+### Replace route-owned workloads with declarative apps
+
+Each app is defined by one user-owned TOML manifest and has a globally unique name. An app contains named services, app-wide public environment, named entrypoints, and routes. A container is only a runtime instance.
+
+Every service is explicitly named, references one image, and has one active instance. There is no app-level image shorthand or implicit default service. Compact and expanded syntax are both accepted but normalize to one model.
+
+An app has an automatic private network. Named private networks allow explicitly selected services from different apps to communicate. The intended public-routing topology adds an automatic per-app ingress network containing edge and only routed services. Runtime may reconcile edge's network attachments while Quadlet remains responsible for creating and restarting edge. Alpha 1 is blocked on a clean-host ADR and proof covering this topology, rootless host ingress, source-IP preservation, privileged ports, dynamic TCP/UDP listeners, socket permissions, UID mappings, and SELinux labels.
+
+App entrypoints describe stable service interfaces. Declaring one does not expose it. Routes are the only exposure primitive and support HTTP, TCP, and UDP. HTTP uses edge's shared listener; dedicated TCP and UDP routes contain their own listen address.
+
+### Separate configuration from runtime mutation
+
+`gordon apps apply --file <manifest>` replaces the complete desired AppSpec after normalization and validation. It only persists configuration. It never mutates containers, networks, volumes, routes, or images. V3-alpha deliberately uses last-successful-write-wins for complete manifests and returns both former and resulting revisions.
+
+`gordon deploy <app>` is the only command that activates a new AppSpec revision. It resolves image selectors to OCI digests, creates an immutable release, applies runtime changes, and publishes the release's routes through persisted `prepared`, `mutating`, `routes-published`, and terminal phases. Activation requires observed runtime state and edge acknowledgement; restart recovery observes before acting and never blindly replays mutations.
+
+`gordon deploy <app> --service <name>` is allowed only when desired and active AppSpec revisions match and creates a composed release changing that service digest only. `push --deploy` and auto-deploy follow the same restriction and cannot implicitly activate pending configuration. Auto-deploy selectors must be unique installation-wide; ambiguous push targets require explicit app and service selection.
+
+### Use immutable releases and scoped rollback
+
+Runtime receives only digest-pinned OCI references. Unqualified image references target Gordon's registry; external references require a full registry hostname. The literal tag `latest` is rejected with no alpha override.
+
+A release combines an immutable normalized AppSpec with exact service digests. Full rollback and service-level rollback both create new releases; historical releases are never mutated. A service rollback uses the currently active app-level environment, entrypoints, routes, networks, and other services, and substitutes only the selected former service definition and digest. The synthetic release must pass complete validation before mutation.
+
+### Minimize secret and storage authority
+
+Public environment values are app-wide and injected into every service. There is no service-local public environment. Values intended for one service use write-only secrets, even if not confidential.
+
+Secrets are identified by app, service, and name. They cannot be read through any Gordon API or shared by reference between services. Control handles values transiently during set/update; runtime persists and injects them as same-name environment variables. This prevents direct API disclosure but does not protect service secrets from a compromised control plane authorized to deploy that service. Secret changes affect only a later deploy/restart, missing declared secrets block deployment, and removal of a desired or active reference is rejected.
+
+App manifests allow only service-owned Podman named volumes. Host bind mounts and cross-service shared volumes are forbidden. `stop` preserves all durable state. `remove` deletes app metadata and secrets but preserves volumes plus a tombstone that reserves the app name and prevents implicit data adoption. `purge` also deletes volumes and the tombstone after explicit confirmation. Registry images have an independent lifecycle. Runtime pulls them through a separate private registry endpoint with pull-only credentials, not through public edge passthrough; the exact rootless endpoint is part of the Alpha 1 ingress proof.
+
+### Limit zero-downtime behavior
+
+Deployment strategy is inferred and not configurable. Only stateless services exclusively routed through HTTP/HTTPS and without persistent volumes are eligible for replacement without a transport outage. Gordon starts the new instance, waits for Podman `running` and an accepting HTTP backend TCP port, switches edge routes, and removes the old instance.
+
+All stateful, worker, TCP, UDP, RCON, mixed-protocol, and volume-owning services use recreate and may experience downtime. V3 has no readiness configuration and does not interpret OCI `HEALTHCHECK`.
+
+### Reduce the CLI and feature set
+
+V3-alpha does not promise v2 parity. Declarative app operations live under `apps`; frequent runtime actions such as `deploy`, `rollback`, `restart`, `stop`, `remove`, `purge`, `logs`, `status`, and `push` remain top-level.
+
+Attachments, autoroute, bootstrap, pin, reload, partial route mutations, and token-printing commands are removed. Backups, previews, CA/TLS inspection, traffic diagnostics, and resource garbage collection are deferred until redesigned around v3 ownership.
+
+### Install alpha from source references
+
+Stable installation and `gordon update` remain release- and version-based. Alpha testing uses `install.sh` with one mutually exclusive source selector:
+
+```text
+GORDON_BRANCH=v3-alpha
+GORDON_COMMIT=<sha>
+GORDON_LOCAL=1
+GORDON_VERSION=<tag>
+```
+
+Alpha 1 will implement branch, commit, and local modes that build and install the selected source through rootless Podman and report the exact commit. These modes do not exist in the current installer and do not introduce an alpha channel into `gordon update`.
+
+## Consequences
+
+### Positive
+
+- An edge or registry compromise no longer directly grants Podman or secret-store access.
+- The trust model is enforced by OS/container boundaries and mounted capabilities, not package conventions alone.
+- Mono-host Unix sockets eliminate most distributed-system and internal TLS complexity.
+- The app manifest is a portable, Git-friendly source of truth.
+- Apply and deploy have distinct, predictable effects.
+- Routes no longer own containers.
+- Digest-pinned releases provide reproducible deployment and rollback.
+- Per-service secrets and volumes reduce workload blast radius.
+- The smaller CLI and fresh-start policy permit substantial code deletion.
+- Incremental alpha milestones can be tested on real clean installations.
+
+### Negative
+
+- V3 cannot upgrade an existing v2 installation in place.
+- Docker users must migrate to rootless Podman.
+- Four containers and Quadlets are operationally heavier than one host process.
+- The initial single host account and engine do not isolate Gordon components from host-account or runtime compromise.
+- Registry availability depends on edge's public TCP mux on a single-IP installation.
+- Control and runtime remain a trusted core; a full control compromise may indirectly request harmful runtime actions.
+- Runtime compromise remains severe because it owns Podman and injected secret values.
+- Service-local non-secret values must use the write-only secret workflow.
+- Shared filesystems and host bind mounts are unavailable to app manifests.
+- Zero downtime is intentionally limited to eligible web frontends.
+- Several v2 features will be absent during alpha and may never return.
+
+### Operational
+
+- Component data and socket permissions require explicit installer and Quadlet tests.
+- Edge must preserve its last valid sanitized snapshot so a control restart does not interrupt traffic.
+- Registry must persist and retry push events while control is unavailable.
+- Runtime must reconstruct actual state from Podman after restart rather than trust stale process memory.
+- Deployment status must distinguish desired AppSpec, active release, and observed runtime state.
+
+## Alternatives considered
+
+### Keep the v2 monolith and only reorganize packages
+
+Rejected. Package boundaries do not stop code execution under one UID from reading secrets or using the runtime socket.
+
+### Repair and continue the archived v3 implementation
+
+Rejected. It combines too many independently risky changes and encodes workload and migration assumptions that the new app model supersedes.
+
+### Run all Gordon containers in one Podman pod
+
+Rejected. Shared networking increases lateral reach from edge to trusted components and weakens role-specific network policy.
+
+### Split components across hosts with network gRPC
+
+Rejected for v3. Gordon is a single-server deployment platform. Multi-host RPC, TLS, discovery, compatibility, and recovery are unnecessary complexity.
+
+### Put registry behind HTTP termination at edge
+
+Rejected. A compromised edge could capture OCI credentials and payloads. Raw SNI passthrough preserves registry's independent TLS boundary.
+
+### Keep registry private and proxy every image through control
+
+Rejected. It removes standard OCI push workflows, makes control a large-blob data path, and increases control's exposed parsing and resource surface.
+
+### Require a VPN for registry access
+
+Rejected as the default because it makes common CI push workflows cumbersome. A private registry remains an optional hardening choice.
+
+### Use automatic app deployment during apply
+
+Rejected. It makes configuration synchronization mutate runtime, couples validation to registry availability, and makes CI effects harder to predict.
+
+### Use tags directly at runtime
+
+Rejected. Tags are mutable. Every release records and deploys immutable OCI digests.
+
+### Support arbitrary health checks and deployment strategies
+
+Rejected for initial v3. Multiple probe and rollout engines substantially increase behavior and test surface. V3 keeps one narrow web replacement algorithm.
+
+### Preserve full v2 feature parity before alpha
+
+Rejected. It would force obsolete ownership and command models into the new architecture and recreate a big-bang rewrite.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Compromised registry causes malicious image deployment | Accept bounded auto-deploy authority only for unique configured targets; runtime enforces no host binds/capabilities; future signature policy may add stronger provenance |
+| Compromised edge attacks app internals | Edge joins only generated ingress networks and only routed services join those networks |
+| Socket mount accidentally grants excessive API access | Separate directories and handlers per capability; installer ownership tests; no generic RPC socket |
+| Stale edge routing after control failure | Persist the last valid monotonic snapshot; reject invalid or older generations; expose applied generation in status |
+| Apply overwrites another operator's desired state | Complete-manifest semantics and future optimistic-concurrency details in a focused API ADR |
+| Failed stateful deployment causes downtime | Do not promise zero downtime; retain immutable former release and perform bounded best-effort recovery |
+| Alpha installer silently moves branch state | Resolve and report exact commit; support `GORDON_COMMIT` for reproduction |
+| Deferred v2 features are forgotten | Keep the feature tracking matrix in `docs/v3/design.md` and require explicit ownership before reintroduction |
+
+## Validation requirements
+
+The decision is considered implemented only when automated tests prove:
+
+1. Edge and registry cannot see the Podman socket or application-secret storage.
+2. Control cannot retrieve persisted secret values through its runtime API.
+3. Components expose only their role-specific Unix-socket handlers.
+4. Control restart does not interrupt already routed applications.
+5. Registry queues and retries authenticated push events.
+6. Apply performs no runtime mutation.
+7. Runtime only receives digest-pinned image references.
+8. An invalid deployment leaves the former route projection active where the deployment strategy permits.
+9. A service rollback does not restart unrelated services.
+10. App removal preserves volumes and purge requires explicit confirmation.
+11. The branch installer provisions a clean rootless Podman host from an exact commit.
+12. The selected host-ingress mechanism preserves required source addresses and supports the documented HTTP, registry SNI, TCP, and UDP listeners under rootless Podman.
+13. Socket directories survive component restart with exact ownership, mode, mount, and SELinux behavior.
+
+## Follow-up decisions
+
+Focused ADRs should define, when implementation reaches them:
+
+- AppSpec and release persistence;
+- internal HTTP DTO versioning;
+- Unix-socket filesystem and UID mapping, which is a prerequisite for Alpha 1 rather than a deferrable implementation detail;
+- rootless host ingress and private runtime-to-registry pulls, also prerequisites for Alpha 1;
+- edge snapshot generation and acknowledgement;
+- registry event outbox semantics;
+- shared named-network declaration;
+- certificate lifecycle;
+- alpha-to-stable component update ordering;
+- release and orphan retention policies.

--- a/docs/v3/adr-001-v3-foundation.md
+++ b/docs/v3/adr-001-v3-foundation.md
@@ -25,7 +25,8 @@ A second big-bang refactor would repeat the same failure. Keeping the v2 monolit
 5. Runtime deployments must use immutable OCI identities.
 6. The system must remain usable when one control component restarts.
 7. Every incremental change on `v3-alpha` must leave an installable, testable system.
-8. V3 may break compatibility and omit v2 features rather than preserve accidental complexity.
+8. One Gordon distribution must install and maintain one coherent generation of the host CLI and all four components.
+9. V3 may break compatibility and omit v2 features rather than preserve accidental complexity.
 
 ## Decision
 
@@ -41,7 +42,24 @@ Gordon runs `control`, `runtime`, `edge`, and `registry` as separate rootless Po
 
 All components initially run under one trusted host account and rootless Podman engine; container UIDs are not separate host security principals. Only runtime receives the rootless Podman socket, which grants full authority over that engine, including Gordon's containers. Host-account or runtime compromise defeats the component boundaries and is an accepted alpha risk. Docker, rootful engines, multi-host operation, and clustering are outside v3 scope.
 
-Systemd and Quadlet own component lifecycle. Gordon does not launch, migrate, replace, or hand off its own components.
+### Ship one distribution as one host binary and one component image
+
+One Gordon distribution provides the host CLI and one component image containing an octet-identical copy of that Gordon executable. The image invokes that executable in four role-specific serve modes: `control`, `runtime`, `edge`, and `registry`. The exact command syntax is an Alpha 1 implementation detail; separate role binaries and independently versioned component images are not allowed. "Distribution" and "installation generation" identify Gordon itself; "release" remains reserved for immutable app deployments.
+
+A distribution identity binds its version or source revision, executable SHA-256, component-image OCI digest, and persistent-format versions. The build copies that exact executable into the image and verifies its hash before publication. Generated Quadlets pin the image digest. Tagged distributions publish a signed manifest attesting the executable hash and image digest. Before executing a downloaded Gordon binary, the shell bootstrap verifies that signature with a pinned release public key and verifies the executable hash. Initial `curl | sh` delivery still trusts HTTPS; an independent root of trust requires obtaining and verifying the installer through a separately trusted channel. Branch and commit modes are unauthenticated alpha inputs attributable to one exact clean revision. Dirty local builds include a source-tree hash in their identity rather than reporting clean `HEAD`.
+
+The installed host binary owns the declarative lifecycle of those four Gordon components. It provisions their Quadlets, asks the user systemd manager to perform lifecycle operations, and verifies process state, role readiness, dependencies, and distribution identity. A future update may temporarily run mixed generations only in an explicit transitional state that is never reported healthy. Alpha 1 is limited to fresh installation and recovery of the same incomplete generation; installing a different generation, update, and component rollback remain blocked on the lifecycle ADR.
+
+Responsibility is deliberately layered:
+
+- Gordon owns the intended distribution identity, configuration, generated Quadlets, installation lock and journal, and installation-level operations;
+- Quadlet translates the Podman declarations into systemd units;
+- systemd owns boot activation, dependency ordering, continuous supervision, and restart-after-failure;
+- Podman creates and runs the four rootless containers.
+
+The shell installer only obtains and verifies or builds the host binary, then invokes Gordon's host-side installer. Gordon permits one installation per host account and rootless engine and performs atomic, locked, journaled, idempotent steps so an interrupted install can resume. Generated Quadlets are checksummed Gordon outputs; supported customization belongs in `gordon.toml`, and unknown edits are preserved and require an explicit recovery operation. The installer configures and tests the user-manager lingering policy needed for boot without login.
+
+Gordon is not a fifth resident supervisor. It does not reimplement systemd or restore the archived checkpointed migration, runtime handoff, or autonomous self-upgrade machinery. Component update support requires a focused lifecycle ADR defining states, replacement order, persistent-format compatibility, backup, rollback or roll-forward, and interruption recovery.
 
 ### Use local capability sockets
 
@@ -63,7 +81,7 @@ Each app is defined by one user-owned TOML manifest and has a globally unique na
 
 Every service is explicitly named, references one image, and has one active instance. There is no app-level image shorthand or implicit default service. Compact and expanded syntax are both accepted but normalize to one model.
 
-An app has an automatic private network. Named private networks allow explicitly selected services from different apps to communicate. The intended public-routing topology adds an automatic per-app ingress network containing edge and only routed services. Runtime may reconcile edge's network attachments while Quadlet remains responsible for creating and restarting edge. Alpha 1 is blocked on a clean-host ADR and proof covering this topology, rootless host ingress, source-IP preservation, privileged ports, dynamic TCP/UDP listeners, socket permissions, UID mappings, and SELinux labels.
+An app has an automatic private network. Named private networks allow explicitly selected services from different apps to communicate. The intended public-routing topology adds an automatic per-app ingress network containing edge and only routed services. Gordon component resources use reserved names and ownership labels and are excluded from workload reconciliation and garbage collection. Runtime's narrow, idempotent reconciliation of edge's app-ingress attachments is the only allowed workload-side component mutation; Quadlet remains responsible for creating and restarting edge. Alpha 1 is blocked on a clean-host ADR and proof covering this exception, rootless host ingress, source-IP preservation, privileged ports, dynamic TCP/UDP listeners, socket permissions, UID mappings, and SELinux labels.
 
 App entrypoints describe stable service interfaces. Declaring one does not expose it. Routes are the only exposure primitive and support HTTP, TCP, and UDP. HTTP uses edge's shared listener; dedicated TCP and UDP routes contain their own listen address.
 
@@ -103,7 +121,7 @@ Attachments, autoroute, bootstrap, pin, reload, partial route mutations, and tok
 
 ### Install alpha from source references
 
-Stable installation and `gordon update` remain release- and version-based. Alpha testing uses `install.sh` with one mutually exclusive source selector:
+Stable installation remains signed-distribution- and version-based. The future v3 `gordon update` will accept only a verified signed distribution manifest, but the command is unavailable until the lifecycle ADR is accepted and implemented. Alpha testing uses `install.sh` with one mutually exclusive source selector:
 
 ```text
 GORDON_BRANCH=v3-alpha
@@ -112,7 +130,7 @@ GORDON_LOCAL=1
 GORDON_VERSION=<tag>
 ```
 
-Alpha 1 will implement branch, commit, and local modes that build and install the selected source through rootless Podman and report the exact commit. These modes do not exist in the current installer and do not introduce an alpha channel into `gordon update`.
+Alpha 1 will implement branch, commit, and local modes that derive one explicit distribution identity, build both the host executable and digest-pinned component image from it, and invoke that executable to provision installation directories and Quadlets, start an installation target through the user systemd manager, and verify all four roles. The executable copied into the image must have the same SHA-256 as the host executable. Installation is locked, journaled, idempotent, and limited to a clean host or same-generation recovery. Branch, commit, and local inputs are not authenticated releases. The shell remains bootstrap transport only; after installation, Gordon owns installation-level operations while systemd supervises the containers. These modes do not exist in the current installer and do not introduce an alpha update channel.
 
 ## Consequences
 
@@ -134,6 +152,7 @@ Alpha 1 will implement branch, commit, and local modes that build and install th
 - V3 cannot upgrade an existing v2 installation in place.
 - Docker users must migrate to rootless Podman.
 - Four containers and Quadlets are operationally heavier than one host process.
+- Installation and future update must coordinate a host binary, a component image, four units, persistent formats, and partial-failure recovery while preserving one distribution identity.
 - The initial single host account and engine do not isolate Gordon components from host-account or runtime compromise.
 - Registry availability depends on edge's public TCP mux on a single-IP installation.
 - Control and runtime remain a trusted core; a full control compromise may indirectly request harmful runtime actions.
@@ -145,6 +164,9 @@ Alpha 1 will implement branch, commit, and local modes that build and install th
 
 ### Operational
 
+- The installed Gordon binary owns generated Quadlets and must detect local edits or generation drift instead of silently accepting an incoherent installation.
+- Installation status must distinguish intended, staged, running, degraded, and rollback-required distribution states.
+- User-manager lingering must be configured and tested so components start after reboot without an interactive login.
 - Component data and socket permissions require explicit installer and Quadlet tests.
 - Edge must preserve its last valid sanitized snapshot so a control restart does not interrupt traffic.
 - Registry must persist and retry push events while control is unavailable.
@@ -207,7 +229,12 @@ Rejected. It would force obsolete ownership and command models into the new arch
 | Stale edge routing after control failure | Persist the last valid monotonic snapshot; reject invalid or older generations; expose applied generation in status |
 | Apply overwrites another operator's desired state | Complete-manifest semantics and future optimistic-concurrency details in a focused API ADR |
 | Failed stateful deployment causes downtime | Do not promise zero downtime; retain immutable former release and perform bounded best-effort recovery |
-| Alpha installer silently moves branch state | Resolve and report exact commit; support `GORDON_COMMIT` for reproduction |
+| Alpha installer silently moves branch state | Resolve and report exact commit; support `GORDON_COMMIT` for reproduction; include a source-tree hash for dirty local builds |
+| Version text identifies different artifacts | Bind the executable hash, OCI digest, and format versions in a distribution identity; verify the same executable is copied into the image; pin image digests; sign tagged distribution manifests |
+| Partial update leaves mixed component generations | Limit Alpha 1 to fresh install; never report transitional mixed state healthy; require a lifecycle ADR before update support |
+| Component rollback meets incompatible persisted data | Version formats and require the lifecycle ADR to define preflight, backup, reversible migration, and roll-forward policy |
+| Workload reconciliation mutates Gordon resources | Reserve names and ownership labels; exclude component resources; keep edge attachment reconciliation narrow and idempotent |
+| Generated Quadlets drift from Gordon's intended state | Record checksums and generation; fail clearly before overwriting unrecognized local changes and preserve a backup |
 | Deferred v2 features are forgotten | Keep the feature tracking matrix in `docs/v3/design.md` and require explicit ownership before reintroduction |
 
 ## Validation requirements
@@ -224,9 +251,15 @@ The decision is considered implemented only when automated tests prove:
 8. An invalid deployment leaves the former route projection active where the deployment strategy permits.
 9. A service rollback does not restart unrelated services.
 10. App removal preserves volumes and purge requires explicit confirmation.
-11. The branch installer provisions a clean rootless Podman host from an exact commit.
-12. The selected host-ingress mechanism preserves required source addresses and supports the documented HTTP, registry SNI, TCP, and UDP listeners under rootless Podman.
-13. Socket directories survive component restart with exact ownership, mode, mount, and SELinux behavior.
+11. The branch installer provisions a clean rootless Podman host from an exact commit and refuses to replace another generation.
+12. The distribution identity binds source/version, executable hash, component-image digest, and persistent-format versions; before executing a tagged binary, the shell verifies its hash against a manifest signature rooted in a pinned release key.
+13. The installed host executable and its octet-identical copy in the image match that identity, and generated Quadlets pin one image digest in four distinct serve roles with only their documented capabilities.
+14. The installer lock prevents concurrent mutation; an interrupted Alpha 1 installation persists an incomplete state and can resume the same generation idempotently.
+15. Process running, role ready, dependencies ready, and identity verified are distinguishable; mixed generations are never reported healthy.
+16. User-manager lingering starts the installation after reboot without an interactive login.
+17. Workload reconciliation cannot mutate or garbage-collect Gordon-owned resources except for the narrow tested edge-network attachment operation.
+18. The selected host-ingress mechanism preserves required source addresses and supports the documented HTTP, registry SNI, TCP, and UDP listeners under rootless Podman.
+19. Socket directories survive component restart with exact ownership, mode, mount, and SELinux behavior.
 
 ## Follow-up decisions
 
@@ -240,5 +273,5 @@ Focused ADRs should define, when implementation reaches them:
 - registry event outbox semantics;
 - shared named-network declaration;
 - certificate lifecycle;
-- alpha-to-stable component update ordering;
+- lifecycle states, component replacement order, persistent-format compatibility, backup, rollback or roll-forward, interruption recovery, and generated-Quadlet drift policy before any component update support;
 - release and orphan retention policies.

--- a/docs/v3/design.md
+++ b/docs/v3/design.md
@@ -1,0 +1,696 @@
+# Gordon v3 design
+
+Status: accepted design baseline; not yet implemented  
+Date: 2026-09-04  
+Supersedes: the distributed implementation archived as `v3-deprecated`
+
+## Purpose
+
+Gordon v3 is a fresh-start redesign focused on one security outcome:
+
+> Compromising an Internet-facing Gordon component must not expose application secrets, the Podman socket, or control-plane private state.
+
+V3 deliberately breaks compatibility with v2. It removes legacy configuration, commands, runtime detection, and migration paths instead of carrying them into the new architecture.
+
+## Scope and non-goals
+
+### In scope
+
+- Four isolated Gordon components on one host.
+- Rootless Podman as the only container runtime.
+- One declarative manifest per app.
+- Apps composed of independently managed services.
+- Explicit app entrypoints and protocol-neutral routes.
+- Immutable releases pinned to OCI digests.
+- Write-only, service-scoped secrets.
+- Explicit deployment and partial rollback.
+- Public authenticated OCI pushes and opt-in auto-deploy.
+- A minimal CLI rebuilt around the v3 model.
+
+### Non-goals
+
+- V2 configuration or CLI compatibility.
+- Automatic or live v2-to-v3 migration.
+- Multi-host operation or clustering.
+- Docker support.
+- A shared Podman pod for Gordon components.
+- Runtime-selectable deployment strategies.
+- Generic readiness checks.
+- Zero downtime for stateful, TCP, UDP, or mixed-protocol services.
+- Feature parity with v2 during alpha.
+
+## Security model
+
+### Trust boundaries
+
+Gordon runs as four independent containers, outside a shared Podman pod:
+
+```text
+Internet
+   |
+   +--> edge ----------- public application traffic
+   |
+   +--> registry ------- authenticated OCI push/pull
+
+control ---------------- desired state and administration
+   |
+runtime ---------------- Podman, workloads, volumes, secret values
+```
+
+Each component has:
+
+- a distinct container, user, mount, and network namespace;
+- its own root filesystem and private data volume;
+- only the Unix sockets it requires;
+- only the network attachments it requires;
+- no added Linux capabilities;
+- `no-new-privileges`;
+- a read-only root filesystem where practical.
+
+Only `runtime` receives the rootless Podman socket. Gordon components are separate containers because a Podman pod shares networking and would weaken the intended trust boundaries.
+
+All four containers initially run under one trusted host account and one rootless Podman engine. Container UIDs are not independent host security principals. A compromise of that host account defeats every component boundary. Runtime has full authority over every container in that engine, including Gordon's own containers; runtime compromise therefore defeats the component boundaries as well. A future stronger design may place workloads and Gordon components in separate rootless engines, but that is not part of the accepted alpha baseline.
+
+### Compromise containment
+
+A compromised `edge` may:
+
+- observe public application traffic that it terminates;
+- read its sanitized route projection;
+- interrupt public traffic and registry passthrough.
+
+It must not be able to:
+
+- read application secrets;
+- access the Podman socket;
+- mutate desired state;
+- invoke runtime operations;
+- read registry credentials or traffic carried through TLS passthrough.
+
+A compromised `registry` controls its OCI storage and may emit malformed or forged push events. It has no general runtime or configuration API. When auto-deploy is enabled, however, registry has bounded authority to trigger a release for an already configured repository-and-tag mapping. Control validates and deduplicates events, maps repositories to configured services, checks auto-deploy policy, and selects the resulting release. Without signature or attestation verification rooted outside registry, registry compromise can supply arbitrary content to those opted-in services; this is an accepted risk for alpha.
+
+`control` and `runtime` form the trusted core. Runtime is the most privileged component because it owns the Podman socket and injects workload secrets.
+
+## Deployment topology
+
+V3 is strictly mono-host. The supported topology is:
+
+```text
+systemd --user / Quadlet
+├── gordon-edge
+├── gordon-registry
+├── gordon-control
+└── gordon-runtime
+    └── rootless Podman socket
+```
+
+Quadlet, not Gordon, owns component startup and restart. V3 does not contain a component launcher, checkpointed split migration, runtime handoff, or self-orchestration system.
+
+## Component ownership
+
+| Component | Owns | Must not own |
+| --- | --- | --- |
+| control | App manifests, AppSpec history, releases, route definitions, deployment status, secret metadata | Podman socket, OCI blobs, stored secret values |
+| runtime | Podman operations, actual state, workload networks, volumes, stored secret values | Public listeners, desired app manifests, OCI registry storage |
+| edge | Public application listeners, active sanitized route snapshot, public app certificates | App secrets, Podman socket, complete manifests, registry credentials |
+| registry | OCI blobs, manifests, tags, registry TLS identity, durable push-event outbox | App secrets, Podman socket, deployment decisions |
+
+The components do not share data volumes. Explicit host-mounted Unix-socket directories are communication capabilities, not shared data stores.
+
+## Internal communication
+
+### Transport
+
+Internal APIs use HTTP with strict JSON DTOs over private Unix sockets. Gordon does not use gRPC or protobuf internally in v3.
+
+Streams use NDJSON or server-sent events only where required, such as logs or edge snapshot updates.
+
+Example sockets:
+
+```text
+control/admin.sock       local and SSH administration
+control/edge.sock        read-only edge projection
+control/registry.sock    registry push events only
+runtime/control.sock     control-to-runtime operations only
+```
+
+Each socket exposes a fixed, minimal handler set. Possession of a mounted socket is the component capability; components do not exchange bearer tokens. Inputs are still treated as untrusted and validated.
+
+### Administration
+
+Control opens no TCP listener by default.
+
+Local flow:
+
+```text
+CLI -> host-visible control/admin.sock -> control container
+```
+
+Remote flow:
+
+```text
+CLI -> OpenSSH Unix-socket forwarding -> remote control/admin.sock -> control container
+```
+
+A public control API is deferred beyond the initial alpha. If later enabled, it must be an explicit opt-in with HTTPS, strong authentication, authorization, rate limits, and separate threat analysis. Enabling it makes control Internet-facing and explicitly forfeits the primary v3 containment guarantee. Plain HTTP is never accepted.
+
+Remote configuration defaults to SSH:
+
+```toml
+[remotes.production]
+host = "user@server"
+```
+
+Equivalent defaults:
+
+```text
+transport = "ssh"
+socket = <default control socket>
+```
+
+A future public endpoint would be explicit:
+
+```toml
+[remotes.public]
+transport = "https"
+url = "https://control.example.com"
+```
+
+This transport is reserved until its separate security ADR is accepted and implemented.
+
+## Public traffic
+
+The logical edge configuration has one main multiplexed listener:
+
+```toml
+[edge]
+listen = ":443"
+```
+
+This is a desired public address, not yet a claim that an unprivileged container can bind host port 443 directly. Alpha 1 requires a clean-host ingress ADR and proof of concept covering rootless privileged ports, source-IP preservation, fixed versus dynamic TCP/UDP publication, address-specific binds, firewall interaction, and edge restarts. Dedicated TCP/UDP listeners remain blocked until that mechanism is selected.
+
+Edge terminates HTTP/HTTPS application traffic. Registry traffic is selected by SNI and forwarded as raw TCP. Registry terminates its own TLS, so edge never receives registry credentials or decrypted OCI payloads.
+
+Sharing edge introduces an accepted availability dependency: a failed or compromised edge can make registry unavailable, but must not compromise registry confidentiality.
+
+Runtime pulls Gordon-hosted images through a separate private registry endpoint that is reachable by the rootless Podman engine and is not routed through edge. Runtime uses pull-only credentials; control and edge receive no OCI push credentials. The exact private endpoint, TLS identity, and rootless reachability are part of the required host-ingress proof.
+
+## Configuration model
+
+### Installation configuration
+
+`gordon.toml` configures the Gordon installation and its components. It changes infrequently and is not modified by app commands.
+
+It includes control, edge, registry, runtime, authentication-backend, and host-level settings.
+
+### App manifests
+
+Each app has one standalone TOML manifest kept by the user, normally in the application's Git repository:
+
+```text
+gordon.app.toml
+```
+
+A manifest contains exactly one app and has a globally unique app name:
+
+```toml
+name = "shop"
+```
+
+The app name is unique across manifests, secrets, releases, volumes, networks, containers, and route identities on one Gordon installation.
+
+The client submits the complete manifest:
+
+```console
+gordon apps apply --file gordon.app.toml
+```
+
+Control is the sole server-side writer. The CLI never edits a remote TOML file directly. Partial mutation commands for services, entrypoints, and routes do not exist.
+
+### Compact and expanded forms
+
+Compact and expanded forms are both supported and documented together. They normalize to one domain model before validation.
+
+Compact service:
+
+```toml
+[services]
+frontend = "shop/frontend:v1.4.0"
+```
+
+Expanded service:
+
+```toml
+[services.frontend]
+image = "shop/frontend:v1.4.0"
+auto_deploy = true
+```
+
+Compact entrypoint:
+
+```toml
+[entrypoints]
+web = "frontend:3000/http"
+```
+
+Expanded entrypoint:
+
+```toml
+[entrypoints.web]
+service = "frontend"
+port = 3000
+protocol = "http"
+```
+
+Compact forms use defaults only. A single item cannot be declared in both forms. Validation errors should show the equivalent expanded fields.
+
+There is no app-level `image` shorthand or implicit service. Every app has at least one explicitly named service.
+
+## App model
+
+```text
+App
+├── public environment
+├── Services
+│   ├── image source
+│   ├── service-scoped secrets
+│   ├── service-owned volumes
+│   └── optional named networks
+├── Entrypoints
+└── Routes
+```
+
+### Services
+
+A service is a logical workload backed by one image. A container is a runtime instance and is not a stable configuration identity.
+
+A service has one active instance. A second instance exists only temporarily while replacing an eligible web frontend.
+
+Persistent dependencies such as PostgreSQL or Valkey may be services inside an app when dedicated to that app. A dependency shared by multiple apps is modeled as its own app.
+
+### Environment and secrets
+
+Public, non-sensitive environment values are global to the app and injected into every service:
+
+```toml
+[env]
+APP_ENV = "production"
+LOG_LEVEL = "info"
+```
+
+There is no service-specific public environment block. Any value intended for only one service uses the secret mechanism, even when the value is not confidential.
+
+Services declare their secret names:
+
+```toml
+[services.database]
+image = "docker.io/library/postgres:18"
+secrets = ["POSTGRES_PASSWORD"]
+```
+
+The secret identity is service-scoped:
+
+```text
+shop/database/POSTGRES_PASSWORD
+```
+
+Secret operations are write-only:
+
+```console
+gordon secrets set --app shop --service database POSTGRES_PASSWORD
+gordon secrets list --app shop --service database
+gordon secrets remove --app shop --service database POSTGRES_PASSWORD
+```
+
+No local or remote API returns a stored value. Control sees a value transiently during set/update, sends it to runtime, and retains metadata only. Runtime offers set, replace, delete, existence-check, and deployment injection operations, but no read operation.
+
+Write-only semantics protect against accidental API disclosure and at-rest exposure in control. They do not protect a service's secrets from a compromised control plane that is already authorized to deploy that service. Secret mutation does not alter a running container; the new value is injected only on its next deploy or restart. Deployment fails before runtime mutation when any declared secret is absent. Removing a secret still declared by the desired or active AppSpec is rejected.
+
+Secrets are injected as environment variables with the same name. Membership in an app grants no implicit secret access, and secrets cannot be shared by reference across services.
+
+`env_file` is not supported.
+
+### Volumes
+
+Volumes are rootless Podman named volumes owned by one service:
+
+```toml
+[services.database.volumes.data]
+target = "/var/lib/postgresql/data"
+```
+
+The canonical identity includes app, service, and volume names. Host bind mounts and volumes shared between services are forbidden in app manifests.
+
+Releases reuse stable service volumes. Rollback never duplicates or deletes persistent data.
+
+### Networks
+
+Every app automatically receives a private Podman network. All services join it and use service names as DNS aliases.
+
+A service can additionally join an explicitly named private network. This is the only primitive for sharing network access between apps. A shared database, for example, is an independent app whose database service and selected client services join the same named private network.
+
+Gordon does not model provider, consumer, or dependency attachments.
+
+For public routing, the intended topology uses an automatic ingress network per app containing edge and only services targeted by active routes. Edge never joins the app's complete internal network. Runtime is explicitly permitted to reconcile edge's app-ingress network attachments even though Quadlet remains responsible for creating and restarting the edge container. Runtime must restore those attachments after an edge restart. This topology and the rootless host-ingress mechanism require a clean-host Podman/Quadlet proof before Alpha 1 is complete.
+
+## Entrypoints and routes
+
+An app entrypoint is a stable interface backed by a service port. Declaring it never exposes traffic.
+
+```toml
+[entrypoints.web]
+service = "frontend"
+port = 8080
+protocol = "http"
+```
+
+All public mappings are called routes, regardless of protocol. Routes are nested under their app and target an entrypoint in that app.
+
+HTTP uses edge's shared listener implicitly:
+
+```toml
+[routes.web]
+host = "game.example.com"
+entrypoint = "web"
+```
+
+Dedicated TCP and UDP routes own their listen address:
+
+```toml
+[routes.game-tcp]
+listen = ":27015/tcp"
+entrypoint = "game-tcp"
+
+[routes.game-udp]
+listen = ":27015/udp"
+entrypoint = "game-udp"
+```
+
+A private RCON route can bind a private address and restrict peers:
+
+```toml
+[routes.rcon]
+listen = "100.64.0.1:27020/tcp"
+entrypoint = "rcon"
+trusted_cidrs = ["100.64.0.0/10"]
+```
+
+Route identity is `<app>/<route>`. Removing or changing a route never creates, stops, or deletes a service by itself.
+
+Apply validation canonicalizes DNS names to lowercase ASCII, rejects duplicate exact hosts, and initially rejects wildcard hosts. For dedicated routes, `(listen address, port, transport protocol)` is unique installation-wide. A route's protocol must match its target entrypoint. HTTP routes target `http` entrypoints and edge terminates public TLS; SNI passthrough targets `tcp` entrypoints and leaves TLS untouched. Registry's configured SNI is reserved and conflicts with no app route. Route and certificate conflicts fail during apply, before persistence.
+
+Registry passthrough is a system-generated route derived from registry configuration, not a fake app.
+
+## Image policy
+
+References without a registry hostname target Gordon's registry exclusively:
+
+```text
+shop/frontend:v1.4.0
+```
+
+External images require a complete hostname:
+
+```text
+docker.io/library/postgres:18
+ghcr.io/example/worker:v2.1.0
+```
+
+Gordon never searches multiple registries. The literal tag `latest` is rejected in AppSpecs and cannot be overridden in v3-alpha.
+
+Tags are ergonomic source selectors, not runtime identities. At deployment, control resolves each selector to an OCI digest. Runtime only receives digest-pinned references:
+
+```text
+docker.io/library/postgres@sha256:...
+```
+
+If an image cannot be resolved, deployment fails before activating a new release. The stored manifest remains valid and unchanged.
+
+## Apply, releases, and deployment
+
+### Apply
+
+`apps apply` only synchronizes configuration:
+
+```text
+receive complete manifest
+-> normalize
+-> validate
+-> compare
+-> persist atomically as a new AppSpec revision
+```
+
+It never pulls, builds, starts, stops, restarts, removes, or otherwise mutates runtime resources. Routes from a new AppSpec do not become active during apply.
+
+Complete-manifest updates intentionally use last-successful-write-wins semantics in v3-alpha. Apply returns the former and resulting revision and records the authenticated actor when available. Optimistic concurrency may be added later, but alpha does not imply it through an incomplete client-side check.
+
+### Releases
+
+A release is immutable and contains:
+
+- one normalized AppSpec revision;
+- exact OCI digests for all services;
+- the resolved service runtime definitions;
+- the route projection associated with that release.
+
+### Deploy
+
+`gordon deploy <app>` is the only operation that activates a new AppSpec revision. It resolves images, creates a release, performs the runtime change, and activates the release's routes after its required backends are available.
+
+`gordon deploy <app> --service <name>` never activates a pending AppSpec. It is valid only when desired and active AppSpec revisions match; it resolves the selected service's image from that active spec and creates a composed release changing only that service digest.
+
+Release activation follows persisted phases:
+
+```text
+prepared -> mutating -> routes-published -> active
+                         \-> failed
+```
+
+Control persists the operation ID and phase before each external effect. It marks a release active only after runtime reports the intended service set and edge acknowledges the intended route generation. On restart, control observes runtime and edge before resuming or failing an operation; it never blindly replays a mutation. Recreate services are changed in a deterministic service-name order. If a later change fails, control keeps the former route generation, performs bounded best-effort restoration of already changed recreate services, and reports the exact mixed or restored actual state as degraded.
+
+`push --deploy` and auto-deploy may update service digests only when the AppSpec revision is already active. If a newer AppSpec awaits deployment, the image push succeeds but deployment is refused until `gordon deploy <app>` activates the pending specification.
+
+### Auto-deploy
+
+Auto-deploy is disabled by default and configured per service. It applies only to repositories in Gordon's registry and requires an exact repository-and-tag match.
+
+Registry emits a minimal durable event containing repository, tag, digest, timestamp, and event ID. Control owns deduplication, policy evaluation, app/service lookup, and release creation. A repository-and-tag selector with auto-deploy enabled must map to exactly one service installation-wide. Ambiguous mappings are rejected during apply. `push --deploy` uses the same mapping and requires explicit `--app` and `--service` selectors when zero or multiple active targets match.
+
+### Rollback
+
+A full rollback creates a new release from a previous immutable release. A service rollback creates a synthetic release from the currently active AppSpec and route projection, replacing only the selected service's resolved service definition and digest with a previous successful version. App-wide environment, entrypoints, routes, networks, and all other services remain from the active AppSpec. The composition is rejected before mutation if the former service definition is incompatible with those current app-level fields.
+
+```console
+gordon rollback shop
+gordon rollback shop --to 39
+gordon rollback shop --service frontend
+gordon rollback shop --service frontend --to 39
+```
+
+Gordon validates the composed release before mutation. Historical secret values are not versioned; rollback resolves the current values for the selected service's secret references.
+
+## Deployment strategy
+
+Deployment strategy is not configurable.
+
+An eligible web service uses replacement without a transport-level outage when it:
+
+- is targeted by HTTP/HTTPS routes;
+- has no active TCP or UDP route;
+- has no persistent volume;
+- can run old and new instances concurrently.
+
+The single algorithm is:
+
+```text
+start new container
+-> wait for Podman running
+-> verify that its HTTP entrypoint accepts TCP
+-> atomically switch edge routes
+-> stop old container
+```
+
+V3 has no readiness configuration and does not consume OCI `HEALTHCHECK`. It does not promise application-level readiness.
+
+Every stateful, worker, TCP, UDP, RCON, mixed-protocol, or volume-owning service uses recreate and may experience downtime.
+
+## Lifecycle commands
+
+```console
+gordon stop shop
+```
+
+Removes active routes and containers while preserving manifest revisions, releases, secrets, and volumes. `gordon deploy shop` starts it again.
+
+```console
+gordon remove shop
+```
+
+Stops the app and removes server-side manifests, releases, secrets, runtime networks, and containers. Service volumes are retained as identified orphans together with a minimal tombstone reserving the former app name. Registry images are untouched. A new app cannot reuse that name or adopt those volumes implicitly while the tombstone exists.
+
+```console
+gordon purge shop
+```
+
+Performs remove and deletes app-owned volumes and the tombstone after explicit confirmation containing the app name. It remains valid after `remove` because the tombstone retains only the ownership metadata required to locate and authorize deletion. Registry images remain independently managed.
+
+## Failure behavior
+
+| Failure | Required behavior |
+| --- | --- |
+| control unavailable | Existing workloads and routes continue. Administration and mutations fail. Registry queues push events durably. |
+| runtime unavailable | Existing Podman containers continue. Edge and registry continue. Runtime mutations fail clearly. |
+| edge unavailable | Workloads and administration continue. Public app traffic and registry passthrough are unavailable. |
+| registry unavailable | Existing apps and routes continue. OCI push/pull fail. Cached digest-pinned images may still be deployable. |
+
+Edge persists only its last valid sanitized route snapshot and public certificates. It may start from that snapshot when control is unavailable. With no valid snapshot, it fails closed. Invalid or older snapshots never replace the active one.
+
+The general rule is that losing the control plane must not interrupt already active workloads or routes.
+
+## CLI surface
+
+### Alpha baseline
+
+Declarative resources:
+
+```text
+gordon apps apply --file <manifest>
+gordon apps list
+gordon apps show <app>
+```
+
+Frequent operations remain top-level:
+
+```text
+gordon deploy <app> [--service]
+gordon rollback <app> [--service] [--to]
+gordon restart <app> [--service]
+gordon stop <app>
+gordon remove <app>
+gordon purge <app>
+gordon logs <app> [--service]
+gordon status [app]
+gordon push <image> [--build] [--deploy]
+```
+
+Inspection and supporting resources:
+
+```text
+gordon routes list [app]
+gordon routes show <app>/<route>
+gordon secrets set/list/remove
+gordon images list
+gordon volumes list
+gordon networks list
+gordon remotes add/list/remove/use
+gordon serve --role control|runtime|edge|registry
+gordon version
+gordon completion
+```
+
+### V2 feature tracking
+
+V3-alpha intentionally omits features until they are redesigned on v3 primitives.
+
+| V2 surface | V3-alpha status | Direction |
+| --- | --- | --- |
+| `attachments` | removed | Replace with app-private and named private networks |
+| `autoroute` | removed | Re-evaluate; no implicit public exposure |
+| `bootstrap` | removed | Replace with manifest apply, secret set, push, and deploy |
+| `pin` | removed | Replace with immutable releases and OCI digests |
+| `reload` | removed | No replacement; control owns persisted specs |
+| route add/remove/purge | removed | Routes are changed only through the complete app manifest |
+| `auth show-token` | removed | Never print stored credentials |
+| previews | deferred | Redesign as temporary apps/releases |
+| backups | deferred | Redesign around service-owned volumes |
+| CA/TLS inspection | deferred | Redesign around edge and registry ownership |
+| traffic status | deferred | Fold into route and edge status |
+| image/volume prune | deferred | Add explicit resource GC after ownership rules are proven |
+
+This table must remain in the v3 backlog. A v2 feature returns only after its ownership and security semantics are explicit.
+
+## Alpha installation
+
+Stable installation remains version-based. `gordon update` only consumes signed, tagged releases and is not used for alpha testing.
+
+The Alpha 1 installer will support:
+
+```console
+curl -fsSL https://gordon.bnema.dev/install | GORDON_BRANCH=v3-alpha sh
+```
+
+A precise commit is reproducible:
+
+```console
+curl -fsSL https://gordon.bnema.dev/install | GORDON_COMMIT=<sha> sh
+```
+
+A checkout can be installed with:
+
+```console
+GORDON_LOCAL=1 ./install.sh
+```
+
+`GORDON_VERSION`, `GORDON_BRANCH`, `GORDON_COMMIT`, and `GORDON_LOCAL` will be mutually exclusive. Branch and commit modes will fetch the exact source revision, build the Gordon image with rootless Podman, install the matching host CLI, generate/update Quadlets, and report the source commit. They will not alter the semantics of stable `gordon update`. These modes do not exist in the current v2 installer and are not usable until Alpha 1 implements and verifies them.
+
+## Incremental delivery
+
+### Alpha 1: isolated foundation
+
+- Branch and installer flow.
+- A clean-host ingress and Unix-socket/UID/SELinux ADR plus Podman/Quadlet proof of concept.
+- Four separately confined containers under the documented trusted host account.
+- Rootless Podman only, with runtime's full-engine authority explicitly tested.
+- Quadlet generation.
+- Private Unix sockets and SSH administration.
+- Socket recreation, startup-order, ownership, mode, mount, and SELinux tests.
+- Status and ownership tests proving only runtime sees Podman.
+
+### Alpha 2: minimal web app
+
+- App manifest and globally unique name.
+- Configuration-only apply.
+- Explicit deploy.
+- One service, private app network, HTTP entrypoint, HTTP route.
+- End-to-end edge traffic.
+
+### Alpha 3: multi-service security
+
+- Multiple services.
+- Global public environment.
+- Service-scoped write-only secrets.
+- Service-owned volumes.
+- Named private networks across apps.
+- Per-app ingress networks.
+
+### Alpha 4: registry and releases
+
+- Public authenticated OCI registry through raw SNI passthrough.
+- Digest-only runtime deployments.
+- Immutable releases.
+- Push deploy and opt-in auto-deploy.
+- Durable registry outbox.
+- Full and service-level rollback.
+
+### Alpha 5: routes and lifecycle
+
+- HTTP, TCP, and UDP routes.
+- Web-only replacement without transport outage.
+- Restart, stop, remove, and purge.
+- Component restart and failure-matrix tests.
+- End-to-end security and recovery checks.
+
+Every commit on `v3-alpha` must remain buildable and testable. Every alpha stage must install on a clean host through the same installer and clearly report unsupported features.
+
+## Remaining implementation details
+
+The following details are intentionally left to focused implementation ADRs, provided they preserve this design:
+
+- exact on-disk formats for AppSpec, releases, and deployment status;
+- exact HTTP DTOs and streaming format;
+- Unix-socket directory layout and Quadlet UID mappings;
+- named shared-network declaration syntax;
+- certificate storage and renewal mechanics inside edge and registry;
+- bounded event-outbox limits and retry schedule;
+- release retention and garbage-collection defaults;
+- safe component update ordering for the first tagged v3 release.

--- a/docs/v3/design.md
+++ b/docs/v3/design.md
@@ -16,6 +16,7 @@ V3 deliberately breaks compatibility with v2. It removes legacy configuration, c
 
 ### In scope
 
+- One Gordon distribution, host binary, and component image generation for one installation.
 - Four isolated Gordon components on one host.
 - Rootless Podman as the only container runtime.
 - One declarative manifest per app.
@@ -93,18 +94,44 @@ A compromised `registry` controls its OCI storage and may emit malformed or forg
 
 ## Deployment topology
 
-V3 is strictly mono-host. The supported topology is:
+V3 is strictly mono-host. One Gordon distribution provides the host CLI and one component image containing an octet-identical copy of that Gordon executable. The image runs that executable in four role-specific serve modes; the exact command syntax is fixed during Alpha 1. "Distribution" and "installation generation" refer to Gordon itself; "release" remains reserved for immutable app deployments.
 
 ```text
-systemd --user / Quadlet
-├── gordon-edge
-├── gordon-registry
-├── gordon-control
-└── gordon-runtime
-    └── rootless Podman socket
+host: gordon <version>
+  |
+  +-- owns installation state and generated Quadlets
+  |
+  `-- systemd --user / Quadlet
+      ├── gordon serve edge
+      ├── gordon serve registry
+      ├── gordon serve control
+      `── gordon serve runtime
+          `── rootless Podman socket
 ```
 
-Quadlet, not Gordon, owns component startup and restart. V3 does not contain a component launcher, checkpointed split migration, runtime handoff, or self-orchestration system.
+A distribution identity binds its version or source revision, executable SHA-256, component-image OCI digest, and persistent-format versions. The build copies that exact executable into the image and verifies its hash before image publication; the signed manifest attests both that hash and the resulting image digest. Quadlets reference the image by digest, never by a mutable tag. Branch and commit builds are attributable to one exact clean revision but are not authenticated releases. A dirty local checkout receives an explicit identity containing both the commit and source-tree hash instead of reporting clean `HEAD`.
+
+The installed host binary and all four running roles must match one intended distribution identity. A future component update will necessarily observe mixed generations while replacing processes; that is permitted only as an explicit transitional state and must never be reported healthy. Alpha 1 supports fresh installation and recovery of that same incomplete installation only. Installing a different generation, component update, and component rollback remain blocked on the lifecycle ADR.
+
+### Component lifecycle ownership
+
+Gordon owns the declarative lifecycle of its installation. A minimal shell bootstrap obtains and verifies or builds the host binary, then invokes its host-side installation command. That command:
+
+- allows one Gordon installation per host account and rootless Podman engine;
+- serializes mutations with an installation lock;
+- records intended, staged, running, and failure state in a persistent journal;
+- uses atomic, idempotent steps so the same generation can resume after interruption;
+- installs the matching component image and creates installation directories and initial configuration;
+- generates the four Quadlet definitions;
+- asks the user systemd manager to reload, enable, start, or stop the installation target;
+- verifies process state, role readiness, dependencies, and distribution identity without granting a mutation capability to public components;
+- reports partial operations as degraded or incomplete without claiming success.
+
+Quadlet translates Gordon's Podman declarations into systemd units. Systemd owns continuous process supervision, boot activation, dependency ordering, and restart-after-failure. The installer must configure and test the user-manager lingering policy required for boot without an interactive login. Podman creates and runs the containers. Gordon is not a fifth resident supervisor and does not reimplement systemd.
+
+Generated Quadlets are Gordon-owned outputs, not user configuration. Gordon records their generation and checksums, writes them atomically, and refuses to overwrite unknown edits without an explicit recovery operation that preserves a backup. Supported customization belongs in `gordon.toml`.
+
+This lifecycle applies only to Gordon's four components. Application containers remain desired by control and reconciled by runtime through the Podman socket. Gordon v3 does not contain the archived checkpointed split migration, runtime handoff, or autonomous self-upgrade system. Component update support remains blocked until the focused lifecycle ADR defines safe replacement order, persistent-format compatibility, rollback or roll-forward, and interruption recovery.
 
 ## Component ownership
 
@@ -116,6 +143,8 @@ Quadlet, not Gordon, owns component startup and restart. V3 does not contain a c
 | registry | OCI blobs, manifests, tags, registry TLS identity, durable push-event outbox | App secrets, Podman socket, deployment decisions |
 
 The components do not share data volumes. Explicit host-mounted Unix-socket directories are communication capabilities, not shared data stores.
+
+Gordon component containers, networks, volumes, and Quadlet-managed resources use reserved names and ownership labels. Runtime workload reconciliation and future garbage collection must exclude them. Runtime's narrowly defined, idempotent reconciliation of edge's app-ingress network attachments is the only allowed workload-side mutation of a Gordon component; the ingress ADR must prove that this exception cannot become a generic component-management path.
 
 ## Internal communication
 
@@ -611,7 +640,7 @@ This table must remain in the v3 backlog. A v2 feature returns only after its ow
 
 ## Alpha installation
 
-Stable installation remains version-based. `gordon update` only consumes signed, tagged releases and is not used for alpha testing.
+Stable installation remains version-based. The future v3 `gordon update` will consume only signed, tagged distributions, but component update is unavailable until the lifecycle ADR is accepted and implemented. A signed distribution manifest defines its future input by binding version and source commit to the executable hash, component-image digest, and persistent-format versions.
 
 The Alpha 1 installer will support:
 
@@ -631,7 +660,20 @@ A checkout can be installed with:
 GORDON_LOCAL=1 ./install.sh
 ```
 
-`GORDON_VERSION`, `GORDON_BRANCH`, `GORDON_COMMIT`, and `GORDON_LOCAL` will be mutually exclusive. Branch and commit modes will fetch the exact source revision, build the Gordon image with rootless Podman, install the matching host CLI, generate/update Quadlets, and report the source commit. They will not alter the semantics of stable `gordon update`. These modes do not exist in the current v2 installer and are not usable until Alpha 1 implements and verifies them.
+`GORDON_VERSION`, `GORDON_BRANCH`, `GORDON_COMMIT`, and `GORDON_LOCAL` will be mutually exclusive. In future version mode, before executing the downloaded Gordon binary, the shell bootstrap verifies the distribution-manifest signature with a pinned release public key and verifies the executable SHA-256 from that manifest. The initial `curl | sh` still trusts HTTPS delivery of the bootstrap itself; users requiring an independent root of trust must obtain and verify the installer through a separately trusted channel. Branch and commit modes resolve one exact clean revision; local mode records a source-tree hash when the checkout is dirty. Source modes are explicitly unauthenticated alpha inputs and use the resulting identity for both artifacts.
+
+The shell is bootstrap transport only: after pre-execution verification or a local/source build, it invokes Gordon's host-side installer. Gordon acquires the installation lock and resumable journal before it:
+
+1. verifies rootless Podman, Quadlet, the user systemd manager, and boot-without-login policy;
+2. builds or acquires the matching component image and records its immutable digest;
+3. installs the host CLI and distribution identity;
+4. creates installation directories, configuration, networks, and capability-socket directories;
+5. atomically generates four Quadlets that invoke the digest-pinned image in distinct serve roles with role-specific mounts, sockets, and networks;
+6. reloads the user systemd manager and enables/starts the installation target;
+7. verifies process state, readiness, dependencies, and identity for all four roles;
+8. records success or an explicitly incomplete, resumable state and reports the exact distribution identity.
+
+Alpha 1 accepts only a clean host or resumption of the same incomplete generation. It does not replace another generation and makes no component update or rollback promise. The v3 `gordon update` command remains unavailable. Enabling it requires the lifecycle ADR to define transitional states, replacement order, persistent-format compatibility, backup, rollback versus roll-forward, and recovery after interruption. Source modes do not create an alpha update channel. They do not exist in the current v2 installer and are not usable until Alpha 1 implements and verifies them.
 
 ## Incremental delivery
 
@@ -641,7 +683,11 @@ GORDON_LOCAL=1 ./install.sh
 - A clean-host ingress and Unix-socket/UID/SELinux ADR plus Podman/Quadlet proof of concept.
 - Four separately confined containers under the documented trusted host account.
 - Rootless Podman only, with runtime's full-engine authority explicitly tested.
-- Quadlet generation.
+- One host binary and one digest-pinned component image built from one distribution identity.
+- Four role-specific serve modes from that image.
+- A locked, journaled, idempotent host installer limited to fresh install and same-generation recovery.
+- Atomic Quadlet generation and an installation target managed by the host binary.
+- Identity, readiness, lingering, partial-failure, and clean-host bootstrap tests.
 - Private Unix sockets and SSH administration.
 - Socket recreation, startup-order, ownership, mode, mount, and SELinux tests.
 - Status and ownership tests proving only runtime sees Podman.
@@ -693,4 +739,4 @@ The following details are intentionally left to focused implementation ADRs, pro
 - certificate storage and renewal mechanics inside edge and registry;
 - bounded event-outbox limits and retry schedule;
 - release retention and garbage-collection defaults;
-- safe component update ordering for the first tagged v3 release.
+- lifecycle states, component replacement order, persistent-format compatibility, backup, rollback or roll-forward, and interrupted-update recovery before any component update support.


### PR DESCRIPTION
## Summary

- define the accepted Gordon v3 security and component architecture
- specify the mono-binary, mono-image, mono-generation component lifecycle
- define the declarative app, release, route, secret, volume, and CLI models
- record rejected alternatives, accepted risks, alpha milestones, and deferred v2 features

## Review

- senior review `568a43bf` completed with no remaining blocking or high-impact objection
- Alpha 1 is fresh-install and same-generation recovery only
- component update remains blocked on a focused lifecycle ADR
- rootless ingress and Unix-socket UID/SELinux behavior remain Alpha 1 ADR/PoC blockers

## Verification

- `git diff --check`
- Markdown fence-balance check
- signed commit verification