### PR TITLE
feat(apps): add app state records and store boundary

### DIFF
--- a/internal/boundaries/out/app_state.go
+++ b/internal/boundaries/out/app_state.go
@@ -1,0 +1,83 @@
+package out
+
+import (
+	"context"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// AppState persists desired/active app state, reservations, intents,
+// operation journals, and ownership records. Implemented by the
+// atomic-file filesystem adapter; consumed by the apps use case.
+// All methods are safe for concurrent use within one process;
+// cross-process coordination is owned by the implementation
+// (store.lock flock). No secret values pass through this boundary.
+type AppState interface {
+	// Recover completes committed-but-unmaterialized apply intents
+	// before any new mutation is accepted (recovery-before-mutation).
+	Recover(ctx context.Context) error
+
+	// LoadCheckpoint returns the global reservation checkpoint.
+	LoadCheckpoint(ctx context.Context) (domain.AppStoreCheckpoint, error)
+
+	// ListApps returns normalized names of apps with any state.
+	ListApps(ctx context.Context) ([]string, error)
+
+	// LoadDesired returns the latest accepted desired revision.
+	// ok is false when the app has no desired state.
+	LoadDesired(ctx context.Context, app string) (domain.AppDesiredRevision, bool, error)
+
+	// LoadRevision returns one immutable revision by id.
+	LoadRevision(ctx context.Context, app, revision string) (domain.AppDesiredRevision, error)
+
+	// ListRevisions returns revision ids ordered newest first.
+	ListRevisions(ctx context.Context, app string) ([]string, error)
+
+	// LoadActive returns the per-service effective state.
+	// ok is false when the app was never deployed.
+	LoadActive(ctx context.Context, app string) (domain.AppActive, bool, error)
+
+	// LoadIntent returns the durable stopped/running intent.
+	LoadIntent(ctx context.Context, app string) (domain.AppStopIntent, error)
+
+	// SaveIntent persists running/stopped intent.
+	SaveIntent(ctx context.Context, intent domain.AppStopIntent) error
+
+	// LoadOwnership returns the ownership record (zero value when absent).
+	LoadOwnership(ctx context.Context, app string) (domain.AppOwnership, error)
+
+	// SaveOwnership persists the ownership record.
+	SaveOwnership(ctx context.Context, ownership domain.AppOwnership) error
+
+	// StageApply writes a staged intent containing the full candidate.
+	// No reservation or revision is visible until CommitApply.
+	StageApply(ctx context.Context, intent domain.AppApplyIntent) error
+
+	// CommitApply is the single atomic commit point: staged→committed.
+	CommitApply(ctx context.Context, app, intentID string) error
+
+	// MaterializeApply finishes a committed intent: revision file,
+	// desired pointer, reservation checkpoint update, intent→applied.
+	// Idempotent by content hash; safe to replay after a crash.
+	MaterializeApply(ctx context.Context, app, intentID string) error
+
+	// LoadIntent returns one apply intent by id.
+	LoadApplyIntent(ctx context.Context, app, intentID string) (domain.AppApplyIntent, error)
+
+	// ListIntents returns apply intent ids for recovery scans.
+	ListIntents(ctx context.Context, app string) ([]string, error)
+
+	// CollectGarbage removes staged orphans, applied intents, and
+	// unreferenced revisions beyond retention. Referenced revisions
+	// (desired/active/in-flight) are never evicted.
+	CollectGarbage(ctx context.Context, app string, inFlight []string) error
+
+	// SaveOperation persists an operation journal record atomically.
+	SaveOperation(ctx context.Context, op domain.AppOperation) error
+
+	// LoadOperation returns one operation journal record.
+	LoadOperation(ctx context.Context, app, opID string) (domain.AppOperation, error)
+
+	// SaveActive persists the per-service effective state.
+	SaveActive(ctx context.Context, active domain.AppActive) error
+}

--- a/internal/domain/app_state.go
+++ b/internal/domain/app_state.go
@@ -1,0 +1,174 @@
+package domain
+
+import "time"
+
+// App state records. Frozen by docs/plans/v2.50.0/02-state.md.
+// These are persistence shapes: the store adapter serializes them as
+// JSON, the apps use case orchestrates transitions. No secret VALUES
+// ever appear in these records — only secret paths.
+
+// AppStoreVersion is the single supported app-state format version.
+const AppStoreVersion = 1
+
+// AppRevisionRetention keeps the last N unreferenced revisions plus
+// every revision referenced by desired/active/in-flight records.
+const AppRevisionRetention = 32
+
+// App intent states for the durable apply protocol.
+const (
+	AppIntentStaged    = "staged"
+	AppIntentCommitted = "committed"
+	AppIntentApplied   = "applied"
+)
+
+// App operation step states.
+const (
+	AppStepPending   = "pending"
+	AppStepSucceeded = "succeeded"
+	AppStepFailed    = "failed"
+	AppStepNotRun    = "not-run"
+)
+
+// App operation outcomes over terminal per-service results.
+const (
+	AppOutcomeSuccess = "success"
+	AppOutcomePartial = "partial"
+	AppOutcomeFailed  = "failed"
+)
+
+// App owned-resource states.
+const (
+	AppResourceAttached = "attached"
+	AppResourceRetained = "retained"
+)
+
+// AppListenerReservation is one global listener claim.
+type AppListenerReservation struct {
+	Proto   string `json:"proto"`
+	IP      string `json:"ip,omitempty"`
+	Port    int    `json:"port,omitempty"`
+	Host    string `json:"host,omitempty"`
+	Service string `json:"service"`
+	App     string `json:"app"`
+	Owner   string `json:"owner,omitempty"`
+	Dual    *bool  `json:"dual,omitempty"`
+}
+
+// AppDesiredRevision is one accepted desired revision.
+type AppDesiredRevision struct {
+	Revision        string                   `json:"revision"`
+	App             string                   `json:"app"`
+	Supersedes      string                   `json:"supersedes,omitempty"`
+	AcceptedAt      time.Time                `json:"accepted_at"`
+	SourceSHA256    string                   `json:"source_sha256"`
+	Spec            AppSpec                  `json:"spec"`
+	Reservations    []AppListenerReservation `json:"reservations"`
+	SecretsRequired []string                 `json:"secrets_required"`
+	SecretsEnv      map[string]string        `json:"secrets_env"`
+	Status          string                   `json:"status"`
+}
+
+// AppEffectiveService is one service's effective (activated) definition.
+type AppEffectiveService struct {
+	EffectiveRevision string     `json:"effective_revision"`
+	ActivatedBy       string     `json:"activated_by"`
+	ActivatedAt       time.Time  `json:"activated_at"`
+	Image             string     `json:"image"`
+	Digest            string     `json:"digest,omitempty"`
+	Container         string     `json:"container,omitempty"`
+	Spec              AppService `json:"spec"`
+}
+
+// AppActive is the per-service effective state of one app.
+type AppActive struct {
+	App               string                         `json:"app"`
+	ConvergedRevision string                         `json:"converged_revision"`
+	Converged         bool                           `json:"converged"`
+	Services          map[string]AppEffectiveService `json:"services"`
+	StopIntent        bool                           `json:"stop_intent"`
+}
+
+// AppStopIntent is the durable running/stopped intent.
+type AppStopIntent struct {
+	App       string    `json:"app"`
+	Stopped   bool      `json:"stopped"`
+	UpdatedBy string    `json:"updated_by"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AppOperationStep is one durable journal step.
+type AppOperationStep struct {
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Before string `json:"before,omitempty"`
+	After  string `json:"after,omitempty"`
+}
+
+// AppOperation is one durable operation journal record.
+type AppOperation struct {
+	Op            string             `json:"op"`
+	Kind          string             `json:"kind"`
+	App           string             `json:"app"`
+	InputRevision string             `json:"input_revision"`
+	StartedAt     time.Time          `json:"started_at"`
+	Steps         []AppOperationStep `json:"steps"`
+	Outcome       string             `json:"outcome,omitempty"`
+}
+
+// AppApplyIntent is one durable apply intent.
+type AppApplyIntent struct {
+	Intent       string                   `json:"intent"`
+	App          string                   `json:"app"`
+	State        string                   `json:"state"`
+	Revision     string                   `json:"revision"`
+	Supersedes   string                   `json:"supersedes,omitempty"`
+	SourceSHA256 string                   `json:"source_sha256"`
+	Spec         AppSpec                  `json:"spec"`
+	Reservations []AppListenerReservation `json:"reservations"`
+	CreatedAt    time.Time                `json:"created_at"`
+}
+
+// AppOwnedVolume tracks one app-owned volume.
+type AppOwnedVolume struct {
+	Name        string `json:"name"`
+	Service     string `json:"service"`
+	RuntimeName string `json:"runtime_name"`
+	State       string `json:"state"`
+}
+
+// AppOwnedSecret tracks one app-referenced secret (path only, never value).
+type AppOwnedSecret struct {
+	Service string `json:"service"`
+	Env     string `json:"env"`
+	Name    string `json:"name"`
+	Path    string `json:"path"`
+	State   string `json:"state"`
+}
+
+// AppOwnedNetwork tracks one app network.
+type AppOwnedNetwork struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+// AppServiceRecovery tracks per-service restart-safety flags.
+type AppServiceRecovery struct {
+	RestartUnsafe bool `json:"restart_unsafe"`
+}
+
+// AppOwnership is the ownership record for one app.
+type AppOwnership struct {
+	App      string                        `json:"app"`
+	Volumes  []AppOwnedVolume              `json:"volumes"`
+	Services map[string]AppServiceRecovery `json:"services"`
+	Secrets  []AppOwnedSecret              `json:"secrets"`
+	Networks []AppOwnedNetwork             `json:"networks"`
+}
+
+// AppStoreCheckpoint is the global reservation checkpoint.
+type AppStoreCheckpoint struct {
+	Version      int                      `json:"version"`
+	Reservations []AppListenerReservation `json:"reservations"`
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -62,6 +62,16 @@ var (
 	// App manifest errors
 	ErrInvalidAppSpec = errors.New("invalid app manifest")
 
+	// App state errors
+	ErrAppStateIO             = errors.New("app state storage failure")
+	ErrAppStateCorrupt        = errors.New("app state is corrupt")
+	ErrAppStateIncompatible   = errors.New("app state format is not supported by this binary")
+	ErrAppStateConflict       = errors.New("app state conflict")
+	ErrAppRevisionNotFound    = errors.New("app revision not found")
+	ErrAppIntentNotFound      = errors.New("app apply intent not found")
+	ErrAppOperationNotFound   = errors.New("app operation not found")
+	ErrAppReservationConflict = errors.New("listener reservation conflict")
+
 	// Environment errors
 	ErrEnvFileNotFound             = errors.New("environment file not found")
 	ErrSecretNotFound              = errors.New("secret not found")


### PR DESCRIPTION
P2 slice 1/2. Domain persistence shapes, sentinels, consumer-owned

out.AppState boundary. No reachable behavior.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>