### PR TITLE
docs(v3): define transport-only ingress and UDP lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,13 +55,13 @@ Control, runtime, edge and registry are independent rootless containers, never o
 
 - `control` owns desired state, AppSpecs, app releases, routes, and secret metadata.
 - `runtime` alone receives the Podman socket; it owns workload mutation, actual state, volumes, and stored secret values.
-- `ingress` binds only control-authorized host listeners, transfers TCP descriptors to edge, and retains UDP sockets for bounded session relay. It owns no secrets, Podman access, routing/TLS decisions or firewall management.
-- `edge` owns handed-off TCP listeners, application TLS, routing and client policy. It receives a sanitized route projection and UDP payload/peer metadata, never host UDP descriptors.
+- `ingress` owns control-authorized host sockets and relays opaque TCP streams and UDP datagrams through private Unix transport, with kernel-observed identity and bounded resources. It owns no secrets, Podman access, HTTP/SNI/game parsing, routing/TLS decisions or firewall management.
+- `edge` owns application TLS, routing, backend connections and client policy. It receives a sanitized route projection and relayed traffic with trusted ingress metadata, never host-network descriptors.
 - `registry` owns OCI storage, registry TLS, and a bounded push-event outbox.
 
 Runtime's Podman socket grants authority over the entire rootless engine, including Gordon's containers. This is an accepted alpha risk, not a strong isolation claim.
 
-Ordinary control APIs use strict HTTP/JSON over role-specific Unix sockets. ADR-002 permits dedicated Unix IPC for TCP descriptor transfer and framed UDP sessions. Keep ingress administration separate from edge's data channel; edge cannot authorize new host binds or choose arbitrary UDP reply destinations. Do not introduce internal TCP APIs, gRPC, protobuf, generic RPC or bearer-token plumbing.
+Ordinary control APIs use strict HTTP/JSON over role-specific Unix sockets. ADR-002 permits dedicated Unix IPC for opaque TCP streams and framed UDP datagrams. Keep ingress administration separate from edge's data channel; edge cannot authorize new host binds, request outbound host connections or choose arbitrary UDP reply destinations. Do not introduce internal TCP APIs, gRPC, protobuf, generic RPC or bearer-token plumbing.
 
 The administrator owns firewalld/equivalent and privileged-port redirections. Gordon must not mutate firewall rules or host sysctls. App route listeners are not duplicated in an installation-level port catalogue.
 
@@ -91,13 +91,15 @@ app -> services -> runtime containers
 - `gordon apps apply --file ...` persists desired configuration only; it never mutates runtime.
 - `gordon deploy <app>` is the only operation that activates a pending AppSpec.
 - Runtime receives digest-pinned OCI references only.
-- Entrypoints describe service interfaces; routes are the only public exposure primitive. Reserve hosts and listeners across desired, active, and in-flight state, including during rollback. Activation requires runtime/edge/ingress readiness; withdrawal must account for edge acknowledgement and ingress listener/session ownership.
+- Entrypoints describe service interfaces; routes are the only public exposure primitive. Reserve hosts and listeners across desired, active, and in-flight state, including during rollback. Activation requires runtime/edge/ingress readiness. Edge acknowledges route withdrawal on shared listeners; dedicated/final shared-listener withdrawal also requires ingress socket/transport cleanup. Do not make opaque ingress identify HTTP/SNI routes.
 - Public environment is app-wide only. All service-specific values use write-only secrets, even when non-confidential; reject public-environment/secret name collisions.
 - Secrets are write-only and service-owned; rollback uses current values, not historical ones.
 - Releases record effective configuration and provenance. Service-targeted deploy and push/auto-deploy require matching desired/active source revisions and effective configuration, including after synthetic rollback.
 - Execution intent is durable and separate from releases. Stopped apps stay stopped after reboot and queued events; only successful full-deploy activation changes their durable intent to running. Interrupted deploy follows its journal, not generic resurrection of a prior release. Restart uses the active release and current secrets.
 - Volumes are named Podman volumes owned by one service; no host bind mounts or shared service volumes.
 - Each app has a private network; edge joins only generated ingress networks for routed services.
+- UDP uses recreate with interruption and bounded in-memory transport associations. Stop admission and invalidate affected per-listener epochs before backend replacement; reopen only after readiness with fresh epochs and reject stale replies, including across restart. No live session migration or session restoration after ingress/edge restart or reboot. Recover only authorized listeners/routes, with empty UDP sessions.
+- Ingress failure interrupts relayed TCP connections and loses UDP sessions. Do not promise transparent ingress restart.
 
 Do not restore v2 route-owned containers, implicit deploy-on-apply, mutable runtime tags, global secret sharing, or ad hoc route mutations.
 
@@ -122,7 +124,7 @@ Alpha 1 is blocked until ADRs and clean-host proofs establish:
 
 1. rootless ingress for `80/443`, dedicated TCP/UDP, source-IP observation at edge and backend across the full proxied path, CIDR enforcement, firewall behavior, edge restarts, and private runtime-to-registry pulls;
 2. Unix-socket paths, UID/GID mappings, ownership, modes, directory mounts, recreation, startup ordering, and SELinux/AppArmor behavior;
-3. host-ingress confinement, TCP handoff/withdrawal and interrupted-operation recovery; bounded bidirectional UDP sessions, source-metadata trust and restart behavior before UDP exposure. Request/response prototypes and manual replay are not production recovery proofs.
+3. host-ingress confinement, TCP relay/withdrawal and interrupted-operation recovery; source-metadata trust for both transports, bounded bidirectional UDP associations and disruptive recreate/restart behavior before UDP exposure. Request/response prototypes and manual replay are not production recovery proofs. The OS confinement mechanism remains undecided; no dedicated account or service-manager change is selected.
 
 Implement Alpha 1 incrementally after those proofs:
 

--- a/dev/v3/README.md
+++ b/dev/v3/README.md
@@ -4,7 +4,7 @@ A small Go wrapper around **libvirt + cloud-init + SSH**. It creates an Ubuntu 2
 
 Gordon v3 is not implemented yet. The example apps below run directly with rootless Podman; their success is **not** evidence that Gordon's edge, installer, routes, or security policy works.
 
-The selected ingress direction is documented in [ADR-002](../../docs/v3/adr-002-host-ingress.md): four rootless containers plus a confined host role, with live TCP socket handoff and bounded UDP relay. This wrapper does not install those roles. Host confinement, recovery and general UDP-session behavior remain proof gates; see the [consolidated design](../../docs/v3/design.md).
+The selected ingress direction is documented in [ADR-002](../../docs/v3/adr-002-host-ingress.md): four rootless containers plus a confined host role, with transport-only TCP/UDP relay and no host-network descriptors passed to edge. This wrapper does not install those roles. Host confinement, relay correctness and listener/route recovery remain proof gates; UDP sessions are disposable, not migrated or restored across restart; see the [consolidated design](../../docs/v3/design.md).
 
 ## Ubuntu dependency caveat: socket-activation experiments
 
@@ -32,8 +32,8 @@ original binary and restore it after stopping the experimental containers and
 networks; do not replace packages on a production host using this procedure.
 
 The sandbox does not apply this workaround automatically. The direct-Podman
-examples below do not use socket activation. ADR-002 uses live TCP handoff rather
-than startup socket activation, so this experimental workaround is not an
+examples below do not use socket activation. ADR-002 retains host sockets in
+ingress for TCP/UDP relay rather than startup activation, so this workaround is not an
 established prerequisite for the selected design. A fixed DNS helper alone does
 not satisfy the remaining Alpha 1 security/lifecycle requirements.
 

--- a/docs/v3/adr-001-v3-foundation.md
+++ b/docs/v3/adr-001-v3-foundation.md
@@ -12,7 +12,8 @@
 
 - Four rootless containers remain, plus a confined non-root host ingress role from the same executable. Systemd supervises five roles; ingress is not a component supervisor.
 - Distribution identity, generated-unit ownership, readiness and recovery cover the host service as well as the four Quadlets.
-- Ingress acquires authorized TCP listeners and transfers them to edge through dedicated Unix IPC. It retains host UDP sockets and relays bounded sessions; edge keeps TLS, routing and client policy.
+- Ingress retains all host sockets and provides opaque TCP relay and bounded UDP associations through dedicated Unix IPC. No host-network descriptors reach edge; edge keeps TLS, routing and client policy.
+- UDP uses recreate with interruption, no live session migration or durable session restoration. Ingress failure interrupts relayed TCP connections and loses UDP associations; authorized listeners/routes recover with new connections and empty sessions.
 - The administrator owns public firewall policy and privileged-port redirections. Gordon does not change firewall rules or host sysctls.
 - Control coordinates listener activation and withdrawal with ingress and edge. Apply/deploy, route reservations, stopped intent and immutable releases are unchanged; app ports are not duplicated in installation configuration.
 - The new public host process must prove OS-enforced isolation from secrets, Podman and control-private state. UDP sessions and crash recovery remain implementation gates, not completed prototype guarantees.
@@ -270,8 +271,9 @@ The decision is considered implemented only when the automated tests below
 **and all validation gates in [ADR-002](adr-002-host-ingress.md#evidence-and-remaining-gates)**
 pass. The original four-container checklist is not sufficient on its own:
 validation also covers the host ingress service's confinement, distribution
-identity/readiness, TCP descriptor authority and non-cooperative withdrawal,
-UDP peer/local-destination identity, and automatic failure/restart recovery.
+identity/readiness, TCP relay correctness and non-cooperative withdrawal,
+trusted peer/local-destination identity for both transports, and automatic
+listener/route recovery without restoring UDP sessions.
 
 1. Edge and registry cannot see the Podman socket or application-secret storage.
 2. Control cannot retrieve persisted secret values through its runtime API.

--- a/docs/v3/adr-002-host-ingress.md
+++ b/docs/v3/adr-002-host-ingress.md
@@ -1,233 +1,252 @@
-# ADR-002: Add a confined host ingress role for TCP handoff and UDP relay
+# ADR-002: Use a confined, transport-only host ingress for TCP and UDP
 
-- Status: Accepted direction; implementation and public use remain gated below
+- Status: Accepted direction, amended to replace TCP descriptor handoff; implementation and public use remain gated below
 - Date: 2026-09-05
 - Amends: [ADR-001](adr-001-v3-foundation.md), for ingress ownership, transport and component lifecycle
 - Related: [V3 design](design.md)
 
 ## Context
 
-The app manifest already declares TCP/UDP listen addresses. Apply persists
-configuration only; full deploy activates the configured release and routes.
-This decision does not change that contract or introduce a second app-port list
-in installation configuration.
+Rootless Podman remains responsible for four isolated containers and their
+private networks. On the tested named-bridge stack, ordinary port publication
+rewrites the client address before edge. Direct pasta networking preserves it
+but cannot be combined with those bridges through the tested configuration.
+Startup socket activation does not provide live listener changes. These are
+limitations of the tested paths, not general claims about rootless Podman.
 
-Rootless Podman remains responsible for containers and their private networks.
-On the tested named-bridge stack, ordinary port publication rewrites the client
-address before edge. Direct pasta networking preserves it but cannot be combined
-with those bridges through the tested Podman configuration. Native systemd
-socket activation delivers listeners at startup, not new listeners to an
-already-running edge. These are limitations of the tested paths, not a claim
-that rootless Podman is unsuitable or that future versions cannot improve them.
+The initial direction transferred host TCP listeners to edge and retained UDP
+sockets in ingress. Security validation invalidated the TCP assumption: a
+validated listening socket could be repurposed with `connect(AF_UNSPEC)` and
+used to reach host loopback from edge, despite network isolation, zero effective
+capabilities, no-new-privileges and the tested seccomp filter. A retained duplicate
+also kept the port bound after a false withdrawal acknowledgement. Previously,
+transferred UDP sockets had demonstrated unwanted host-network send authority.
 
-A host process can instead transfer TCP listeners to edge over Unix IPC. Passing
-host UDP sockets also works, but gives edge additional host-network authority:
-a prototype used a transferred UDP socket to reach host loopback, inaccessible
-through edge's ordinary container socket. Host UDP descriptors therefore must
-not be transferred to edge.
+The amendment therefore removes host-network descriptor transfer entirely.
+Ingress transports traffic; edge retains application intelligence. UDP deployment
+uses recreate with interruption, not live game-session migration. This decision
+does not change manifests, apply/deploy or introduce a second app-port catalogue.
 
 ## Decision
 
-### Keep four containers; add one narrowly scoped host role
+### Keep four containers and one transport-only host role
 
-Retain the independent rootless `control`, `runtime`, `edge` and `registry`
-containers. Add a logical **ingress** role running from the installed Gordon
-executable as a non-root host process. Its exact CLI spelling remains an
-implementation detail; it is not another binary or independently versioned
-artifact.
+Retain independent rootless `control`, `runtime`, `edge` and `registry` containers.
+Ingress runs as a confined, non-root host process from the same installed Gordon
+executable. It is not another binary or independently versioned artifact.
 
-The host installer generates four Quadlets and one ordinary `systemd --user`
-service for ingress. Systemd supervises all five roles. Ingress neither launches
-nor supervises components and cannot invoke arbitrary commands, Podman, systemd
-management operations, secret storage or desired-state mutation APIs.
+The host installer owns four Quadlets and an ordinary `systemd --user` ingress
+service under the current lifecycle baseline. Systemd supervises all five roles.
+Distribution identity, installation locking, journaling, generated-file checksums,
+readiness, lingering and same-generation recovery cover all five. Updates and
+component rollback remain deferred under ADR-001.
 
-All five roles must match the distribution identity. Installation locking,
-journaling, generated-file checksums, readiness, dependency checks, lingering
-and same-generation recovery cover the ingress service as well as the Quadlets.
-Updates and component rollback remain deferred under ADR-001.
+The exact OS confinement mechanism remains undecided and must be proven before
+public use. This amendment does not select a dedicated host account, change the
+service-manager ownership or authorize privileged ingress. If confinement needs
+such an installation change, decide and record it before implementing that change.
 
-### Leave the public firewall to the administrator
-
-The administrator installs/configures firewalld or an equivalent firewall,
-authorizes public traffic, and provisions any privileged-port redirections.
-For example, public TCP 443 may be redirected to a host listener on 8443. Gordon
-binds the configured local destination; it does not manage firewall rules,
-change host sysctls or silently elevate privileges. An unauthorized local bind
-fails with an actionable error.
-
-App routes remain the sole workload exposure declarations. Installation settings
-cover shared system listeners and host-level policy, not a duplicate catalogue
-of app ports. The precise representation of public-to-local address translation
-and its participation in listener-conflict validation must be settled before
-implementation; do not assume public 443 and local 8443 are the same reservation.
-That representation must derive or express the translation without introducing
-an installation-level catalogue of ports for each app.
-
-### Separate listener acquisition from application routing
+```text
+control -- authorize listener operations --> ingress
+                                              |
+client -- TCP/UDP --> ingress -- private Unix transport --> edge --> backend
+                     owns host sockets                    TLS and routing
+```
 
 | Role | Responsibility |
 | --- | --- |
-| control | Validate and reserve routes; authorize listener changes for a journaled operation and generation |
-| ingress | Bind authorized host listeners; hand off TCP; relay bounded UDP traffic |
-| edge | TLS, HTTP/TCP/UDP routing, backend selection, CIDR enforcement and connection/session lifecycle |
-| runtime | Workload and app-ingress networks; no new host-network or component-management authority |
-| registry | OCI operations and independent TLS identity, unchanged |
+| control | Validate/reserve routes; authorize listener operations for a journaled operation and generation |
+| ingress | Own host sockets; relay TCP bytes and UDP datagrams; attach kernel-observed identities; enforce transport resource bounds |
+| edge | Application TLS, HTTP/TCP/UDP routing, backend selection, CIDR policy and backend connections |
+| runtime | Workloads and app-ingress networks; no new host-network or component-management authority |
+| registry | OCI operations and independent registry TLS identity, unchanged |
 
-Control alone authorizes listener creation/removal through a dedicated private
-capability. Edge's data channel grants no permission to bind host addresses,
-change destinations arbitrarily or invoke ingress administration. Ingress
-receives a minimal listener projection, not complete manifests or app secrets.
+Ingress does not interpret HTTP, SNI, domains, certificates, app manifests or game
+protocols. It neither selects backends nor applies `trusted_cidrs`. It cannot read
+secrets, invoke Podman/systemd management, launch components or mutate desired
+state. It receives only the minimal authorized listener/transport generation
+projection. Transport limits are not application routing policy.
 
-Ordinary control APIs remain strict HTTP/JSON over Unix sockets. This ADR adds
-a narrowly scoped Unix IPC exception for descriptor transfer (`SCM_RIGHTS`) and
-framed UDP traffic. It does not introduce gRPC, internal TCP RPC, a generic
-message bus or a general-purpose forwarding API. Capability paths, peer checks,
-UID mappings, frame formats and versioning require the implementation proof.
+### Leave the public firewall to the administrator
 
-### TCP: transfer the listener, not the traffic
+The administrator owns firewall policy and privileged-port redirects, for example
+public TCP 443 to local 8443. Gordon binds the configured local destination; it
+never changes firewall rules or host sysctls, or silently elevates privileges.
+An unauthorized bind fails clearly.
 
-Ingress binds an authorized TCP listener and transfers it to the running edge.
-Once ownership is acknowledged, ingress closes its duplicate. Edge accepts the
-connections directly and performs TLS and routing. This avoids an additional TCP
-proxy hop and preserves the peer address supplied by the host network; it does
-not undo source rewriting already performed by external NAT/proxies.
+App routes remain the only workload exposure declarations. Public-to-local
+translation and reservation checks must distinguish the public and local address
+without duplicating app ports in installation configuration. The exact mapping
+syntax remains an implementation prerequisite.
 
-Track every descriptor through transfer, acknowledgement, rejection and timeout.
-The production protocol must handle lost acknowledgements, duplicate operations
-and either process crashing mid-transfer without leaking listeners or declaring
-an uninstalled generation active. Native startup activation is not a substitute
-for this live handoff protocol.
+### Separate administration from the transport capability
 
-Before accepting a descriptor, validate that it is a TCP stream socket in
-`LISTEN` state, with the authorized address family and local bind address/port
-for that operation and generation. Reject other socket types, connected sockets,
-wrong families/addresses and unexpected descriptors. Successful handoff is not
-proof that a host TCP descriptor is safe: negative tests must characterize and
-constrain the host-network operations a compromised edge can perform through
-it, including attempts to repurpose it for outbound connections. If the retained
-authority violates containment, the handoff design remains blocked.
+Control alone authorizes journaled listener operations: creation, activation,
+invalidation and removal, including rollback and recovery, using the operation's
+captured authorized release/applied state and generation. Administration uses a
+dedicated private capability; apply remains mutation-free. Recovery reconciles
+previously authorized applied state, not a new authorization from edge. Edge's
+data channel cannot authorize binds, choose arbitrary host-network destinations
+or invoke ingress administration.
 
-### UDP: retain the host socket and constrain replies
+Ordinary control APIs remain strict HTTP/JSON over role-specific Unix sockets.
+The data path uses dedicated Unix IPC for TCP streams and framed UDP datagrams,
+not internal TCP APIs, gRPC, generic RPC or a general forwarding service.
+**No host-network descriptors, listening or connected, are passed to edge.**
+The framing, capability paths, peer validation, UID mappings and versioning still
+require a focused protocol design and tests; no particular multiplexing scheme
+is selected here.
 
-Ingress retains each UDP socket. It records the kernel-observed client and local
-destination addresses for each datagram, including address family and IPv6 scope
-or receiving interface where needed. It forwards payload and this identity to
-edge via the private data channel. Edge uses that authenticated
-metadata for `trusted_cidrs`, then routes to the backend. This is not a claim
-that edge observes the original client through a local `ReadFrom` call.
+Both transports carry the kernel-observed client and local destination identity,
+with family/interface/scope where required, bound to their listener and transport
+generation. Edge trusts this identity only from the authenticated ingress
+capability, never from a client-supplied payload/header. Authentication here means
+validated capability ownership and peer identity, not new bearer-token plumbing.
+Edge uses that identity for `trusted_cidrs`. Neither transport undoes prior NAT;
+ordinary edge-to-backend proxying still exposes edge's address at the backend.
+Backend original-source requirements remain a separate gate.
 
-Ingress may send responses only to the original client associated with a live,
-ingress-owned session. Edge must not choose an arbitrary host-network destination
-or create a session without an incoming datagram. Session identifiers must be
-bound to the listener generation, peer, observed local destination and lifetime;
-stale or unknown identifiers must fail closed. Ingress selects the reply's local
-source address/interface from that kernel-derived tuple, not from edge input.
-Wildcard binds must retain the actual destination address rather than treating
-all local addresses as interchangeable. Test multi-address IPv4/IPv6 and scoped
-interfaces. Sender-controlled payload fields are never peer or local identity.
+### TCP: relay opaque streams, retain all host sockets
 
-Production UDP requires binary-transparent, bidirectional sessions, including
-multiple and unsolicited backend responses within a valid session. Bound frame
-sizes, queued bytes, sessions, idle lifetimes, response amplification and work
-per client. Define backpressure and malformed-peer behavior before implementation.
-The successful one-request/one-response prototype is not a game-server proxy.
+Ingress owns each authorized listener and each accepted host connection. It relays
+bytes bidirectionally between that connection and edge's private Unix transport.
+Replies go only to that existing client connection; edge cannot request outbound
+host connections. TLS remains opaque to ingress, and edge retains TLS termination
+or registry SNI passthrough as appropriate.
 
-### Preserve apply/deploy and reservation semantics
+The relay must preserve byte order and half-close semantics, bound buffers and
+connections, apply backpressure, and clean up on cancellation or peer failure.
+Ingress can close its listener without relying on edge to relinquish a descriptor.
+Stopping acceptance is distinct from draining or terminating existing connections;
+withdrawal must account for both with bounded cleanup. This is transport plumbing,
+not an HTTP proxy or a second routing engine.
 
-Apply does not bind sockets or change ingress. Deploy activates only its captured,
-validated release configuration; it does not invent routes. Listener handoff and
-UDP relay readiness participate in the operation journal and activation checks.
+### UDP: bounded associations, disruptive lifecycle
 
-Control retains reservations across desired, active and in-flight state. Route
-removal requires edge withdrawal acknowledgement and ingress confirmation that
-host ownership/session state has been released as appropriate. Historical
-releases do not retain bindings; rollback reacquires and validates them. No
-restart or recovery may bind a merely pending AppSpec or revive a stopped app.
+Ingress retains each UDP socket. A datagram from a client can create a temporary
+association of listener, generation, kernel-observed peer and local destination.
+Ingress forwards payload and identity to edge; edge chooses the backend.
+Edge may return datagrams only for a live ingress-owned association. It cannot
+invent sessions or select arbitrary host destinations. Replies use that
+association's original peer and observed local source address/interface.
 
-TCP withdrawal acknowledgements describe cooperative operation only. Once ingress
-has closed its copy, it cannot revoke edge's descriptor or certify that edge
-closed every copy merely by receiving an ACK. Timeout, refusal or uncertain
-closure fails the operation and retains the reservation. Non-cooperative recovery
-requires stopping the descriptor-holding processes through the existing,
-operator-controlled installation lifecycle and verifying release before
-reassignment; an edge restart must not restore the withdrawn listener. This does
-not authorize runtime or ingress to restart edge during workload reconciliation.
-Tests must cover retained/duplicated descriptors and failed withdrawal.
+Preserve datagram boundaries and binary payloads. Support multiple and unsolicited
+backend replies within a live association, not just one request/one response.
+Bound datagram/frame sizes, queued bytes, sessions, idle lifetimes, response
+amplification and work per client; define overload and malformed-peer handling.
+These limits remain necessary even when deployments may interrupt players.
 
-Recovery must reconcile authorized applied state with observed ingress and edge
-state, not trust edge to request arbitrary new binds. Minimal persisted listener
-metadata and crash reconciliation require a focused protocol/persistence design;
-the prototype's manual replay is not automatic recovery.
+UDP services use recreate. Each affected listener has a non-reused association
+epoch, independent of unrelated listeners and the global edge route generation.
+The journaled operation first stops new association admission and forwarding for
+that listener, then invalidates its old epoch and associations in ingress and
+edge before replacing/stopping the backend. Admission stays closed during the
+replacement. Only after the replacement backend and route are ready may control
+authorize admission under a fresh epoch. Late backend/IPC responses from old epochs
+remain rejected, including across restart; the protocol must prevent epoch reuse.
+Selecting the restart-safe epoch allocation mechanism is a prerequisite of the
+focused IPC/persistence design, not an invitation to persist UDP sessions. Its
+tests must restart processes and inject an old response to verify non-reuse and
+rejection. This amendment does not select a storage format or allocation algorithm.
+Unrelated apps' associations are not invalidated by that deployment.
+
+There is no session migration, transparent cutover, persisted UDP session state
+or session restoration after ingress/edge restart or host reboot. Clients recover
+according to their own protocol. A fresh client datagram may have been delayed
+in the network; ingress does not parse game protocols to determine its age.
+Listener/route recovery remains required, but always starts with empty sessions.
+
+### Preserve apply/deploy, reservations and execution intent
+
+Apply persists desired configuration only. Deploy activates only its captured,
+validated release after runtime, edge route generation and ingress relay readiness
+are confirmed. Control journals operations and retains reservations across desired,
+active and in-flight state; a desired removal alone does not free an active port.
+
+For a route on a shared HTTP/SNI listener, edge acknowledges its route-generation
+withdrawal and owns route-level draining/rejection on existing streams. Ingress
+cannot identify application routes in opaque TCP and must not close unrelated
+streams or the shared listener to certify that route's withdrawal. The host/route
+reservation may be released after that acknowledgement and removal of all desired
+and in-flight references; the shared listener reservation remains.
+
+Withdrawal of a dedicated listener or the final authorization for a shared
+listener additionally requires ingress confirmation of listener closure and
+bounded cleanup of its accepted connections/UDP associations. A false ACK from
+edge cannot retain a host descriptor, but cannot prove ingress cleanup either.
+Timeout, refusal or uncertain cleanup fails withdrawal and retains the applicable
+reservation. Reassignment requires verified release; uncertain ownership may
+require operator-controlled installation recovery. This grants neither runtime
+nor ingress new component-restart authority.
+
+Recovery reconciles authorized applied state with observed ingress/edge state,
+not arbitrary bind requests from edge. It must not activate a pending AppSpec or
+revive a stopped app. Historical releases do not reserve listeners indefinitely;
+rollback reacquires and validates reservations before mutation. Minimal persisted
+listener metadata and interrupted-operation reconciliation remain protocol and
+persistence requirements, separate from disposable connection/session state.
 
 ## Security and availability consequences
 
-Ingress is Internet-facing through UDP and is therefore part of the public
-attack surface. It must not become an unconfined process under the trusted
-Podman account: that would recreate the v2 secret/socket exposure risk. Non-root
-execution and `NoNewPrivileges` alone do not prevent same-account file access.
+Ingress is now on the TCP and UDP data paths. The extra TCP relay adds I/O, CPU
+and buffering and must be benchmarked; no negligible-overhead claim is made.
+Its failure interrupts relayed TCP connections, including registry passthrough,
+and loses UDP sessions. This availability trade-off is accepted instead of giving
+edge host-network descriptors. No zero-downtime ingress restart is promised.
 
-Before public use, prove an OS-enforced service sandbox denies application
-secrets, control-private state, Podman sockets/storage, unauthorized filesystem
-writes and escapes through `/proc`, other processes or inherited descriptors.
-Keep allowed capability directories separate. Exact systemd/LSM isolation must
-be tested on the reference host; if insufficient, stop and revisit the execution
-boundary rather than accepting this risk implicitly. Do not disable AppArmor,
-SELinux or seccomp to make the service work.
+Ingress remains a public attack surface even without application parsing. Non-root
+and `NoNewPrivileges` alone do not isolate it from the Podman account's files and
+processes. Tested user-service filesystem properties left forbidden canary access
+possible; stronger tested profiles failed before execution with capability errors
+and AppArmor denials. These profiles are not an acceptable fallback, and their
+failure does not prove that no OS confinement solution exists.
+
+Before public use, prove denial of secrets, Podman sockets/storage, control-private
+state, unauthorized writes and process/filesystem escape paths, while required
+binds and private transport remain usable. Do not weaken AppArmor/SELinux, seccomp
+or container isolation to obtain a working prototype. The relay removes the
+observed descriptor capability from edge; it does not establish ingress confinement.
 
 | Failure | Required behavior |
 | --- | --- |
-| control unavailable | Already active TCP/UDP traffic continues; listener mutations fail clearly |
-| ingress unavailable | Handed-off TCP listeners/connections can continue; UDP is unavailable; new binds fail |
-| edge unavailable | Application traffic is unavailable; fail closed; recover only authorized applied state |
-| ingress restart | Reconcile TCP ownership and restore authorized UDP listeners without restarting healthy edge |
-| edge restart/reboot | Reconcile listeners, sessions and routes without activating pending configuration or stopped apps |
+| control unavailable | Already active TCP/UDP traffic continues; mutations fail clearly |
+| ingress unavailable | Relayed TCP connections terminate; UDP sessions are lost; public traffic and new binds are unavailable |
+| edge unavailable | Public traffic fails closed; affected TCP relays close and UDP associations are invalidated |
+| ingress restart | Restore only authorized listeners and relay readiness, with new connections/empty UDP sessions; do not restart healthy edge |
+| edge restart/reboot | Recover authorized listeners/routes with new connections/empty UDP sessions; never activate pending configuration or stopped apps |
 
-UDP now depends on ingress throughput and availability as well as edge. No
-zero-downtime UDP promise is added. Backend original-source preservation remains
-unproven: ordinary proxying exposes edge's address to the backend. Registry TLS
-passthrough and the separate certificate-impersonation gate remain unchanged.
+Registry TLS stays independent of edge and ingress. The certificate-impersonation
+proof gate is unchanged. No zero-downtime UDP deployment or game compatibility
+claim follows from this transport design.
 
 ## Evidence and remaining gates
 
-Two bounded disposable-VM prototypes supplied different evidence:
+The descriptor experiments justify rejecting TCP/UDP host-socket handoff, not a
+claim that the replacement relay is implemented or secure. Earlier UDP
+request/response and manual replay tests do not establish general bidirectional
+sessions or automatic recovery. Product reservation persistence/recovery has not
+been verified by those experiments.
 
-- The initial TCP-and-UDP descriptor-transfer prototype demonstrated live changes,
-  TCP/UDP source delivery, traffic continuity after ingress termination, listener
-  release after edge termination and explicit replay. Its UDP handoff was rejected
-  because it granted edge host-loopback send authority.
-- The selected-direction prototype kept UDP on the host and transferred only TCP.
-  It demonstrated live changes, UDP peer metadata, TCP continuity but UDP loss
-  after ingress termination, and manual UDP resumption. A forged UDP reply
-  destination was ignored while the real client received the response. Edge
-  termination/recovery with this revised UDP relay was not tested.
-
-Neither prototype demonstrated automatic durable recovery or complete TCP
-capability confinement. The UDP tests were textual request/response exchanges,
-not general bidirectional sessions.
-
-These results support the direction, not production readiness. Alpha 1 remains
-blocked on confined host-role execution, capability permissions, TCP descriptor
-validation and negative authority tests, non-cooperative withdrawal, UDP local
-address/session identity, interrupted-transfer recovery,
-automatic restart/reboot behavior, IPv4/IPv6 and address conflicts, firewall
-coexistence, full-path CIDR allow/deny, and private runtime-to-registry access.
-General UDP sessions, binary fidelity, limits and performance must be proven
-before UDP exposure is enabled. The observed Podman/pasta AppArmor cleanup
-failure is a separate platform issue, not solved by this design.
-
-**Recommendation:** keep the implementation narrow: TCP descriptor handoff plus
-UDP session relay, no host firewall management, no generic supervisor, and no
-routing/TLS logic duplicated outside edge. Build and verify these boundaries
-before implementing workload features on top of them.
+Proceed with a narrow transport implementation and focused checks, not workload
+features built on an assumed boundary. Alpha 1 completion and public use still
+require host confinement, capability permissions, TCP relay correctness and
+resource bounds, authenticated source identity, dynamic listener withdrawal,
+non-cooperative peer handling, interrupted-operation and restart/reboot recovery,
+IPv4/IPv6/address conflicts, firewall coexistence, full-path CIDR allow/deny and
+private runtime-to-registry access. UDP exposure additionally requires binary
+fidelity, bidirectional associations, stale-generation rejection, disruptive
+recreate/restart tests and measured limits/performance. Live UDP session migration
+and restoration are explicitly not gates or planned alpha features.
 
 ## Alternatives not selected
 
 - Ordinary rootless bridge publication alone: failed the tested source-address requirement.
 - Startup socket activation alone: does not provide live listener changes.
-- Transfer host UDP sockets to edge: grants unwanted host-network send authority.
-- General TCP/UDP host proxy: adds a TCP data hop and source-metadata protocol unnecessarily.
-- Privileged veth/DNAT integration: promising transport proof, but privileged lifecycle ownership is unresolved.
-- Move edge to host networking: violates the retained container isolation contract.
+- Host TCP/UDP descriptor transfer: grants unwanted host-network authority; receipt validation is insufficient.
+- Application-aware host proxy: duplicates edge's TLS/routing responsibility; ingress is opaque transport only.
+- Live UDP session migration or durable session recovery: unnecessary for the accepted recreate lifecycle.
+- Privileged veth/DNAT integration: privileged lifecycle ownership remains unresolved.
+- Edge with host networking: violates the retained container isolation contract.
 
 ## Related
 

--- a/docs/v3/design.md
+++ b/docs/v3/design.md
@@ -58,7 +58,7 @@ Gordon runs four independent rootless containers, outside a shared Podman pod, p
 Internet -> administrator-managed firewall/redirects
    |
    v
-host ingress -- TCP listener handoff / bounded UDP relay --> edge
+host ingress -- opaque TCP streams / bounded UDP datagrams --> edge
                                                             |
                                                apps / registry TLS passthrough
 
@@ -81,7 +81,7 @@ Only `runtime` receives the rootless Podman socket. Gordon components are separa
 
 All four containers initially run under one trusted host account and one rootless Podman engine. Container UIDs are not independent host security principals. A compromise of that host account defeats every component boundary. Runtime has full authority over every container in that engine, including Gordon's own containers; runtime compromise therefore defeats the component boundaries as well. A future stronger design may place workloads and Gordon components in separate rootless engines, but that is not part of the accepted alpha baseline.
 
-The host ingress process is also Internet-facing, through UDP. It must have an OS-enforced sandbox excluding secrets, control-private state, the Podman socket/storage and same-account process/filesystem escape paths. Running it unconfined under the Podman account would defeat the primary containment goal; non-root and `NoNewPrivileges` alone are insufficient. Public use remains blocked until this boundary is proven on the reference host (ADR-002).
+The transport-only host ingress process is Internet-facing through TCP and UDP. It must have an OS-enforced sandbox excluding secrets, control-private state, the Podman socket/storage and same-account process/filesystem escape paths. Running it unconfined under the Podman account would defeat the primary containment goal; non-root and `NoNewPrivileges` alone are insufficient. Public use remains blocked until this boundary is proven on the reference host (ADR-002).
 
 ### Compromise containment
 
@@ -98,7 +98,7 @@ It must not be able to:
 - mutate desired state;
 - invoke runtime operations;
 - read registry credentials or traffic carried through TLS passthrough;
-- obtain host UDP descriptors or direct ingress to arbitrary host-network destinations.
+- obtain any host-network descriptors or direct ingress to arbitrary host-network destinations.
 
 A compromised `registry` controls its OCI storage and may emit malformed or forged push events. It has no general runtime or configuration API. When auto-deploy is enabled, however, registry has bounded authority to trigger a release for an already configured repository-and-tag mapping. Control validates and deduplicates events, maps repositories to configured services, checks auto-deploy policy, and selects the resulting release. Without signature or attestation verification rooted outside registry, registry compromise can supply arbitrary content to those opted-in services; this is an accepted risk for alpha.
 
@@ -153,8 +153,8 @@ This lifecycle applies only to Gordon's five managed roles. Application containe
 | --- | --- | --- |
 | control | App manifests, AppSpec history, releases, route definitions, deployment status, secret metadata | Podman socket, OCI blobs, stored secret values |
 | runtime | Podman operations, actual state, workload networks, volumes, stored secret values | Public listeners, desired app manifests, OCI registry storage |
-| ingress (host) | Authorized host binds, TCP descriptor handoff, bounded UDP sessions and relay | Firewall policy, TLS/routing decisions, app secrets, Podman, component supervision |
-| edge | Handed-off TCP listeners, HTTP/TCP/UDP routing, client policy, active sanitized route snapshot, public app certificates | Host UDP descriptors, app secrets, Podman socket, complete manifests, registry credentials |
+| ingress (host) | Authorized host sockets, opaque TCP relay, bounded UDP associations, kernel-observed source metadata and transport limits | Firewall policy, HTTP/SNI/game parsing, TLS/routing decisions, app secrets, Podman, component supervision |
+| edge | Relayed TCP streams/UDP datagrams, HTTP/TCP/UDP routing, client policy, active sanitized route snapshot, public app certificates | Host-network descriptors, app secrets, Podman socket, complete manifests, registry credentials |
 | registry | OCI blobs, manifests, tags, registry TLS identity, durable push-event outbox | App secrets, Podman socket, deployment decisions |
 
 The components do not share data volumes. Explicit host-mounted Unix-socket directories are communication capabilities, not shared data stores. Ingress administration is accessible only to control, separately from the edge data capability; edge cannot request new host binds or choose arbitrary UDP destinations.
@@ -165,7 +165,7 @@ Gordon component containers, networks, volumes, and Quadlet-managed resources us
 
 ### Transport
 
-Ordinary internal control APIs use HTTP with strict JSON DTOs over private Unix sockets. ADR-002 adds a narrow Unix IPC transport for live TCP descriptor transfer (`SCM_RIGHTS`) and framed UDP sessions between ingress and edge. Its format, peer validation and recovery protocol remain implementation gates; it is not generic RPC. Gordon does not use gRPC or protobuf internally in v3.
+Ordinary internal control APIs use HTTP with strict JSON DTOs over private Unix sockets. ADR-002 adds a narrow Unix IPC transport for opaque TCP streams and framed UDP datagrams between ingress and edge. No host-network descriptors, listening or connected, are passed to edge. Its format, peer validation and recovery protocol remain implementation gates; it is not generic RPC. Gordon does not use gRPC or protobuf internally in v3.
 
 Streams use NDJSON or server-sent events only where required, such as logs or edge snapshot updates.
 
@@ -233,11 +233,15 @@ listen = ":443"
 
 This is a logical public address, not a requirement for an unprivileged process to bind host 443 directly. The administrator configures firewalld or equivalent, including public access and any redirect such as 443 to 8443. Gordon binds the configured local destination; it does not change firewall rules or host sysctls. Public-to-local mapping syntax and reservation checks must distinguish both addresses before implementation, without introducing an installation-level catalogue of app ports.
 
-[ADR-002](adr-002-host-ingress.md) selects a confined host ingress role. Control authorizes listener changes from the deploying release, never from apply alone. Ingress transfers TCP listeners to the already-running edge and closes its copies after acknowledged handoff. It retains UDP sockets and relays datagrams through bounded, private sessions; replies can target only the original client of an ingress-owned session. Host UDP sockets are never passed to edge. Edge keeps TLS, routing, backend selection, CIDR policy and connection/session handling.
+[ADR-002](adr-002-host-ingress.md) selects a confined, transport-only host ingress role. Control authorizes journaled listener creation, activation, invalidation and removal, including rollback and recovery, from captured authorized release/applied state and generation. Apply never mutates ingress; recovery reconciles previously authorized applied state rather than accepting new bind authority from edge. Ingress retains all host sockets and relays opaque TCP streams and UDP datagrams to edge through private Unix IPC. TCP replies go only to the accepted client connection; UDP replies go only to the original client of a live ingress-owned association. Edge cannot request outbound host connections or arbitrary UDP destinations. Ingress neither parses HTTP/SNI/game protocols nor selects backends; edge keeps TLS, routing and CIDR policy.
 
-TCP handoff requires descriptor type, `LISTEN` state, family and authorized bind-address validation, plus negative tests of residual host-network authority. TCP peer identity comes from the handed-off socket; UDP identity comes from authenticated ingress metadata, not client payloads. Each UDP session includes the kernel-observed local destination and family/interface/scope where needed, so ingress can choose the correct reply source for wildcard and multi-address binds. Both require full-path allow/deny tests. Neither mechanism reverses prior source NAT, and ordinary edge-to-backend proxying still exposes edge's address at the backend. Backend original-source requirements remain gated.
+Both transports carry authenticated ingress metadata derived from the kernel-observed client and local destination, including family/interface/scope where needed. Client payloads or headers cannot override this identity. UDP reply source selection uses the observed local destination, including wildcard and multi-address binds. Both require full-path allow/deny tests. Neither reverses prior source NAT, and ordinary edge-to-backend proxying still exposes edge's address at the backend. Backend original-source requirements remain gated.
 
-Alpha 1 still requires clean-host proofs for host-process confinement, dynamic listener ownership and withdrawal, interrupted handoff, restart/reboot recovery, address-specific and dual-stack conflicts, firewall coexistence and ingress-network isolation. General bidirectional UDP sessions, binary fidelity, limits and performance must pass before UDP exposure. A request/response prototype is not evidence of game-server compatibility.
+TCP relay requires ordered, binary-transparent delivery, half-close semantics, bounded buffers/connections, backpressure and cleanup. The extra relay costs I/O, CPU and memory; performance must be measured. Ingress failure interrupts TCP connections, including registry passthrough, and loses UDP associations. No transparent ingress restart is promised. This replaces TCP listener handoff because a validated host listener could be repurposed by edge for outbound host-network access.
+
+UDP uses bounded, in-memory associations of listener/epoch, client and local destination. It preserves datagram boundaries and supports multiple/unsolicited backend replies within a live association. UDP deployment uses recreate: stop admission and forwarding for each affected listener, invalidate its old epoch and associations in ingress and edge before backend replacement, keep admission closed until replacement route readiness, then authorize admission under a fresh epoch. Epochs are per listener, not the global edge route generation, and must not be reused even across restart; late backend/IPC responses from old epochs remain rejected. Unrelated apps' sessions are not reset. No live session migration, durable session storage or session restoration after ingress/edge restart or reboot is required. Delayed client datagrams cannot be distinguished from new ones without application knowledge; game-protocol recovery belongs to clients and servers.
+
+Alpha 1 completion still requires clean-host proofs for host-process confinement, capability/source-metadata trust, TCP relay correctness and limits, dynamic listener withdrawal, interrupted operations, restart/reboot recovery, address-specific and dual-stack conflicts, firewall coexistence and ingress-network isolation. Bidirectional UDP associations, binary fidelity, expiry/resource bounds, stale-generation rejection and disruptive recreate/restart behavior must pass before UDP exposure. Listener/route recovery remains required with empty UDP sessions. The OS confinement mechanism remains undecided; this amendment selects neither a dedicated host account nor a service-manager change, and does not relax containment to accommodate the failed user-service profiles.
 
 Edge terminates HTTP/HTTPS application traffic. Registry traffic is selected by SNI and forwarded as raw TCP. Registry terminates its own TLS, so edge never receives registry credentials or decrypted OCI payloads.
 
@@ -453,9 +457,9 @@ Route identity is `<app>/<route>`. Removing or changing a route never creates, s
 
 Apply validation canonicalizes DNS names to lowercase ASCII, rejects duplicate exact hosts, and initially rejects wildcard hosts. Dedicated listeners must not overlap installation-wide for the same transport protocol, including wildcard-versus-specific address binds and IPv4/IPv6 dual-stack conflicts. Installation listeners, including edge's shared HTTP/HTTPS ports, participate in this check. A route's protocol must match its target entrypoint. HTTP routes target `http` entrypoints and edge terminates public TLS; SNI passthrough targets `tcp` entrypoints and leaves TLS untouched. Registry's configured SNI is reserved and conflicts with no app route. Route and certificate conflicts fail during apply, before persistence.
 
-Control reserves route hosts and listener bindings across desired AppSpecs, active routes, and in-flight operations. Reservations belonging to the same app may overlap across those states, but a candidate configuration must remain internally conflict-free. Removing a route from desired state does not free its active reservation. It becomes available to another app only after no desired or in-flight reference remains, edge has acknowledged withdrawal, and ingress has confirmed release of the relevant host listener/session ownership.
+Control reserves route hosts and listener bindings across desired AppSpecs, active routes, and in-flight operations. Reservations belonging to the same app may overlap across those states, but a candidate configuration must remain internally conflict-free. Removing a route from desired state does not free its active reservation. A host/route reservation on a shared HTTP/SNI listener becomes available after no desired or in-flight reference remains and edge acknowledges its route-generation withdrawal, including route-level draining/rejection on existing streams. Ingress cannot attribute opaque shared streams to application routes and must not close unrelated traffic; the shared listener reservation remains while other authorized routes need it.
 
-TCP handoff gives ingress no remote revocation power over edge's copy: an ACK describes cooperative withdrawal, not proof against retained descriptors. Timeout, refusal or uncertain closure fails withdrawal and retains the reservation. Reassignment then requires operator-controlled installation recovery to stop descriptor holders and verify release, without restoring the withdrawn listener or granting runtime/ingress new restart authority.
+Withdrawal of a dedicated listener or the final authorization for a shared listener additionally requires ingress confirmation of listener closure and bounded cleanup of accepted connections/UDP associations. Ingress owns all host sockets; edge has no host descriptors to retain. Stopping acceptance is distinct from draining/termination, and an edge ACK alone does not prove ingress cleanup. Timeout, refusal or uncertain release fails withdrawal and retains the applicable reservation. Reassignment requires verified release, with operator-controlled installation recovery if ownership remains uncertain, without restoring the withdrawn listener or granting runtime/ingress new restart authority.
 
 Historical releases do not reserve routes indefinitely: deploy and rollback revalidate and acquire reservations before runtime mutation. Apply validation and reservation changes are one atomic control-side operation; they do not change edge or Podman.
 
@@ -529,7 +533,7 @@ prepared -> mutating -> routes-published -> active
                          \-> failed
 ```
 
-Control persists the operation ID and phase before each external effect. It marks a release active only after runtime reports the intended service set, edge acknowledges the intended route generation, and ingress confirms the required listener handoffs or UDP relay readiness. On restart, control observes runtime, edge and ingress before resuming or failing an operation; it never blindly replays a mutation. Recreate services are changed in a deterministic service-name order. If a later change fails, control keeps the former route generation, performs bounded best-effort restoration of already changed recreate services subject to the volume-safety restriction above, and reports the exact mixed or restored actual state as degraded.
+Control persists the operation ID and phase before each external effect. It marks a release active only after runtime reports the intended service set, edge acknowledges the intended route generation, and ingress confirms the required listener and TCP/UDP relay readiness. On restart, control observes runtime, edge and ingress before resuming or failing an operation; it never blindly replays a mutation. Recreate services are changed in a deterministic service-name order. If a later change fails, control keeps the former route generation, performs bounded best-effort restoration of already changed recreate services subject to the volume-safety restriction above, and reports the exact mixed or restored actual state as degraded.
 
 `push --deploy` and auto-deploy use the same revision and effective-configuration checks as service-targeted deploy. If a newer AppSpec awaits deployment or a synthetic rollback has changed the effective configuration, the image push succeeds but deployment is refused until a full `gordon deploy <app>` activates the desired specification. They cannot implicitly reconcile that divergence.
 
@@ -610,7 +614,7 @@ Performs remove and deletes app-owned volumes and the tombstone after explicit c
 | --- | --- |
 | control unavailable | Existing workloads and routes continue. Administration and mutations fail. Registry queues push events durably. |
 | runtime unavailable | Existing Podman containers continue. Edge and registry continue. Runtime mutations fail clearly. |
-| ingress unavailable | Handed-off TCP traffic can continue. UDP and new host binds are unavailable. Healthy edge is not restarted merely to recover ingress. |
+| ingress unavailable | Relayed TCP connections terminate, UDP associations are lost, and public traffic/registry passthrough and new host binds are unavailable. Healthy edge is not restarted merely to recover ingress. |
 | edge unavailable | Workloads and administration continue. Public app traffic and registry passthrough are unavailable. |
 | registry unavailable | Existing apps and routes continue. OCI push/pull fail. Cached digest-pinned images may still be deployable. |
 
@@ -735,7 +739,7 @@ Alpha 1 accepts only a clean host or resumption of the same incomplete generatio
 - Four role-specific serve modes from that image.
 - A locked, journaled, idempotent host installer limited to fresh install and same-generation recovery.
 - Atomic Quadlet and ingress-service generation with an installation target managed by the host binary.
-- Live TCP handoff, bounded UDP relay, effective withdrawal and automatic ingress/edge recovery tests; no firewall mutation.
+- Opaque TCP relay, bounded UDP associations, effective withdrawal and automatic listener/route recovery tests with new connections and empty UDP sessions; no firewall mutation or live UDP session migration.
 - Identity, readiness, lingering, partial-failure, and clean Ubuntu 26.04 bootstrap tests.
 - Private Unix sockets and SSH administration.
 - Socket recreation, startup-order, ownership, mode, mount, and SELinux tests.

--- a/docs/v3/multi-host-evolution.md
+++ b/docs/v3/multi-host-evolution.md
@@ -31,7 +31,7 @@ critical review before implementation.
 | Releases and operations | Releases capture immutable effective configuration and digests; operations journal effects and observed results. | Keep release identity separate from container identity and operation outcome. A future shared release could have different deployment results on different hosts. |
 | Control and runtime | Control owns desired state; runtime owns Podman and observed local resources. | Keep Podman IDs, local paths and transport mechanics at their owning boundary, not in logical app identity. |
 | Routing | Routes target stable entrypoints; edge consumes a sanitized projection. | Keep logical routing separate from resolving live backend addresses. Do not make a container IP the stable route identity. |
-| Host ingress | Ingress binds local sockets and hands TCP descriptors to its local edge. | Keep this local. `SCM_RIGHTS` is not a cross-host transport; an upstream load balancer would not need to change that. |
+| Host ingress | Ingress owns host sockets and relays opaque TCP/UDP traffic to its local edge over Unix IPC. | Keep this transport local; an upstream load balancer does not require ingress-to-edge IPC to become a cross-host API. |
 | Persistent data | A volume belongs to a service; releases reuse it and rollback does not roll back its contents. | Do not infer volume mobility or safe replication from a reusable service definition. |
 
 These are implementation review criteria, not a request to introduce generic


### PR DESCRIPTION
## Summary

- Amend ADR-002 and the consolidated design: ingress retains all host sockets and relays opaque TCP streams/UDP datagrams over private Unix IPC. Edge keeps TLS, routing, backend selection and CIDR policy.
- Make UDP lifecycle deliberately disruptive: recreate invalidates affected associations; restart recovers authorized listeners/routes with empty sessions. No live session migration or durable session restoration.
- Record the TCP relay's performance and availability trade-offs, preserve apply/deploy, reservations, durable execution intent and confinement gates, and synchronize existing guidance.

## Boundaries

No implementation or probe artifacts are included. The OS confinement mechanism remains undecided; this does not select a dedicated ingress account, change systemd ownership or weaken container/LSM protections. IPC details and transport validation still precede exposure.

## Validation

- `git diff --check`
- Markdown fence and local-link/anchor checks on all changed documents
- Critical architecture review: shared-route withdrawal and per-listener UDP admission/epoch ordering clarified
- CodeRabbit review: lifecycle authorization clarified; restart-safe epoch allocation remains an explicit prerequisite for the focused IPC/persistence design

Documentation-only change; Go tests and lint are not applicable. This PR targets `v3-alpha`, not `main`.
