### PR TITLE
docs(v3): clarify workload lifecycle and safety contracts

### DIFF
--- a/.agent-reviews/redteam.md
+++ b/.agent-reviews/redteam.md
@@ -47,3 +47,39 @@ Senior review `568a43bf-aa10-49e3-8d0b-30caf08fbd5a` found one blocking and four
 ### Final verdict
 
 After two correction rounds, senior reviewer `568a43bf-aa10-49e3-8d0b-30caf08fbd5a` returned **VALIDATED** with no remaining blocking or high-impact objection.
+
+## 2026-09-04 — Workload design clarification
+
+### Builder decision
+
+Clarify route reservations across desired/active/in-flight state, effective configuration identity after partial rollback, durable execution intent, volume-safe restoration, and the minimum workload invariants required in Alpha 2. Require full-path ingress proofs, registry certificate/client-trust analysis, and a concurrency/draining ADR before the corresponding features are enabled.
+
+Public environment remains app-wide only. All service-specific values remain write-only secrets, including non-confidential values. Their historical values are not reproduced by manifests or release rollback. No new per-service public environment, rollout eligibility field, registry trust mechanism, or component update support is introduced.
+
+### Evidence
+
+- Updated design, foundation ADR, and agent guidance only; sandbox and runtime code are untouched.
+- `git diff --check` passes.
+- Markdown fences and relative file links pass validation; all 15 design TOML examples parse with Python `tomllib`.
+- No Go tests or VM execution are claimed for this documentation-only change.
+- CodeRabbit CLI is unavailable in this environment.
+
+### Critic pass
+
+Senior reviewer `63230960-eaa2-41af-8fbe-c8ceb49d680a` reviewed the changes against `origin/v3-alpha` and raised four high-impact and one medium-impact clarification, plus two wording improvements.
+
+### Resolutions
+
+- Unified source-address acceptance around full-path observation, original-client CIDR enforcement, and an explicit gate for workloads requiring preservation at the backend. Observation alone does not waive a workload's preservation requirement.
+- Defined service rollback provenance as the base active AppSpec revision plus base/donor release identities and the composed effective AppSpec; full rollback retains the selected historical revision.
+- Replaced mutable observed network attachments with declarations from the active release's effective AppSpec.
+- Kept stopped intent until successful full-deploy activation; interrupted operations use their journal and failed attempts clean up rather than resurrecting prior releases.
+- Distinguished certificate-lifecycle decisions from their implementation proof and clarified that web concurrency eligibility remains unselected.
+
+### Remaining gates
+
+The public-env model is unchanged. Detailed persistence/recovery, registry trust, ingress implementation, and rollout eligibility remain subject to their stated ADRs and runtime proofs.
+
+### Final verdict
+
+The same senior reviewer verified the corrections in commit `139ebd4b` and returned no remaining must-fix semantic contradictions within that scope. This closes the documentation critic pass, not the future implementation proofs. The final commit additionally records this review outcome.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,11 @@ app -> services -> runtime containers
 - `gordon apps apply --file ...` persists desired configuration only; it never mutates runtime.
 - `gordon deploy <app>` is the only operation that activates a pending AppSpec.
 - Runtime receives digest-pinned OCI references only.
-- Entrypoints describe service interfaces; routes are the only public exposure primitive.
-- Secrets are write-only and service-owned.
+- Entrypoints describe service interfaces; routes are the only public exposure primitive. Reserve hosts and listeners across desired, active, and in-flight state, including during rollback.
+- Public environment is app-wide only. All service-specific values use write-only secrets, even when non-confidential; reject public-environment/secret name collisions.
+- Secrets are write-only and service-owned; rollback uses current values, not historical ones.
+- Releases record effective configuration and provenance. Service-targeted deploy and push/auto-deploy require matching desired/active source revisions and effective configuration, including after synthetic rollback.
+- Execution intent is durable and separate from releases. Stopped apps stay stopped after reboot and queued events; only successful full-deploy activation changes their durable intent to running. Interrupted deploy follows its journal, not generic resurrection of a prior release. Restart uses the active release and current secrets.
 - Volumes are named Podman volumes owned by one service; no host bind mounts or shared service volumes.
 - Each app has a private network; edge joins only generated ingress networks for routed services.
 
@@ -111,7 +114,7 @@ Prefer standard-library and native Podman/systemd mechanisms over new dependenci
 
 Alpha 1 is blocked until ADRs and clean-host proofs establish:
 
-1. rootless ingress for `80/443`, dedicated TCP/UDP, source-IP preservation, firewall behavior, edge restarts, and private runtime-to-registry pulls;
+1. rootless ingress for `80/443`, dedicated TCP/UDP, source-IP observation at edge and backend across the full proxied path, CIDR enforcement, firewall behavior, edge restarts, and private runtime-to-registry pulls;
 2. Unix-socket paths, UID/GID mappings, ownership, modes, directory mounts, recreation, startup ordering, and SELinux/AppArmor behavior.
 
 Implement Alpha 1 incrementally after those proofs:
@@ -125,7 +128,9 @@ Implement Alpha 1 incrementally after those proofs:
 7. private sockets and SSH administration;
 8. clean Ubuntu 26.04 installation, reboot, authority, and failure tests.
 
-Do not start Alpha 2 workload features until Alpha 1 installs and passes on a clean reference host.
+Do not start Alpha 2 workload features until Alpha 1 installs and passes on a clean reference host. Alpha 2 must already include minimal digest-pinned immutable releases, separate ingress networks, durable execution intent, stop, and interruption/reboot tests. Persistence, reservation, edge-snapshot, and workload-recovery ADRs precede those features; do not defer their invariants to Alpha 4.
+
+Before public registry access, require a certificate-lifecycle ADR and proof that compromised edge cannot obtain a registry identity accepted by clients. Before web replacement in Alpha 5, require a rollout ADR for concurrency-safe eligibility and bounded draining. Neither the registry trust mechanism nor the web concurrency-eligibility mechanism is selected yet. Do not automatically restore an older volume-owning service after a replacement may have written its data.
 
 ## Architecture and Go style
 

--- a/docs/v3/adr-001-v3-foundation.md
+++ b/docs/v3/adr-001-v3-foundation.md
@@ -73,6 +73,8 @@ Edge terminates public application HTTP/HTTPS. It receives only a sanitized, gen
 
 Registry is publicly reachable for authenticated OCI operations. Edge selects registry traffic by SNI and forwards the encrypted TCP stream without terminating TLS. Registry owns its TLS identity and a durable push-event outbox, but has no general configuration or runtime API. Auto-deploy deliberately grants registry bounded authority to trigger a release for one configured repository-and-tag target. Without artifact verification rooted outside registry, registry compromise can deploy arbitrary content to that opted-in service; this is accepted for alpha.
 
+Before public registry access, a certificate-lifecycle ADR must define issuance, renewal, and client trust; a separate implementation proof must demonstrate that a compromised edge cannot obtain a registry identity accepted by OCI clients. TLS passthrough and separate private-key storage alone do not prevent impersonation if edge can satisfy registry-domain ACME challenges through its public ports. Issuance, renewal, and client trust remain an explicit implementation gate.
+
 Control and runtime form the trusted core. Control owns desired state and deployment decisions. Runtime owns actual Podman state and persisted secret values.
 
 ### Replace route-owned workloads with declarative apps
@@ -81,9 +83,11 @@ Each app is defined by one user-owned TOML manifest and has a globally unique na
 
 Every service is explicitly named, references one image, and has one active instance. There is no app-level image shorthand or implicit default service. Compact and expanded syntax are both accepted but normalize to one model.
 
-An app has an automatic private network. Named private networks allow explicitly selected services from different apps to communicate. The intended public-routing topology adds an automatic per-app ingress network containing edge and only routed services. Gordon component resources use reserved names and ownership labels and are excluded from workload reconciliation and garbage collection. Runtime's narrow, idempotent reconciliation of edge's app-ingress attachments is the only allowed workload-side component mutation; Quadlet remains responsible for creating and restarting edge. Alpha 1 is blocked on a clean-host ADR and proof covering this exception, rootless host ingress, source-IP preservation, privileged ports, dynamic TCP/UDP listeners, socket permissions, UID mappings, and SELinux labels.
+An app has an automatic private network. Named private networks allow explicitly selected services from different apps to communicate. The intended public-routing topology adds an automatic per-app ingress network containing edge and only routed services. Gordon component resources use reserved names and ownership labels and are excluded from workload reconciliation and garbage collection. Runtime's narrow, idempotent reconciliation of edge's app-ingress attachments is the only allowed workload-side component mutation; Quadlet remains responsible for creating and restarting edge. Alpha 1 is blocked on a clean-host ADR and proof covering this exception, rootless host ingress, source-address behavior, privileged ports, dynamic TCP/UDP listeners, socket permissions, UID mappings, and SELinux labels.
 
-App entrypoints describe stable service interfaces. Declaring one does not expose it. Routes are the only exposure primitive and support HTTP, TCP, and UDP. HTTP uses edge's shared listener; dedicated TCP and UDP routes contain their own listen address.
+App entrypoints describe stable service interfaces. Declaring one does not expose it. Routes are the only exposure primitive and support HTTP, TCP, and UDP. HTTP uses edge's shared listener; dedicated TCP and UDP routes contain their own listen address. The ingress proof must test the complete client-to-edge-to-backend path, document source addresses observed at edge and backend, identify the `trusted_cidrs` enforcement point, and prove allow/deny behavior using the original client address there. Workloads requiring that address at the backend remain blocked unless preservation there is proven; direct Podman publication is not sufficient evidence.
+
+Control atomically reserves route hosts and listener bindings across desired, active, and in-flight state. Removing a desired route does not release an active binding until edge acknowledges withdrawal and no desired or in-flight reference remains. Historical releases hold no permanent reservation; deploy and rollback reacquire and validate before mutation. Listener conflicts include installation listeners, wildcard/specific address overlap, and IPv4/IPv6 dual-stack behavior.
 
 ### Separate configuration from runtime mutation
 
@@ -91,25 +95,35 @@ App entrypoints describe stable service interfaces. Declaring one does not expos
 
 `gordon deploy <app>` is the only command that activates a new AppSpec revision. It resolves image selectors to OCI digests, creates an immutable release, applies runtime changes, and publishes the release's routes through persisted `prepared`, `mutating`, `routes-published`, and terminal phases. Activation requires observed runtime state and edge acknowledgement; restart recovery observes before acting and never blindly replays mutations.
 
-`gordon deploy <app> --service <name>` is allowed only when desired and active AppSpec revisions match and creates a composed release changing that service digest only. `push --deploy` and auto-deploy follow the same restriction and cannot implicitly activate pending configuration. Auto-deploy selectors must be unique installation-wide; ambiguous push targets require explicit app and service selection.
+`gordon deploy <app> --service <name>` is allowed only when desired and active source AppSpec revisions match and the desired normalized configuration equals the active release's effective configuration. It creates a composed release changing that service digest only. `push --deploy` and auto-deploy follow the same restriction and cannot implicitly activate pending configuration or undo configuration changes from a synthetic rollback. Auto-deploy selectors must be unique installation-wide; ambiguous push targets require explicit app and service selection.
+
+Control serializes mutations of each app, including apply and secret mutation, so operation inputs cannot change mid-flight. Route reservations and edge snapshot publication require installation-wide coordination across apps. Persistence, snapshot, and workload-recovery ADRs are prerequisites for Alpha 2. The first workload stage already requires digest-pinned immutable releases, ingress isolation, durable execution intent, and restart/interruption tests; Alpha 4 adds Gordon's registry and rollback rather than introducing those invariants.
 
 ### Use immutable releases and scoped rollback
 
 Runtime receives only digest-pinned OCI references. Unqualified image references target Gordon's registry; external references require a full registry hostname. The literal tag `latest` is rejected with no alpha override.
 
-A release combines an immutable normalized AppSpec with exact service digests. Full rollback and service-level rollback both create new releases; historical releases are never mutated. A service rollback uses the currently active app-level environment, entrypoints, routes, networks, and other services, and substitutes only the selected former service definition and digest. The synthetic release must pass complete validation before mutation.
+A release records its immutable effective normalized AppSpec, source revision, exact service digests, and source release identities when composed. Full rollback and service-level rollback both create new releases; neither desired configuration nor historical releases are mutated. A service rollback retains the active release's app-level environment, entrypoints, routes, network declarations, and other services, and substitutes only the selected former service definition and digest. Network declarations come from the active release's effective AppSpec, never observed Podman attachments. The new release retains the base active release's source AppSpec revision as provenance and records base and donor release identities plus the composed effective AppSpec. A full rollback retains the selected historical release's source AppSpec revision. The synthetic release must pass complete validation before mutation and expose its actual effective configuration, not merely reuse a revision label. Configuration divergence blocks subsequent service-targeted deploy and push/auto-deploy until full deploy activates the desired AppSpec.
+
+Rollback uses current secret values and never reverses data migrations. Automatic best-effort restoration must not restart an older volume-owning service after its replacement may have written data; report degraded state for operator recovery. Explicit rollback requires the operator to establish volume compatibility outside Gordon.
 
 ### Minimize secret and storage authority
 
-Public environment values are app-wide and injected into every service. There is no service-local public environment. Values intended for one service use write-only secrets, even if not confidential.
+Public environment values are app-wide and injected into every service. There is no service-local public environment. Values intended for one service use write-only secrets, even if not confidential. This deliberately separates public app configuration from service-owned values: manifests declare the required secret names but do not reproduce their values, and release rollback does not restore historical values. A secret name colliding with an app-wide public environment key is rejected during validation.
 
 Secrets are identified by app, service, and name. They cannot be read through any Gordon API or shared by reference between services. Control handles values transiently during set/update; runtime persists and injects them as same-name environment variables. This prevents direct API disclosure but does not protect service secrets from a compromised control plane authorized to deploy that service. Secret changes affect only a later deploy/restart, missing declared secrets block deployment, and removal of a desired or active reference is rejected.
 
 App manifests allow only service-owned Podman named volumes. Host bind mounts and cross-service shared volumes are forbidden. `stop` preserves all durable state. `remove` deletes app metadata and secrets but preserves volumes plus a tombstone that reserves the app name and prevents implicit data adoption. `purge` also deletes volumes and the tombstone after explicit confirmation. Registry images have an independent lifecycle. Runtime pulls them through a separate private registry endpoint with pull-only credentials, not through public edge passthrough; the exact rootless endpoint is part of the Alpha 1 ingress proof.
 
+### Persist workload execution intent
+
+Control stores `running` or `stopped` intent separately from desired configuration, the last active release, and observed containers. Apply preserves intent; a new app starts stopped. A full deploy of a stopped app changes durable intent to running only upon successful release activation. Its journaled operation may create resources and resume after interruption, but generic reboot reconciliation must not resurrect a prior release. If deployment fails, intent stays stopped and recovery cleans up partial resources. Stop persists stopped intent before cleanup, which resumes after interruption. Restart, rollback, service-targeted deploy, push deploy, and auto-deploy refuse stopped apps; only full deploy requests running state again. Restart uses the active effective configuration and pinned digests with current secret values, never pending configuration or newly resolved tags.
+
+Before Alpha 2, the workload-recovery ADR must identify who restarts app containers after host reboot and how to restore active releases, retain stopped intent, recover interrupted operations, and validate persisted edge backends. Component Quadlets and lingering alone do not establish workload recovery. Reboot recovery may wait for the trusted core and must not activate pending AppSpecs implicitly.
+
 ### Limit zero-downtime behavior
 
-Deployment strategy is inferred and not configurable. Only stateless services exclusively routed through HTTP/HTTPS and without persistent volumes are eligible for replacement without a transport outage. Gordon starts the new instance, waits for Podman `running` and an accepting HTTP backend TCP port, switches edge routes, and removes the old instance.
+Deployment strategy is not configurable. Statelessness, exclusive HTTP/HTTPS routing, and absence of persistent volumes are necessary but insufficient conditions for web replacement without a transport outage. Replacement remains disabled until the Alpha 5 rollout ADR selects a concurrency-eligibility mechanism and implementation proofs validate it, multi-entrypoint checks, and bounded draining including WebSockets. No concurrency-eligibility mechanism or strategy selector is chosen here. Gordon starts the new instance, waits for Podman `running` and an accepting HTTP backend TCP port, switches edge routes, drains existing connections up to a deadline, and removes the old instance. Connections outliving that deadline may be interrupted.
 
 All stateful, worker, TCP, UDP, RCON, mixed-protocol, and volume-owning services use recreate and may experience downtime. V3 has no readiness configuration and does not interpret OCI `HEALTHCHECK`.
 
@@ -142,7 +156,7 @@ Alpha 1 will implement branch, commit, and local modes that derive one explicit 
 - The app manifest is a portable, Git-friendly source of truth.
 - Apply and deploy have distinct, predictable effects.
 - Routes no longer own containers.
-- Digest-pinned releases provide reproducible deployment and rollback.
+- Digest-pinned releases reproduce image identities and recorded configuration, not historical secret values or volume contents.
 - Per-service secrets and volumes reduce workload blast radius.
 - The smaller CLI and fresh-start policy permit substantial code deletion.
 - Incremental alpha milestones can be tested on real clean installations.
@@ -171,7 +185,7 @@ Alpha 1 will implement branch, commit, and local modes that derive one explicit 
 - Edge must preserve its last valid sanitized snapshot so a control restart does not interrupt traffic.
 - Registry must persist and retry push events while control is unavailable.
 - Runtime must reconstruct actual state from Podman after restart rather than trust stale process memory.
-- Deployment status must distinguish desired AppSpec, active release, and observed runtime state.
+- Deployment status must distinguish desired AppSpec, active release's effective configuration, execution intent, and observed runtime state.
 
 ## Alternatives considered
 
@@ -228,7 +242,7 @@ Rejected. It would force obsolete ownership and command models into the new arch
 | Socket mount accidentally grants excessive API access | Separate directories and handlers per capability; installer ownership tests; no generic RPC socket |
 | Stale edge routing after control failure | Persist the last valid monotonic snapshot; reject invalid or older generations; expose applied generation in status |
 | Apply overwrites another operator's desired state | Complete-manifest semantics and future optimistic-concurrency details in a focused API ADR |
-| Failed stateful deployment causes downtime | Do not promise zero downtime; retain immutable former release and perform bounded best-effort recovery |
+| Failed stateful deployment causes downtime or data incompatibility | Do not promise zero downtime; retain the former release but do not automatically restart an older volume-owning service after replacement writes; operator recovery must establish data compatibility |
 | Alpha installer silently moves branch state | Resolve and report exact commit; support `GORDON_COMMIT` for reproduction; include a source-tree hash for dirty local builds |
 | Version text identifies different artifacts | Bind the executable hash, OCI digest, and format versions in a distribution identity; verify the same executable is copied into the image; pin image digests; sign tagged distribution manifests |
 | Partial update leaves mixed component generations | Limit Alpha 1 to fresh install; never report transitional mixed state healthy; require a lifecycle ADR before update support |
@@ -258,20 +272,29 @@ The decision is considered implemented only when automated tests prove:
 15. Process running, role ready, dependencies ready, and identity verified are distinguishable; mixed generations are never reported healthy.
 16. User-manager lingering starts the installation after reboot without an interactive login.
 17. Workload reconciliation cannot mutate or garbage-collect Gordon-owned resources except for the narrow tested edge-network attachment operation.
-18. The selected host-ingress mechanism preserves required source addresses and supports the documented HTTP, registry SNI, TCP, and UDP listeners under rootless Podman.
+18. Full-path ingress tests document source addresses at edge and backend, prove `trusted_cidrs` allow/deny behavior using the original client address at its enforcement point, and cover HTTP, registry SNI, TCP, and UDP under rootless Podman. Workloads requiring the original address at their backend remain blocked until preservation there is proven.
 19. Socket directories survive component restart with exact ownership, mode, mount, and SELinux behavior.
+20. Pending route removal cannot free an active binding; concurrent app operations and rollback cannot claim conflicting hosts or listeners, including wildcard and dual-stack overlaps.
+21. Synthetic rollback exposes its effective configuration and prevents service-targeted deploy or auto-deploy from implicitly reverting configuration changes.
+22. Stopped apps remain stopped across component restart, reboot, and queued push events; restart uses the active release and current secrets without resolving newer tags.
+23. Alpha 2 already uses immutable digest-pinned releases, separate ingress networks, and interrupted-operation recovery, including stop.
+24. Registry issuance and client trust resist identity impersonation by a compromised edge, not only disclosure of the existing registry key.
+25. Web replacement has proven concurrent-instance eligibility and bounded draining before it is enabled; stateful recovery never assumes older code is compatible with modified volumes.
+26. Service-owned values remain write-only even when non-confidential; public-environment/secret name collisions fail validation and rollback injects current values.
 
 ## Follow-up decisions
 
 Focused ADRs should define, when implementation reaches them:
 
-- AppSpec and release persistence;
+- AppSpec/release persistence, effective configuration identity, execution intent, route reservations, and app-operation serialization before Alpha 2;
+- workload startup ownership and host reboot/interruption recovery before Alpha 2;
 - internal HTTP DTO versioning;
 - Unix-socket filesystem and UID mapping, which is a prerequisite for Alpha 1 rather than a deferrable implementation detail;
 - rootless host ingress and private runtime-to-registry pulls, also prerequisites for Alpha 1;
-- edge snapshot generation and acknowledgement;
-- registry event outbox semantics;
+- edge snapshot generation, publication coordination across apps, and acknowledgement before Alpha 2;
+- registry event outbox limits, ordering, deduplication, stale-event handling, and retry semantics before auto-deploy;
 - shared named-network declaration;
-- certificate lifecycle;
+- certificate issuance, renewal, and client trust against edge impersonation before public registry access;
+- concurrent-instance eligibility, multi-entrypoint checks, and bounded connection draining before web replacement in Alpha 5;
 - lifecycle states, component replacement order, persistent-format compatibility, backup, rollback or roll-forward, interruption recovery, and generated-Quadlet drift policy before any component update support;
 - release and orphan retention policies.

--- a/docs/v3/design.md
+++ b/docs/v3/design.md
@@ -1,7 +1,9 @@
 # Gordon v3 design
 
-Status: accepted design baseline; not yet implemented  
-Date: 2026-09-04  
+Status: accepted design baseline; not yet implemented
+
+Date: 2026-09-04
+
 Supersedes: the distributed implementation archived as `v3-deprecated`
 
 ## Purpose
@@ -216,11 +218,13 @@ The logical edge configuration has one main multiplexed listener:
 listen = ":443"
 ```
 
-This is a desired public address, not yet a claim that an unprivileged container can bind host port 443 directly. Alpha 1 requires a clean-host ingress ADR and proof of concept covering rootless privileged ports, source-IP preservation, fixed versus dynamic TCP/UDP publication, address-specific binds, firewall interaction, and edge restarts. Dedicated TCP/UDP listeners remain blocked until that mechanism is selected.
+This is a desired public address, not yet a claim that an unprivileged container can bind host port 443 directly. Alpha 1 requires a clean-host ingress ADR and proof of concept covering rootless privileged ports, source-address behavior, fixed versus dynamic TCP/UDP publication, address-specific binds, firewall interaction, and edge restarts. The proof must exercise the complete client-to-edge-to-backend path, not only direct Podman port publication. It must document the source addresses observed by edge and TCP/UDP backends, identify the `trusted_cidrs` enforcement point, and prove allow/deny behavior using the original client address there. A conventional TCP proxy does not preserve that address at the backend; workloads requiring it there remain blocked unless the selected mechanism proves preservation at that point. Dedicated TCP/UDP listeners remain blocked until that mechanism is selected.
 
 Edge terminates HTTP/HTTPS application traffic. Registry traffic is selected by SNI and forwarded as raw TCP. Registry terminates its own TLS, so edge never receives registry credentials or decrypted OCI payloads.
 
 Sharing edge introduces an accepted availability dependency: a failed or compromised edge can make registry unavailable, but must not compromise registry confidentiality.
+
+TLS passthrough alone does not establish that confidentiality guarantee. Before public registry access is enabled, a certificate-lifecycle ADR must define issuance, renewal, and client trust so a compromised edge cannot obtain a registry identity accepted by clients. In particular, evaluate registry-domain ACME HTTP-01 and TLS-ALPN-01 challenges against edge's control of public ports. Keeping registry's existing private key out of edge is necessary but insufficient. The trust mechanism remains undecided; no public registry implementation may assume that SNI routing enforces it.
 
 Runtime pulls Gordon-hosted images through a separate private registry endpoint that is reachable by the rootless Podman engine and is not routed through edge. Runtime uses pull-only credentials; control and edge receive no OCI push credentials. The exact private endpoint, TLS identity, and rootless reachability are part of the required host-ingress proof.
 
@@ -327,7 +331,9 @@ APP_ENV = "production"
 LOG_LEVEL = "info"
 ```
 
-There is no service-specific public environment block. Any value intended for only one service uses the secret mechanism, even when the value is not confidential.
+There is no service-specific public environment block. Any value intended for only one service uses the secret mechanism, even when the value is not confidential. This deliberately keeps two configuration paths: public app-wide values in the manifest and write-only service-owned values outside it. The manifest declares the required secret names, not a complete reproducible set of service values. Those values must be provisioned separately and are not restored by release rollback.
+
+A declared secret name must not collide with an app-wide public environment key; validation rejects the collision rather than silently choosing a value.
 
 Services declare their secret names:
 
@@ -370,7 +376,7 @@ target = "/var/lib/postgresql/data"
 
 The canonical identity includes app, service, and volume names. Host bind mounts and volumes shared between services are forbidden in app manifests.
 
-Releases reuse stable service volumes. Rollback never duplicates or deletes persistent data.
+Releases reuse stable service volumes. Rollback never duplicates or deletes persistent data and does not reverse database or filesystem migrations. An older image is not evidence that the current volume remains compatible. Automatic best-effort restoration must not restart an older volume-owning service after a replacement may have written its data; report the degraded state for operator recovery instead. An explicit rollback of such a service requires the operator to establish data compatibility outside Gordon.
 
 ### Networks
 
@@ -426,7 +432,9 @@ trusted_cidrs = ["100.64.0.0/10"]
 
 Route identity is `<app>/<route>`. Removing or changing a route never creates, stops, or deletes a service by itself.
 
-Apply validation canonicalizes DNS names to lowercase ASCII, rejects duplicate exact hosts, and initially rejects wildcard hosts. For dedicated routes, `(listen address, port, transport protocol)` is unique installation-wide. A route's protocol must match its target entrypoint. HTTP routes target `http` entrypoints and edge terminates public TLS; SNI passthrough targets `tcp` entrypoints and leaves TLS untouched. Registry's configured SNI is reserved and conflicts with no app route. Route and certificate conflicts fail during apply, before persistence.
+Apply validation canonicalizes DNS names to lowercase ASCII, rejects duplicate exact hosts, and initially rejects wildcard hosts. Dedicated listeners must not overlap installation-wide for the same transport protocol, including wildcard-versus-specific address binds and IPv4/IPv6 dual-stack conflicts. Installation listeners, including edge's shared HTTP/HTTPS ports, participate in this check. A route's protocol must match its target entrypoint. HTTP routes target `http` entrypoints and edge terminates public TLS; SNI passthrough targets `tcp` entrypoints and leaves TLS untouched. Registry's configured SNI is reserved and conflicts with no app route. Route and certificate conflicts fail during apply, before persistence.
+
+Control reserves route hosts and listener bindings across desired AppSpecs, active routes, and in-flight operations. Reservations belonging to the same app may overlap across those states, but a candidate configuration must remain internally conflict-free. Removing a route from desired state does not free its active reservation. It becomes available to another app only after no desired or in-flight reference remains and edge has acknowledged its withdrawal. Historical releases do not reserve routes indefinitely: deploy and rollback revalidate and acquire reservations before runtime mutation. Apply validation and reservation changes are one atomic control-side operation; they do not change edge or Podman.
 
 Registry passthrough is a system-generated route derived from registry configuration, not a fake app.
 
@@ -477,7 +485,8 @@ Complete-manifest updates intentionally use last-successful-write-wins semantics
 
 A release is immutable and contains:
 
-- one normalized AppSpec revision;
+- the immutable effective normalized AppSpec;
+- source AppSpec revision (the base active release's revision for service composition) and the source release identities;
 - exact OCI digests for all services;
 - the resolved service runtime definitions;
 - the route projection associated with that release.
@@ -486,7 +495,9 @@ A release is immutable and contains:
 
 `gordon deploy <app>` is the only operation that activates a new AppSpec revision. It resolves images, creates a release, performs the runtime change, and activates the release's routes after its required backends are available.
 
-`gordon deploy <app> --service <name>` never activates a pending AppSpec. It is valid only when desired and active AppSpec revisions match; it resolves the selected service's image from that active spec and creates a composed release changing only that service digest.
+`gordon deploy <app> --service <name>` never activates a pending AppSpec. It is valid only when desired and active source AppSpec revisions match and the desired normalized configuration equals the active release's effective configuration. Revision equality alone is insufficient after a synthetic rollback. It resolves the selected service's image selector from that effective configuration and creates a composed release changing only that service digest.
+
+Control serializes app mutations, including apply, deploy, rollback, secret mutation, restart, stop, remove, and purge. An operation captures its configuration and source release before effects; a concurrent request cannot change that operation's inputs. Global route reservations and edge snapshot publication also require installation-wide coordination so deployments of different apps cannot overwrite each other's routes. The persistence and edge-snapshot ADRs must define these atomicity boundaries before Alpha 2.
 
 Release activation follows persisted phases:
 
@@ -495,9 +506,9 @@ prepared -> mutating -> routes-published -> active
                          \-> failed
 ```
 
-Control persists the operation ID and phase before each external effect. It marks a release active only after runtime reports the intended service set and edge acknowledges the intended route generation. On restart, control observes runtime and edge before resuming or failing an operation; it never blindly replays a mutation. Recreate services are changed in a deterministic service-name order. If a later change fails, control keeps the former route generation, performs bounded best-effort restoration of already changed recreate services, and reports the exact mixed or restored actual state as degraded.
+Control persists the operation ID and phase before each external effect. It marks a release active only after runtime reports the intended service set and edge acknowledges the intended route generation. On restart, control observes runtime and edge before resuming or failing an operation; it never blindly replays a mutation. Recreate services are changed in a deterministic service-name order. If a later change fails, control keeps the former route generation, performs bounded best-effort restoration of already changed recreate services subject to the volume-safety restriction above, and reports the exact mixed or restored actual state as degraded.
 
-`push --deploy` and auto-deploy may update service digests only when the AppSpec revision is already active. If a newer AppSpec awaits deployment, the image push succeeds but deployment is refused until `gordon deploy <app>` activates the pending specification.
+`push --deploy` and auto-deploy use the same revision and effective-configuration checks as service-targeted deploy. If a newer AppSpec awaits deployment or a synthetic rollback has changed the effective configuration, the image push succeeds but deployment is refused until a full `gordon deploy <app>` activates the desired specification. They cannot implicitly reconcile that divergence.
 
 ### Auto-deploy
 
@@ -507,7 +518,9 @@ Registry emits a minimal durable event containing repository, tag, digest, times
 
 ### Rollback
 
-A full rollback creates a new release from a previous immutable release. A service rollback creates a synthetic release from the currently active AppSpec and route projection, replacing only the selected service's resolved service definition and digest with a previous successful version. App-wide environment, entrypoints, routes, networks, and all other services remain from the active AppSpec. The composition is rejected before mutation if the former service definition is incompatible with those current app-level fields.
+A full rollback creates a new release from a previous immutable release. A service rollback creates a synthetic release from the active release's effective configuration and route projection, replacing only the selected service's resolved service definition and digest with a previous successful version. App-wide environment, entrypoints, routes, network declarations, and all other services remain from the active release's effective AppSpec. Runtime reconciles actual network attachments from those declarations; observed Podman state is not a configuration source. The composition is rejected before mutation if the former service definition is incompatible with those retained fields.
+
+Rollback never rewrites desired configuration or historical releases. A service rollback creates a new release identity, retains the base active release's source AppSpec revision as provenance, and records the base and donor release identities plus the composed effective AppSpec. That retained revision does not claim that the effective configuration is unchanged. A full rollback retains the selected historical release's source AppSpec revision. Status exposes any divergence between desired and effective configuration; subsequent service-targeted deploy, push deploy, and auto-deploy follow the checks above.
 
 ```console
 gordon rollback shop
@@ -520,7 +533,7 @@ Gordon validates the composed release before mutation. Historical secret values 
 
 ## Deployment strategy
 
-Deployment strategy is not configurable.
+Deployment strategy is not configurable. The web replacement algorithm below remains gated on a focused rollout ADR before Alpha 5. That ADR must establish how Gordon knows concurrent instances are safe; HTTP routes and absence of volumes cannot prove this for an image that may also run migrations, schedulers, or workers. This design does not yet choose a concurrency-eligibility mechanism or add a user-selectable strategy.
 
 An eligible web service uses replacement without a transport-level outage when it:
 
@@ -536,20 +549,25 @@ start new container
 -> wait for Podman running
 -> verify that its HTTP entrypoint accepts TCP
 -> atomically switch edge routes
+-> drain existing requests/connections up to a bounded deadline
 -> stop old container
 ```
 
-V3 has no readiness configuration and does not consume OCI `HEALTHCHECK`. It does not promise application-level readiness.
+V3 has no readiness configuration and does not consume OCI `HEALTHCHECK`. It does not promise application-level readiness or uninterrupted connections beyond the drain deadline. The rollout ADR must define multi-entrypoint checks, the drain deadline, and treatment of long-lived connections such as WebSockets.
 
 Every stateful, worker, TCP, UDP, RCON, mixed-protocol, or volume-owning service uses recreate and may experience downtime.
 
 ## Lifecycle commands
 
+Control persists an app's execution intent (`running` or `stopped`) separately from desired configuration, the last active release, and observed containers. Apply does not change execution intent. A newly applied app is stopped. A full deploy of a stopped app changes durable intent to running only when its new release successfully activates. Its journaled in-flight operation may create resources and resume after interruption, but generic reboot reconciliation must not resurrect a retained prior release. On failure, intent remains stopped and operation recovery cleans up partial resources rather than treating them as an active app.
+
+`restart` uses the active release's effective configuration and pinned digests, with current secret values. It never resolves newer image tags or activates pending configuration. Restart, rollback, service-targeted deploy, push deploy, and auto-deploy refuse a stopped app; only a full `deploy` can request running state again. Queued events cannot undo `stop`.
+
 ```console
 gordon stop shop
 ```
 
-Removes active routes and containers while preserving manifest revisions, releases, secrets, and volumes. `gordon deploy shop` starts it again.
+Persists stopped intent before removing active routes and containers, while preserving manifest revisions, releases, secrets, and volumes. Interrupted stop resumes cleanup rather than resurrecting the app. `gordon deploy shop` starts it again.
 
 ```console
 gordon remove shop
@@ -575,6 +593,8 @@ Performs remove and deletes app-owned volumes and the tombstone after explicit c
 Edge persists only its last valid sanitized route snapshot and public certificates. It may start from that snapshot when control is unavailable. With no valid snapshot, it fails closed. Invalid or older snapshots never replace the active one.
 
 The general rule is that losing the control plane must not interrupt already active workloads or routes.
+
+Host reboot is distinct from a component restart. Before Alpha 2, the workload-recovery ADR must define how persisted execution intent and active releases restore running apps, keep stopped apps stopped, and recover interrupted operations. It must identify who starts workload containers and when edge's persisted backends become valid again. Do not assume component Quadlets or user-manager lingering alone restart applications. Reboot recovery may wait for the trusted core; pending AppSpecs and newly resolved tags must never replace the last active release implicitly.
 
 ## CLI surface
 
@@ -698,9 +718,12 @@ Alpha 1 accepts only a clean host or resumption of the same incomplete generatio
 
 - App manifest and globally unique name.
 - Configuration-only apply.
-- Explicit deploy.
-- One service, private app network, HTTP entrypoint, HTTP route.
-- End-to-end edge traffic.
+- Explicit deploy with digest-pinned images from an external registry and a minimal immutable release.
+- Persistence, reservation, edge-snapshot, and workload-recovery ADRs covering the first deploy, not deferred until registry support.
+- One service, private app network, separate per-app ingress network, HTTP entrypoint, HTTP route.
+- End-to-end edge traffic and negative network-access tests.
+- Durable execution intent, minimal stop, and interrupted-deploy/stop recovery.
+- Component restart and host reboot tests proving the active release is recovered without activating pending configuration.
 
 ### Alpha 3: multi-service security
 
@@ -709,13 +732,13 @@ Alpha 1 accepts only a clean host or resumption of the same incomplete generatio
 - Service-scoped write-only secrets.
 - Service-owned volumes.
 - Named private networks across apps.
-- Per-app ingress networks.
+- Multi-service ingress isolation and volume-safe failure recovery.
 
-### Alpha 4: registry and releases
+### Alpha 4: registry and rollback
 
+- Certificate-lifecycle ADR and proof against registry identity impersonation by a compromised edge.
 - Public authenticated OCI registry through raw SNI passthrough.
-- Digest-only runtime deployments.
-- Immutable releases.
+- Extend the existing digest-pinned release flow to Gordon-hosted images.
 - Push deploy and opt-in auto-deploy.
 - Durable registry outbox.
 - Full and service-level rollback.
@@ -723,9 +746,9 @@ Alpha 1 accepts only a clean host or resumption of the same incomplete generatio
 ### Alpha 5: routes and lifecycle
 
 - HTTP, TCP, and UDP routes.
-- Web-only replacement without transport outage.
-- Restart, stop, remove, and purge.
-- Component restart and failure-matrix tests.
+- Rollout ADR establishing concurrency-safe eligibility and bounded connection draining before web replacement is enabled.
+- Restart, remove, and purge; extend the existing stop/recovery flow to all supported protocols.
+- Complete multi-service and multi-protocol failure-matrix tests.
 - End-to-end security and recovery checks.
 
 Every commit on `v3-alpha` must remain buildable and testable. Every alpha stage must install on a clean host through the same installer and clearly report unsupported features.
@@ -734,11 +757,14 @@ Every commit on `v3-alpha` must remain buildable and testable. Every alpha stage
 
 The following details are intentionally left to focused implementation ADRs, provided they preserve this design:
 
-- exact on-disk formats for AppSpec, releases, and deployment status;
+- AppSpec/release persistence, effective configuration identity, execution intent, and app-operation serialization before Alpha 2;
+- route reservations and edge snapshot publication/acknowledgement under concurrent app operations before Alpha 2;
+- workload startup ownership and reboot/interruption recovery before Alpha 2;
 - exact HTTP DTOs and streaming format;
 - Unix-socket directory layout and Quadlet UID mappings;
 - named shared-network declaration syntax;
-- certificate storage and renewal mechanics inside edge and registry;
-- bounded event-outbox limits and retry schedule;
+- certificate issuance, storage, renewal, and client trust preventing registry impersonation by edge before public registry access;
+- bounded event-outbox limits, ordering, deduplication, stale-event handling, and retry schedule before auto-deploy;
+- concurrency-safe web replacement eligibility, multi-entrypoint checks, and bounded draining before Alpha 5;
 - release retention and garbage-collection defaults;
 - lifecycle states, component replacement order, persistent-format compatibility, backup, rollback or roll-forward, and interrupted-update recovery before any component update support.


### PR DESCRIPTION
## Summary

Clarify the accepted v3 design and ADR before workload implementation, without changing runtime code or the parallel development sandbox.

- Reserve routes/listeners across desired, active, and in-flight state; cover overlapping binds and concurrent app operations.
- Distinguish effective release configuration from revision provenance after partial rollback, and prevent implicit configuration changes through targeted/auto-deploy.
- Persist execution intent so stop survives restart, reboot, and queued push events; define restart against the active release and current secrets.
- Bring minimal immutable releases, digest pinning, ingress isolation, stop, and recovery checks into Alpha 2.
- Gate public registry access on certificate issuance/client-trust analysis and web replacement on a concurrency/draining ADR.
- Require ingress proofs across the complete edge-to-backend path and prevent unsafe automatic restoration of older volume-owning workloads.

## Product constraints preserved

Public environment remains **app-wide only**. Every service-specific value still uses write-only secrets, even when non-confidential. The docs now explain that manifests and rollback do not reproduce historical secret values, and reject public-environment/secret name collisions.

No registry trust mechanism, new rollout eligibility field, user-selectable deployment strategy, or component update mechanism is chosen here. Focused implementation ADRs remain required at their stated milestones.

## Validation

- `git diff --check`
- Signed commit verified with `git verify-commit`
- Senior architecture review: five must-fix clarifications addressed (source-address acceptance, rollback provenance, declarative networks, failed stopped-app deploy, ADR versus implementation proof); final focused verification found no remaining must-fix contradictions
- Balanced Markdown fences and existing relative file links
- All 15 TOML examples in `docs/v3/design.md` parsed with Python `tomllib`
- CodeRabbit CLI unavailable in this environment; no local CodeRabbit review performed
- No Go tests or VM execution: documentation-only change

## Scope

Draft PR targeting `v3-alpha`, not `main`. The sandbox branch and its work in progress are untouched.
