### PR TITLE
feat(apps): app API/CLI surface as unreachable preparation

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -48,6 +48,7 @@ packages:
       PublicTLSService:
       TrafficStatusService:
       StandaloneServiceService:
+      AppService:
   # Exception: pushImageOps is a CLI-local interface, not a boundary port.
   # Mocked here because it abstracts Docker SDK calls that require a running
   # daemon, making unit/integration tests impractical without a test double.

--- a/internal/adapters/dto/admin_apps.go
+++ b/internal/adapters/dto/admin_apps.go
@@ -1,0 +1,177 @@
+package dto
+
+// App admin DTOs. Frozen field names by docs/plans/v2.50.0/05-api-cli.md.
+// No secret values exist in any shape here: secret references carry
+// paths and env keys only. The versioned error envelope is a deliberate
+// change from ErrorResponse for app mutations; clients accept both
+// during the mixed-version window.
+
+// AppError is the v2.50 app-mutation error envelope. Frozen field names
+// by docs/plans/v2.50.0/05-api-cli.md §3: error/message/cause/hint.
+// `logs` never appears on mutations. Clients accept the legacy
+// single-field ErrorResponse during the mixed-version window.
+type AppError struct {
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+	Cause   string `json:"cause,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+// AppDiffSection carries normalized added/removed/changed paths.
+type AppDiffSection struct {
+	Added   []string `json:"added"`
+	Removed []string `json:"removed"`
+	Changed []string `json:"changed"`
+}
+
+// AppApplyRequest asks the daemon to validate and persist desired state.
+type AppApplyRequest struct {
+	ManifestTOML string `json:"manifest_toml"`
+	DryRun       bool   `json:"dry_run,omitempty"`
+}
+
+// AppApplyResponse reports persistence success separately from deploy.
+type AppApplyResponse struct {
+	App               string         `json:"app"`
+	FormerRevision    string         `json:"former_revision,omitempty"`
+	ResultingRevision string         `json:"resulting_revision"`
+	Pending           bool           `json:"pending"`
+	Noop              bool           `json:"noop,omitempty"`
+	Diff              AppDiffSection `json:"diff"`
+	Warnings          []string       `json:"warnings,omitempty"`
+	Intent            string         `json:"intent,omitempty"`
+}
+
+// AppDeployRequest activates a captured revision.
+type AppDeployRequest struct {
+	Revision string `json:"revision,omitempty"`
+	Service  string `json:"service,omitempty"`
+}
+
+// AppServiceResultDTO is one service's terminal deployment result.
+type AppServiceResultDTO struct {
+	Result            string `json:"result"`
+	EffectiveRevision string `json:"effective_revision"`
+	Before            string `json:"before,omitempty"`
+	After             string `json:"after,omitempty"`
+	RestartUnsafe     bool   `json:"restart_unsafe"`
+	Error             string `json:"error,omitempty"`
+}
+
+// AppStepDTO is one journaled operation step.
+type AppStepDTO struct {
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Before string `json:"before,omitempty"`
+	After  string `json:"after,omitempty"`
+}
+
+// AppCleanupWarningDTO records post-publication leftovers.
+type AppCleanupWarningDTO struct {
+	Service  string `json:"service"`
+	Leftover string `json:"leftover"`
+	Detail   string `json:"detail"`
+}
+
+// AppEffectiveDTO maps services to effective revisions.
+type AppEffectiveDTO struct {
+	Converged         bool              `json:"converged"`
+	ConvergedRevision string            `json:"converged_revision,omitempty"`
+	Services          map[string]string `json:"services"`
+}
+
+// AppObservedDTO carries observed runtime state (ids, never secrets).
+type AppObservedDTO struct {
+	Running []string `json:"running"`
+	Stopped []string `json:"stopped"`
+}
+
+// AppRetainedDTO lists retained resources (names/paths, never values).
+type AppRetainedDTO struct {
+	Volumes []string `json:"volumes"`
+	Secrets []string `json:"secrets"`
+}
+
+// AppDeployResponse reports deploy outcome with terminal results.
+type AppDeployResponse struct {
+	Op              string                         `json:"op"`
+	App             string                         `json:"app"`
+	Revision        string                         `json:"revision"`
+	Outcome         string                         `json:"outcome"`
+	Services        map[string]AppServiceResultDTO `json:"services"`
+	Steps           []AppStepDTO                   `json:"steps"`
+	CleanupWarnings []AppCleanupWarningDTO         `json:"cleanup_warnings,omitempty"`
+	Effective       AppEffectiveDTO                `json:"effective"`
+	Observed        AppObservedDTO                 `json:"observed"`
+	Retained        AppRetainedDTO                 `json:"retained"`
+}
+
+// AppDesiredDTO summarizes desired state.
+type AppDesiredDTO struct {
+	Revision string `json:"revision,omitempty"`
+	Status   string `json:"status,omitempty"`
+}
+
+// AppActiveServiceDTO is one effective service for inspection.
+type AppActiveServiceDTO struct {
+	EffectiveRevision string `json:"effective_revision"`
+	Digest            string `json:"digest,omitempty"`
+	Container         string `json:"container,omitempty"`
+	RestartUnsafe     bool   `json:"restart_unsafe"`
+}
+
+// AppActiveDTO carries per-service effective state.
+type AppActiveDTO struct {
+	Converged         bool                           `json:"converged"`
+	ConvergedRevision string                         `json:"converged_revision,omitempty"`
+	Services          map[string]AppActiveServiceDTO `json:"services"`
+}
+
+// AppIntentDTO carries durable stopped/running intent.
+type AppIntentDTO struct {
+	Stopped bool `json:"stopped"`
+}
+
+// AppLastOpDTO references the latest operation.
+type AppLastOpDTO struct {
+	Op      string `json:"op"`
+	Outcome string `json:"outcome"`
+}
+
+// AppShowResponse inspects desired + active + intent + op ref.
+type AppShowResponse struct {
+	App     string        `json:"app"`
+	Desired AppDesiredDTO `json:"desired"`
+	Active  AppActiveDTO  `json:"active"`
+	Intent  AppIntentDTO  `json:"intent"`
+	LastOp  AppLastOpDTO  `json:"last_op,omitempty"`
+}
+
+// AppSummaryDTO is one row of the app list.
+type AppSummaryDTO struct {
+	App       string `json:"app"`
+	Desired   string `json:"desired,omitempty"`
+	Active    string `json:"active,omitempty"`
+	Converged bool   `json:"converged"`
+	Stopped   bool   `json:"stopped"`
+}
+
+// AppDiffResponse reports normalized desired-vs-active diff.
+type AppDiffResponse struct {
+	App  string         `json:"app"`
+	Diff AppDiffSection `json:"diff"`
+}
+
+// AppSecretSetRequest writes secret values (names pre-registered).
+type AppSecretSetRequest struct {
+	Service string            `json:"service"`
+	Secrets map[string]string `json:"secrets"`
+}
+
+// AppSecretDeleteRequest removes one secret value.
+type AppSecretDeleteRequest struct {
+	Service string `json:"service"`
+	Key     string `json:"key"`
+}

--- a/internal/adapters/dto/admin_apps_test.go
+++ b/internal/adapters/dto/admin_apps_test.go
@@ -1,0 +1,151 @@
+package dto
+
+// Frozen-wire tests for the v2.50 app admin DTOs
+// (docs/plans/v2.50.0/05-api-cli.md §3). These pin the exact JSON field
+// names the daemon and the CLI exchange, and prove no response shape can
+// carry secret values. The single intentional exception is
+// AppSecretSetRequest: the write path must transport values.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dtoJSONKeys(t *testing.T, v any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	return decoded
+}
+
+func TestAppErrorEnvelopeKeys(t *testing.T) {
+	envelope := AppError{Error: "secret-missing", Message: "db password missing", Cause: "pass lookup failed", Hint: "set it first"}
+	keys := dtoJSONKeys(t, envelope)
+	assert.Equal(t, "secret-missing", keys["error"])
+	assert.Equal(t, "db password missing", keys["message"])
+	assert.Equal(t, "pass lookup failed", keys["cause"])
+	assert.Equal(t, "set it first", keys["hint"])
+	assert.NotContains(t, keys, "logs", "mutations must never carry logs")
+
+	// Mixed-version window: the legacy single-field shape still decodes.
+	var legacy AppError
+	require.NoError(t, json.Unmarshal([]byte(`{"error":"image-unresolvable"}`), &legacy))
+	assert.Equal(t, "image-unresolvable", legacy.Error)
+	assert.Empty(t, legacy.Message)
+}
+
+func TestAppApplyResponseKeys(t *testing.T) {
+	resp := AppApplyResponse{
+		App:               "blog",
+		FormerRevision:    "rev-old",
+		ResultingRevision: "rev-new",
+		Pending:           true,
+		Diff:              AppDiffSection{Added: []string{"service.web"}, Removed: []string{}, Changed: []string{}},
+		Warnings:          []string{"w"},
+		Intent:            "apply-abc",
+	}
+	keys := dtoJSONKeys(t, resp)
+	for _, key := range []string{"app", "former_revision", "resulting_revision", "pending", "diff", "warnings", "intent"} {
+		assert.Contains(t, keys, key)
+	}
+	diff := keys["diff"].(map[string]any)
+	for _, key := range []string{"added", "removed", "changed"} {
+		assert.Contains(t, diff, key)
+	}
+}
+
+func TestAppDeployResponseKeys(t *testing.T) {
+	resp := AppDeployResponse{
+		Op:       "op-abc",
+		App:      "blog",
+		Revision: "rev-new",
+		Outcome:  "success",
+		Services: map[string]AppServiceResultDTO{
+			"web": {Result: "deployed", EffectiveRevision: "rev-new"},
+		},
+		Steps: []AppStepDTO{{ID: "service.web.replace", State: "succeeded"}},
+		CleanupWarnings: []AppCleanupWarningDTO{
+			{Service: "web", Leftover: "ctr-old", Detail: "retire failed after publish"},
+		},
+		Effective: AppEffectiveDTO{Converged: true, Services: map[string]string{"web": "rev-new"}},
+		Observed:  AppObservedDTO{Running: []string{"ctr-new"}},
+		Retained:  AppRetainedDTO{Volumes: []string{"blog-db"}, Secrets: []string{"db/password"}},
+	}
+	keys := dtoJSONKeys(t, resp)
+	for _, key := range []string{"op", "app", "revision", "outcome", "services", "steps", "cleanup_warnings", "effective", "observed", "retained"} {
+		assert.Contains(t, keys, key)
+	}
+	svc := keys["services"].(map[string]any)["web"].(map[string]any)
+	for _, key := range []string{"result", "effective_revision", "restart_unsafe"} {
+		assert.Contains(t, svc, key)
+	}
+}
+
+func TestAppShowResponseKeys(t *testing.T) {
+	resp := AppShowResponse{
+		App:     "blog",
+		Desired: AppDesiredDTO{Revision: "rev-new", Status: "pending"},
+		Active: AppActiveDTO{Converged: false, Services: map[string]AppActiveServiceDTO{
+			"web": {EffectiveRevision: "rev-old", Digest: "sha256:abc", Container: "ctr-old", RestartUnsafe: true},
+		}},
+		Intent: AppIntentDTO{Stopped: false},
+		LastOp: AppLastOpDTO{Op: "op-abc", Outcome: "success"},
+	}
+	keys := dtoJSONKeys(t, resp)
+	for _, key := range []string{"app", "desired", "active", "intent", "last_op"} {
+		assert.Contains(t, keys, key)
+	}
+	web := keys["active"].(map[string]any)["services"].(map[string]any)["web"].(map[string]any)
+	for _, key := range []string{"effective_revision", "digest", "container", "restart_unsafe"} {
+		assert.Contains(t, web, key)
+	}
+	assert.NotContains(t, web, "env", "active services must not inline env values")
+}
+
+// TestAppResponsesCarryNoSecretValues marshals representative responses and
+// proves a sentinel secret value appears nowhere. The request that carries
+// values (AppSecretSetRequest) is asserted as the single exception.
+func TestAppResponsesCarryNoSecretValues(t *testing.T) {
+	const sentinel = "s3cr3t-value-sentinel"
+
+	responses := []any{
+		AppApplyResponse{App: "blog", ResultingRevision: "rev-x", Intent: "apply-x"},
+		AppDeployResponse{
+			Op: "op-x", App: "blog", Revision: "rev-x", Outcome: "failed",
+			Services: map[string]AppServiceResultDTO{
+				"web": {Result: "failed", EffectiveRevision: "rev-x", Error: "boom"},
+			},
+			Effective: AppEffectiveDTO{Services: map[string]string{"web": "rev-x"}},
+			Observed:  AppObservedDTO{Running: []string{"ctr-x"}, Stopped: []string{}},
+			Retained:  AppRetainedDTO{Volumes: []string{"blog-db"}, Secrets: []string{"db/password"}},
+		},
+		AppShowResponse{
+			App:     "blog",
+			Desired: AppDesiredDTO{Revision: "rev-x", Status: "active"},
+			Active: AppActiveDTO{Services: map[string]AppActiveServiceDTO{
+				"web": {EffectiveRevision: "rev-x", Digest: "sha256:x", Container: "ctr-x"},
+			}},
+		},
+		AppSummaryDTO{App: "blog", Desired: "rev-x", Active: "rev-x"},
+		AppDiffResponse{App: "blog", Diff: AppDiffSection{Changed: []string{"secret.db/password"}}},
+	}
+	for i, resp := range responses {
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err, "response %d", i)
+		body := string(raw)
+		assert.NotContains(t, body, sentinel, "response %d leaks a secret value", i)
+		assert.NotContains(t, strings.ToLower(body), `"value"`, "response %d has a value field", i)
+	}
+
+	// The one intentional exception: the set-secret request transports values.
+	setReq := AppSecretSetRequest{Service: "web", Secrets: map[string]string{"password": sentinel}}
+	raw, err := json.Marshal(setReq)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), sentinel)
+}

--- a/internal/adapters/in/cli/app_controlplane.go
+++ b/internal/adapters/in/cli/app_controlplane.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+)
+
+// AppControlPlane abstracts local vs remote app operations. The remote
+// implementation delegates to remote.Client HTTP methods; the local
+// implementation calls service interfaces directly at cutover.
+// CLI commands in apps.go consume this interface; root.go registration
+// lands at the cutover slice (this file is unreachable until then).
+type AppControlPlane interface {
+	ApplyApp(ctx context.Context, req dto.AppApplyRequest) (*dto.AppApplyResponse, error)
+	ListApps(ctx context.Context) ([]dto.AppSummaryDTO, error)
+	ShowApp(ctx context.Context, app string) (*dto.AppShowResponse, error)
+	DiffApp(ctx context.Context, app string) (*dto.AppDiffResponse, error)
+	DeployApp(ctx context.Context, app string, req dto.AppDeployRequest) (*dto.AppDeployResponse, string, error)
+	StopApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error)
+	StartApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error)
+	RestartApp(ctx context.Context, app, service string) (*dto.AppDeployResponse, string, error)
+	RemoveApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error)
+	OperationByKey(ctx context.Context, app, key string) (*dto.AppDeployResponse, error)
+	SetAppSecrets(ctx context.Context, app string, req dto.AppSecretSetRequest) error
+	DeleteAppSecret(ctx context.Context, app string, req dto.AppSecretDeleteRequest) error
+}
+
+// remoteAppControlPlane delegates to remote.Client HTTP methods.
+type remoteAppControlPlane struct {
+	client *remote.Client
+}
+
+// NewRemoteAppControlPlane creates the remote app control plane.
+func NewRemoteAppControlPlane(client *remote.Client) AppControlPlane {
+	return &remoteAppControlPlane{client: client}
+}
+
+func (p *remoteAppControlPlane) ApplyApp(ctx context.Context, req dto.AppApplyRequest) (*dto.AppApplyResponse, error) {
+	return p.client.ApplyApp(ctx, req)
+}
+
+func (p *remoteAppControlPlane) ListApps(ctx context.Context) ([]dto.AppSummaryDTO, error) {
+	return p.client.ListApps(ctx)
+}
+
+func (p *remoteAppControlPlane) ShowApp(ctx context.Context, app string) (*dto.AppShowResponse, error) {
+	return p.client.ShowApp(ctx, app)
+}
+
+func (p *remoteAppControlPlane) DiffApp(ctx context.Context, app string) (*dto.AppDiffResponse, error) {
+	return p.client.DiffApp(ctx, app)
+}
+
+func (p *remoteAppControlPlane) DeployApp(ctx context.Context, app string, req dto.AppDeployRequest) (*dto.AppDeployResponse, string, error) {
+	return p.client.DeployApp(ctx, app, req)
+}
+
+func (p *remoteAppControlPlane) StopApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return p.client.StopApp(ctx, app)
+}
+
+func (p *remoteAppControlPlane) StartApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return p.client.StartApp(ctx, app)
+}
+
+func (p *remoteAppControlPlane) RestartApp(ctx context.Context, app, service string) (*dto.AppDeployResponse, string, error) {
+	return p.client.RestartApp(ctx, app, service)
+}
+
+func (p *remoteAppControlPlane) RemoveApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return p.client.RemoveApp(ctx, app)
+}
+
+func (p *remoteAppControlPlane) OperationByKey(ctx context.Context, app, key string) (*dto.AppDeployResponse, error) {
+	return p.client.OperationByKey(ctx, app, key)
+}
+
+func (p *remoteAppControlPlane) SetAppSecrets(ctx context.Context, app string, req dto.AppSecretSetRequest) error {
+	return p.client.SetAppSecrets(ctx, app, req)
+}
+
+func (p *remoteAppControlPlane) DeleteAppSecret(ctx context.Context, app string, req dto.AppSecretDeleteRequest) error {
+	return p.client.DeleteAppSecret(ctx, app, req)
+}

--- a/internal/adapters/in/cli/apps.go
+++ b/internal/adapters/in/cli/apps.go
@@ -1,0 +1,883 @@
+package cli
+
+// App CLI surface. Frozen by docs/plans/v2.50.0/05-api-cli.md §5.
+//
+// PREPARATION: this file is unreachable. None of these constructors are
+// referenced from root.go — registration lands at the cutover slice
+// together with the admin handlers, the local control plane, and the
+// deletion of the retired domain-based commands. Until then the daemon
+// owns no app state and these commands must not run.
+//
+// Conventions (per AGENTS.md): cmd.Context(), cmd.OutOrStdout(), errors
+// from RunE, --json via writeJSON with equivalent semantics, stable
+// sorted ordering, and NO secret values or sensitive output anywhere.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+)
+
+// appApplyMaxBytes bounds the apply manifest body (05-api-cli.md §2).
+const appApplyMaxBytes = 1 << 20
+
+// resolveAppControlPlane returns the daemon-backed app plane. App mutations
+// are daemon-owned for BOTH local and remote paths (05-api-cli.md §1):
+// when no daemon endpoint is reachable there is no local-write fallback —
+// the command fails with daemon-unavailable. The local-proxy path (local
+// CLI speaking to a reachable daemon over the same DTOs and auth) wires in
+// at cutover; until then only --remote works.
+func resolveAppControlPlane() (AppControlPlane, error) {
+	client, isRemote, err := GetRemoteClient()
+	if err != nil {
+		return nil, err
+	}
+	if !isRemote {
+		return nil, fmt.Errorf(
+			"daemon-unavailable: no daemon endpoint is reachable; " +
+				"app mutations are daemon-owned and have no local-write fallback " +
+				"(start the daemon or pass --remote)")
+	}
+	return NewRemoteAppControlPlane(client), nil
+}
+
+// appMutationError translates ambiguous transport outcomes into the
+// outcome-unknown guidance: never blindly retry, re-query by key first.
+func appMutationError(op, app, key string, err error) error {
+	var unknown *remote.OutcomeUnknownError
+	if errors.As(err, &unknown) {
+		return fmt.Errorf(
+			"outcome-unknown: %s %s may have executed; query "+
+				"GET /admin/apps/%s/operations/by-key/%s before retrying (same key): %w",
+			op, app, app, key, err)
+	}
+	return err
+}
+
+// newAppsCmd creates the `apps` parent command.
+func newAppsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apps",
+		Short: "Manage applications (daemon-owned)",
+		Long: `Validate, persist, inspect, and operate applications.
+
+All mutations are executed by the daemon through the admin API;
+without a reachable daemon the commands fail instead of writing locally.
+
+Examples:
+  gordon apps apply --file blog.toml
+  gordon apps list
+  gordon apps show blog
+  gordon apps diff blog`,
+	}
+	cmd.AddCommand(
+		newAppsApplyCmd(),
+		newAppsListCmd(),
+		newAppsShowCmd(),
+		newAppsDiffCmd(),
+		newAppsSecretsCmd(),
+	)
+	return cmd
+}
+
+// newAppsApplyCmd creates `apps apply`.
+func newAppsApplyCmd() *cobra.Command {
+	var file string
+	var dryRun bool
+	var chainDeploy bool
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Validate and persist an app manifest",
+		Long: `Validates a manifest file and persists it as desired state (or dry-runs).
+
+With --deploy, chains exactly the accepted revision into a deploy after
+persistence succeeds; the two outcomes are reported separately because a
+deploy may fail after the apply succeeded.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppsApply(cmd.Context(), plane, os.Stdin, cmd.OutOrStdout(), file, dryRun, chainDeploy, jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&file, "file", "", "Path to the app manifest file (required)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate without persisting")
+	cmd.Flags().BoolVar(&chainDeploy, "deploy", false, "Deploy the accepted revision after applying")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsApply(ctx context.Context, plane AppControlPlane, _ io.Reader, out io.Writer, file string, dryRun, chainDeploy, jsonOut bool) error {
+	if dryRun && chainDeploy {
+		return fmt.Errorf("cannot combine --dry-run with --deploy: dry-run persists nothing to deploy")
+	}
+	if file == "" {
+		return fmt.Errorf("missing required flag --file")
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest file: %w", err)
+	}
+	if len(data) > appApplyMaxBytes {
+		return fmt.Errorf("manifest exceeds the 1 MiB apply bound (%d bytes)", len(data))
+	}
+	resp, err := plane.ApplyApp(ctx, dto.AppApplyRequest{ManifestTOML: string(data), DryRun: dryRun})
+	if err != nil {
+		return err
+	}
+	if jsonOut && !chainDeploy {
+		return writeJSON(out, resp)
+	}
+	if err := renderAppApply(out, resp, dryRun); err != nil {
+		return err
+	}
+	if !chainDeploy {
+		return nil
+	}
+	deployResp, key, deployErr := plane.DeployApp(ctx, resp.App, dto.AppDeployRequest{Revision: resp.ResultingRevision})
+	if deployErr != nil {
+		return fmt.Errorf("apply of %s succeeded (%s); %w",
+			resp.App, resp.ResultingRevision, appMutationError("deploy", resp.App, key, deployErr))
+	}
+	if jsonOut {
+		return writeJSON(out, deployResp)
+	}
+	return renderAppDeployResponse(out, deployResp)
+}
+
+func renderAppApply(out io.Writer, resp *dto.AppApplyResponse, dryRun bool) error {
+	if resp.Noop {
+		return cliWriteLine(out, cliRenderMuted(fmt.Sprintf("No changes for %s (%s)", resp.App, resp.ResultingRevision)))
+	}
+	verb := "Applied"
+	if dryRun {
+		verb = "Validated (dry-run)"
+	}
+	if err := cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("%s %s (%s)", verb, resp.App, resp.ResultingRevision))); err != nil {
+		return err
+	}
+	if resp.Pending {
+		if err := cliWriteLine(out, cliRenderMeta("intent:", resp.Intent)); err != nil {
+			return err
+		}
+	}
+	for _, w := range resp.Warnings {
+		if err := cliWriteLine(out, cliRenderWarning(w)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newAppsListCmd creates `apps list`.
+func newAppsListCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List applications",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppsList(cmd.Context(), plane, cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsList(ctx context.Context, plane AppControlPlane, out io.Writer, jsonOut bool) error {
+	apps, err := plane.ListApps(ctx)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		if apps == nil {
+			apps = []dto.AppSummaryDTO{}
+		}
+		return writeJSON(out, apps)
+	}
+	if len(apps) == 0 {
+		return cliWriteLine(out, cliRenderEmptyState("No apps."))
+	}
+	names := make([]string, 0, len(apps))
+	byName := make(map[string]dto.AppSummaryDTO, len(apps))
+	for _, a := range apps {
+		names = append(names, a.App)
+		byName[a.App] = a
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		a := byName[name]
+		state := "active"
+		if a.Stopped {
+			state = "stopped"
+		} else if !a.Converged {
+			state = "pending"
+		}
+		if err := cliWriteLine(out, cliRenderListItem(fmt.Sprintf("%s (%s)", name, state))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newAppsShowCmd creates `apps show`.
+func newAppsShowCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "show APP",
+		Short: "Show desired and active state for an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppsShow(cmd.Context(), plane, args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsShow(ctx context.Context, plane AppControlPlane, app string, out io.Writer, jsonOut bool) error {
+	resp, err := plane.ShowApp(ctx, app)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	if err := cliWriteLine(out, cliRenderTitle(resp.App)); err != nil {
+		return err
+	}
+	if err := cliWriteLine(out, cliRenderMeta("desired:", resp.Desired.Revision+" ("+resp.Desired.Status+")")); err != nil {
+		return err
+	}
+	for _, line := range renderActiveServices(resp.Active) {
+		if err := cliWriteLine(out, line); err != nil {
+			return err
+		}
+	}
+	if resp.Intent.Stopped {
+		if err := cliWriteLine(out, cliRenderWarning("stopped intent is set")); err != nil {
+			return err
+		}
+	}
+	if resp.LastOp.Op != "" {
+		return cliWriteLine(out, cliRenderMeta("last-op:", resp.LastOp.Op+" ("+resp.LastOp.Outcome+")"))
+	}
+	return nil
+}
+
+// renderActiveServices renders per-service effective state, sorted by name.
+// Only ids and digests appear — never secret values.
+func renderActiveServices(active dto.AppActiveDTO) []string {
+	names := make([]string, 0, len(active.Services))
+	for name := range active.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	lines := make([]string, 0, len(names)+1)
+	converged := "converged"
+	if !active.Converged {
+		converged = "diverged"
+	}
+	lines = append(lines, cliRenderMeta("active:", converged))
+	for _, name := range names {
+		svc := active.Services[name]
+		detail := svc.EffectiveRevision
+		if svc.Container != "" {
+			detail += " container=" + svc.Container
+		}
+		if svc.RestartUnsafe {
+			detail += " restart_unsafe"
+		}
+		lines = append(lines, cliRenderMeta("  "+name+":", detail))
+	}
+	return lines
+}
+
+// newAppsDiffCmd creates `apps diff`.
+func newAppsDiffCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "diff APP",
+		Short: "Show the normalized desired-vs-active diff",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppsDiff(cmd.Context(), plane, args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsDiff(ctx context.Context, plane AppControlPlane, app string, out io.Writer, jsonOut bool) error {
+	resp, err := plane.DiffApp(ctx, app)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	if len(resp.Diff.Added) == 0 && len(resp.Diff.Removed) == 0 && len(resp.Diff.Changed) == 0 {
+		return cliWriteLine(out, cliRenderMuted(fmt.Sprintf("No differences for %s.", app)))
+	}
+	for _, section := range []struct {
+		title string
+		paths []string
+	}{
+		{"added:", resp.Diff.Added},
+		{"removed:", resp.Diff.Removed},
+		{"changed:", resp.Diff.Changed},
+	} {
+		paths := append([]string(nil), section.paths...)
+		sort.Strings(paths)
+		for _, p := range paths {
+			if err := cliWriteLine(out, cliRenderMeta(section.title, p)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// newAppsSecretsCmd creates the `apps secrets` parent command.
+func newAppsSecretsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Manage app secret values",
+		Long: `Values are accepted via KEY=VALUE arguments (discouraged: shell history),
+--stdin (preferred), or an interactive prompt. Names must already exist in
+desired or active state. Only key names are ever echoed back — never values.`,
+	}
+	cmd.AddCommand(newAppsSecretsSetCmd(), newAppsSecretsDeleteCmd())
+	return cmd
+}
+
+// newAppsSecretsSetCmd creates `apps secrets set`.
+func newAppsSecretsSetCmd() *cobra.Command {
+	var service string
+	var fromStdin bool
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "set APP KEY=VALUE…",
+		Short: "Write app secret values",
+		Args:  cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("missing APP argument")
+			}
+			return runAppsSecretsSet(cmd.Context(), plane, os.Stdin, cmd.OutOrStdout(), args[0], args[1:], service, fromStdin, jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&service, "service", "", "Service the secrets belong to (required)")
+	cmd.Flags().BoolVar(&fromStdin, "stdin", false, "Read KEY=VALUE lines from stdin")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsSecretsSet(ctx context.Context, plane AppControlPlane, stdin io.Reader, out io.Writer, app string, pairs []string, service string, fromStdin, jsonOut bool) error {
+	if app == "" {
+		return fmt.Errorf("missing APP argument")
+	}
+	if service == "" {
+		return fmt.Errorf("missing required flag --service: secrets are service-scoped")
+	}
+	if fromStdin {
+		stdinPairs, err := readSecretStdin(stdin)
+		if err != nil {
+			return err
+		}
+		pairs = append(pairs, stdinPairs...)
+	}
+	values, err := parseSecretPairs(pairs)
+	if err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("no secrets provided: pass KEY=VALUE arguments or --stdin")
+	}
+	if err := plane.SetAppSecrets(ctx, app, dto.AppSecretSetRequest{Service: service, Secrets: values}); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if jsonOut {
+		return writeJSON(out, map[string]any{"app": app, "service": service, "keys": keys})
+	}
+	return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Set %d secret(s) for %s/%s: %s", len(keys), app, service, strings.Join(keys, ", "))))
+}
+
+// newAppsSecretsDeleteCmd creates `apps secrets delete`.
+func newAppsSecretsDeleteCmd() *cobra.Command {
+	var service string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "delete APP KEY",
+		Short: "Delete an app secret value",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppsSecretsDelete(cmd.Context(), plane, cmd.OutOrStdout(), args[0], args[1], service, jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&service, "service", "", "Service the secret belongs to (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppsSecretsDelete(ctx context.Context, plane AppControlPlane, out io.Writer, app, key, service string, jsonOut bool) error {
+	if service == "" {
+		return fmt.Errorf("missing required flag --service: secrets are service-scoped")
+	}
+	if key == "" {
+		return fmt.Errorf("missing KEY argument")
+	}
+	if err := plane.DeleteAppSecret(ctx, app, dto.AppSecretDeleteRequest{Service: service, Key: key}); err != nil {
+		return err
+	}
+	if jsonOut {
+		return writeJSON(out, map[string]any{"app": app, "service": service, "deleted": key})
+	}
+	return cliWriteLine(out, cliRenderSuccess(fmt.Sprintf("Deleted secret %s for %s/%s", key, app, service)))
+}
+
+// parseSecretPairs parses KEY=VALUE arguments. Keys must be non-empty;
+// values may be empty (explicit empty secret).
+func parseSecretPairs(pairs []string) (map[string]string, error) {
+	values := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid secret %q: expected KEY=VALUE", pair)
+		}
+		values[key] = value
+	}
+	return values, nil
+}
+
+// readSecretStdin reads KEY=VALUE lines (blank lines ignored).
+func readSecretStdin(in io.Reader) ([]string, error) {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read secrets from stdin: %w", err)
+	}
+	var pairs []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			pairs = append(pairs, trimmed)
+		}
+	}
+	return pairs, nil
+}
+
+// newAppDeployCmd creates `deploy APP`. At cutover this replaces the
+// domain-based deploy for apps; domain-based deploy keeps working for
+// non-app resources until then (05-api-cli.md §5).
+func newAppDeployCmd() *cobra.Command {
+	var revision string
+	var service string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "deploy APP",
+		Short: "Activate an app revision",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppDeploy(cmd.Context(), plane, args[0], revision, service, cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&revision, "revision", "", "Revision to activate (default: desired head)")
+	cmd.Flags().StringVar(&service, "service", "", "Deploy a single service only")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppDeploy(ctx context.Context, plane AppControlPlane, app, revision, service string, out io.Writer, jsonOut bool) error {
+	resp, key, err := plane.DeployApp(ctx, app, dto.AppDeployRequest{Revision: revision, Service: service})
+	if err != nil {
+		return appMutationError("deploy", app, key, err)
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	return renderAppDeployResponse(out, resp)
+}
+
+// newAppRestartCmd creates `restart APP`: pinned digests, no re-resolve.
+func newAppRestartCmd() *cobra.Command {
+	var service string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "restart APP",
+		Short: "Restart an app from pinned digests",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppRestart(cmd.Context(), plane, args[0], service, cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&service, "service", "", "Restart a single service only")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppRestart(ctx context.Context, plane AppControlPlane, app, service string, out io.Writer, jsonOut bool) error {
+	resp, key, err := plane.RestartApp(ctx, app, service)
+	if err != nil {
+		return appMutationError("restart", app, key, err)
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	return renderAppDeployResponse(out, resp)
+}
+
+// newAppStopCmd creates `stop APP`: durable stopped intent, data preserved.
+func newAppStopCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "stop APP",
+		Short: "Stop an app (preserves all data)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppLifecycle(cmd.Context(), plane.StopApp, "stop", args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+// newAppStartCmd creates `start APP`: clears intent, ensures running.
+func newAppStartCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "start APP",
+		Short: "Start a stopped app from active state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppLifecycle(cmd.Context(), plane.StartApp, "start", args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+// newAppRemoveCmd creates `remove APP`: withdraws workloads, retains data.
+func newAppRemoveCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "remove APP",
+		Short: "Remove app workloads (volumes and secrets are retained)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppLifecycle(cmd.Context(), plane.RemoveApp, "remove", args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+// appLifecycleFunc is one body-less app lifecycle mutation.
+type appLifecycleFunc func(ctx context.Context, app string) (*dto.AppDeployResponse, string, error)
+
+func runAppLifecycle(ctx context.Context, fn appLifecycleFunc, op, app string, out io.Writer, jsonOut bool) error {
+	resp, key, err := fn(ctx, app)
+	if err != nil {
+		return appMutationError(op, app, key, err)
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	return renderAppDeployResponse(out, resp)
+}
+
+// renderAppDeployResponse renders the deploy outcome with terminal
+// per-service results, cleanup warnings, and the effective/retained
+// summaries. Sorts services for stable output.
+func renderAppDeployResponse(out io.Writer, resp *dto.AppDeployResponse) error {
+	if err := renderDeployHeadline(out, resp); err != nil {
+		return err
+	}
+	if err := renderDeployServices(out, resp); err != nil {
+		return err
+	}
+	return renderDeploySummaries(out, resp)
+}
+
+func renderDeployHeadline(out io.Writer, resp *dto.AppDeployResponse) error {
+	headline := fmt.Sprintf("%s %s: %s", resp.Op, resp.App, resp.Outcome)
+	if resp.Outcome == "success" {
+		return cliWriteLine(out, cliRenderSuccess(headline))
+	}
+	return cliWriteLine(out, cliRenderWarning(headline))
+}
+
+func renderDeployServices(out io.Writer, resp *dto.AppDeployResponse) error {
+	names := make([]string, 0, len(resp.Services))
+	for name := range resp.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		svc := resp.Services[name]
+		detail := svc.Result + " " + svc.EffectiveRevision
+		if svc.RestartUnsafe {
+			detail += " restart_unsafe"
+		}
+		if svc.Error != "" {
+			detail += ": " + svc.Error
+		}
+		if err := cliWriteLine(out, cliRenderMeta("  "+name+":", detail)); err != nil {
+			return err
+		}
+	}
+	for _, w := range resp.CleanupWarnings {
+		if err := cliWriteLine(out, cliRenderWarning(fmt.Sprintf("cleanup: %s left %s (%s)", w.Service, w.Leftover, w.Detail))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderDeploySummaries(out io.Writer, resp *dto.AppDeployResponse) error {
+	if len(resp.Effective.Services) > 0 {
+		pairs := make([]string, 0, len(resp.Effective.Services))
+		for name, rev := range resp.Effective.Services {
+			pairs = append(pairs, name+"="+rev)
+		}
+		sort.Strings(pairs)
+		if err := cliWriteLine(out, cliRenderMeta("effective:", strings.Join(pairs, " "))); err != nil {
+			return err
+		}
+	}
+	if len(resp.Retained.Volumes) > 0 || len(resp.Retained.Secrets) > 0 {
+		retained := append(append([]string(nil), resp.Retained.Volumes...), resp.Retained.Secrets...)
+		sort.Strings(retained)
+		if err := cliWriteLine(out, cliRenderMeta("retained:", strings.Join(retained, " "))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// newAppStatusCmd creates `status APP`: effective vs observed, per service.
+func newAppStatusCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "status APP",
+		Short: "Show effective vs observed state for an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			return runAppStatus(cmd.Context(), plane, args[0], cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppStatus(ctx context.Context, plane AppControlPlane, app string, out io.Writer, jsonOut bool) error {
+	resp, err := plane.ShowApp(ctx, app)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return writeJSON(out, resp)
+	}
+	if err := cliWriteLine(out, cliRenderTitle(resp.App)); err != nil {
+		return err
+	}
+	for _, line := range renderActiveServices(resp.Active) {
+		if err := cliWriteLine(out, line); err != nil {
+			return err
+		}
+	}
+	var running []string
+	for _, svc := range resp.Active.Services {
+		if svc.Container != "" {
+			running = append(running, svc.Container)
+		}
+	}
+	sort.Strings(running)
+	observed := "none"
+	if len(running) > 0 {
+		observed = strings.Join(running, " ")
+	}
+	if err := cliWriteLine(out, cliRenderMeta("observed:", observed)); err != nil {
+		return err
+	}
+	if resp.Intent.Stopped {
+		return cliWriteLine(out, cliRenderWarning("stopped intent is set"))
+	}
+	return nil
+}
+
+// appLogReader streams container logs by container ref. At cutover the
+// service-to-container mapping comes from the active record and this is
+// backed by the daemon log transport; until then callers supply the
+// remote client's container-log methods with the recorded container id.
+type appLogReader interface {
+	GetContainerLogs(ctx context.Context, ref string, lines int) ([]string, error)
+	StreamContainerLogs(ctx context.Context, ref string, lines int) (<-chan string, error)
+}
+
+// remoteAppLogReader adapts *remote.Client to appLogReader.
+type remoteAppLogReader struct {
+	client *remote.Client
+}
+
+func (r *remoteAppLogReader) GetContainerLogs(ctx context.Context, ref string, lines int) ([]string, error) {
+	return r.client.GetContainerLogs(ctx, ref, lines)
+}
+
+func (r *remoteAppLogReader) StreamContainerLogs(ctx context.Context, ref string, lines int) (<-chan string, error) {
+	return r.client.StreamContainerLogs(ctx, ref, lines)
+}
+
+// newAppLogsCmd creates `logs APP`.
+func newAppLogsCmd() *cobra.Command {
+	var service string
+	var follow bool
+	var tail int
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "logs APP",
+		Short: "Show logs for an app service",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plane, err := resolveAppControlPlane()
+			if err != nil {
+				return err
+			}
+			client, isRemote, err := GetRemoteClient()
+			if err != nil {
+				return err
+			}
+			if !isRemote {
+				return fmt.Errorf("daemon-unavailable: app logs stream from the daemon")
+			}
+			return runAppLogs(cmd.Context(), plane, &remoteAppLogReader{client: client}, args[0], service, follow, tail, cmd.OutOrStdout(), jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&service, "service", "", "Service to read logs from (required when the app has several)")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
+	cmd.Flags().IntVarP(&tail, "tail", "n", 50, "Number of lines to show")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runAppLogs(ctx context.Context, plane AppControlPlane, reader appLogReader, app, service string, follow bool, tail int, out io.Writer, jsonOut bool) error {
+	show, err := plane.ShowApp(ctx, app)
+	if err != nil {
+		return err
+	}
+	ref, err := appLogRef(show, service)
+	if err != nil {
+		return err
+	}
+	if follow {
+		stream, err := reader.StreamContainerLogs(ctx, ref, tail)
+		if err != nil {
+			return err
+		}
+		for line := range stream {
+			if err := cliWriteLine(out, line); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	lines, err := reader.GetContainerLogs(ctx, ref, tail)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return writeJSON(out, map[string]any{"app": app, "service": service, "lines": lines})
+	}
+	for _, line := range lines {
+		if err := cliWriteLine(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// appLogRef resolves the container ref for one app service. When service
+// is empty and the app has exactly one service, that service is used;
+// otherwise --service is required. A service with no recorded container
+// has nothing to stream yet.
+func appLogRef(show *dto.AppShowResponse, service string) (string, error) {
+	if service == "" {
+		if len(show.Active.Services) == 1 {
+			for name := range show.Active.Services {
+				service = name
+			}
+		} else {
+			names := make([]string, 0, len(show.Active.Services))
+			for name := range show.Active.Services {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			return "", fmt.Errorf("app %s has several services (%s): pass --service", show.App, strings.Join(names, ", "))
+		}
+	}
+	svc, ok := show.Active.Services[service]
+	if !ok {
+		return "", fmt.Errorf("app %s has no service %q", show.App, service)
+	}
+	if svc.Container == "" {
+		return "", fmt.Errorf("service %s has no recorded container yet", service)
+	}
+	return svc.Container, nil
+}

--- a/internal/adapters/in/cli/apps_test.go
+++ b/internal/adapters/in/cli/apps_test.go
@@ -1,0 +1,494 @@
+package cli
+
+// Tests for the unreachable v2.50 app CLI surface (apps.go). The commands
+// are not registered in root.go until cutover; these tests exercise the
+// run functions directly against a scripted AppControlPlane fake: JSON
+// parity (text and --json carry equivalent semantics), no secret values in
+// output, plan-contract errors, and outcome-unknown guidance.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+	"github.com/bnema/gordon/internal/adapters/in/cli/remote"
+)
+
+// fakeAppPlane scripts AppControlPlane responses for CLI tests.
+type fakeAppPlane struct {
+	applyResp   *dto.AppApplyResponse
+	applyErr    error
+	listResp    []dto.AppSummaryDTO
+	showResp    *dto.AppShowResponse
+	diffResp    *dto.AppDiffResponse
+	deployResp  *dto.AppDeployResponse
+	deployKey   string
+	deployErr   error
+	lifecycleFn func(ctx context.Context, app string) (*dto.AppDeployResponse, string, error)
+	setErr      error
+	setGot      dto.AppSecretSetRequest
+	setGotApp   string
+	deleteErr   error
+}
+
+func (f *fakeAppPlane) ApplyApp(_ context.Context, _ dto.AppApplyRequest) (*dto.AppApplyResponse, error) {
+	if f.applyErr != nil {
+		return nil, f.applyErr
+	}
+	return f.applyResp, nil
+}
+
+func (f *fakeAppPlane) ListApps(_ context.Context) ([]dto.AppSummaryDTO, error) {
+	return f.listResp, nil
+}
+
+func (f *fakeAppPlane) ShowApp(_ context.Context, _ string) (*dto.AppShowResponse, error) {
+	return f.showResp, nil
+}
+
+func (f *fakeAppPlane) DiffApp(_ context.Context, _ string) (*dto.AppDiffResponse, error) {
+	return f.diffResp, nil
+}
+
+func (f *fakeAppPlane) DeployApp(_ context.Context, _ string, _ dto.AppDeployRequest) (*dto.AppDeployResponse, string, error) {
+	return f.deployResp, f.deployKey, f.deployErr
+}
+
+func (f *fakeAppPlane) StopApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return f.lifecycleFn(ctx, app)
+}
+
+func (f *fakeAppPlane) StartApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return f.lifecycleFn(ctx, app)
+}
+
+func (f *fakeAppPlane) RestartApp(_ context.Context, _ string, _ string) (*dto.AppDeployResponse, string, error) {
+	return f.deployResp, f.deployKey, f.deployErr
+}
+
+func (f *fakeAppPlane) RemoveApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return f.lifecycleFn(ctx, app)
+}
+
+func (f *fakeAppPlane) OperationByKey(_ context.Context, _, _ string) (*dto.AppDeployResponse, error) {
+	return f.deployResp, f.deployErr
+}
+
+func (f *fakeAppPlane) SetAppSecrets(_ context.Context, app string, req dto.AppSecretSetRequest) error {
+	f.setGotApp = app
+	f.setGot = req
+	return f.setErr
+}
+
+func (f *fakeAppPlane) DeleteAppSecret(_ context.Context, _ string, _ dto.AppSecretDeleteRequest) error {
+	return f.deleteErr
+}
+
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "app.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestRunAppsApply_RejectsDryRunWithDeploy(t *testing.T) {
+	plane := &fakeAppPlane{}
+	err := runAppsApply(context.Background(), plane, strings.NewReader(""), &bytes.Buffer{}, "x.toml", true, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--dry-run")
+	assert.Contains(t, err.Error(), "--deploy")
+}
+
+func TestRunAppsApply_RequiresFile(t *testing.T) {
+	plane := &fakeAppPlane{}
+	err := runAppsApply(context.Background(), plane, strings.NewReader(""), &bytes.Buffer{}, "", false, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--file")
+}
+
+func TestRunAppsApply_JSONParity(t *testing.T) {
+	want := &dto.AppApplyResponse{
+		App: "blog", FormerRevision: "rev-a", ResultingRevision: "rev-b",
+		Pending: true, Intent: "apply-123",
+		Diff: dto.AppDiffSection{Added: []string{"service.web"}},
+	}
+	plane := &fakeAppPlane{applyResp: want}
+	var out bytes.Buffer
+	require.NoError(t, runAppsApply(context.Background(), plane, strings.NewReader(""), &out,
+		writeManifest(t, "[app]\nname = \"blog\"\n"), false, false, true))
+	var got dto.AppApplyResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, *want, got)
+}
+
+func TestRunAppsApply_ChainsAcceptedRevision(t *testing.T) {
+	plane := &fakeAppPlane{
+		applyResp:  &dto.AppApplyResponse{App: "blog", ResultingRevision: "rev-b", Pending: true, Intent: "apply-1"},
+		deployResp: &dto.AppDeployResponse{Op: "op-1", App: "blog", Revision: "rev-b", Outcome: "success"},
+	}
+	var out bytes.Buffer
+	require.NoError(t, runAppsApply(context.Background(), plane, strings.NewReader(""), &out,
+		writeManifest(t, "x"), false, true, false))
+	assert.Contains(t, out.String(), "rev-b")
+}
+
+func TestRunAppsList_JSONParityAndSorting(t *testing.T) {
+	plane := &fakeAppPlane{listResp: []dto.AppSummaryDTO{
+		{App: "zeta", Converged: true},
+		{App: "alpha", Stopped: true},
+	}}
+	var out bytes.Buffer
+	require.NoError(t, runAppsList(context.Background(), plane, &out, true))
+	var got []dto.AppSummaryDTO
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got, 2)
+
+	out.Reset()
+	require.NoError(t, runAppsList(context.Background(), plane, &out, false))
+	text := out.String()
+	assert.Less(t, strings.Index(text, "alpha"), strings.Index(text, "zeta"), "text lists apps sorted")
+	assert.Contains(t, text, "stopped")
+}
+
+func TestRunAppsList_EmptyJSONIsArray(t *testing.T) {
+	plane := &fakeAppPlane{}
+	var out bytes.Buffer
+	require.NoError(t, runAppsList(context.Background(), plane, &out, true))
+	assert.JSONEq(t, `[]`, strings.TrimSpace(out.String()))
+}
+
+func TestRunAppsShow_JSONParity(t *testing.T) {
+	want := &dto.AppShowResponse{
+		App:     "blog",
+		Desired: dto.AppDesiredDTO{Revision: "rev-b", Status: "pending"},
+		Active: dto.AppActiveDTO{Converged: false, Services: map[string]dto.AppActiveServiceDTO{
+			"web": {EffectiveRevision: "rev-a", Container: "ctr-a", RestartUnsafe: true},
+		}},
+		Intent: dto.AppIntentDTO{Stopped: true},
+		LastOp: dto.AppLastOpDTO{Op: "op-9", Outcome: "failed"},
+	}
+	plane := &fakeAppPlane{showResp: want}
+	var out bytes.Buffer
+	require.NoError(t, runAppsShow(context.Background(), plane, "blog", &out, true))
+	var got dto.AppShowResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, *want, got)
+
+	out.Reset()
+	require.NoError(t, runAppsShow(context.Background(), plane, "blog", &out, false))
+	assert.Contains(t, out.String(), "restart_unsafe", "text shows WHY recovery is blocked")
+}
+
+func TestRunAppsSecretsSet_NeverEchoesValues(t *testing.T) {
+	plane := &fakeAppPlane{}
+	var out bytes.Buffer
+	require.NoError(t, runAppsSecretsSet(context.Background(), plane, strings.NewReader(""),
+		&out, "blog", []string{"password=s3cr3t-hunter2", "token=abc"}, "web", false, false))
+	text := out.String()
+	assert.NotContains(t, text, "s3cr3t-hunter2")
+	assert.NotContains(t, text, "abc")
+	assert.Contains(t, text, "password")
+	assert.Contains(t, text, "token")
+	assert.Equal(t, "blog", plane.setGotApp)
+	assert.Equal(t, "web", plane.setGot.Service)
+	assert.Equal(t, map[string]string{"password": "s3cr3t-hunter2", "token": "abc"}, plane.setGot.Secrets)
+}
+
+func TestRunAppsSecretsSet_RequiresService(t *testing.T) {
+	plane := &fakeAppPlane{}
+	err := runAppsSecretsSet(context.Background(), plane, strings.NewReader(""),
+		&bytes.Buffer{}, "blog", []string{"k=v"}, "", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--service")
+}
+
+func TestRunAppsSecretsSet_StdinAndValidation(t *testing.T) {
+	plane := &fakeAppPlane{}
+	var out bytes.Buffer
+	stdin := strings.NewReader("from_stdin=stdin-value\n\nempty_val=\n")
+	require.NoError(t, runAppsSecretsSet(context.Background(), plane, stdin,
+		&out, "blog", []string{"from_flag=flag-value"}, "web", true, false))
+	assert.Equal(t, map[string]string{
+		"from_stdin": "stdin-value",
+		"empty_val":  "",
+		"from_flag":  "flag-value",
+	}, plane.setGot.Secrets)
+
+	err := runAppsSecretsSet(context.Background(), plane, strings.NewReader(""),
+		&bytes.Buffer{}, "blog", []string{"no-equals-here"}, "web", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KEY=VALUE")
+}
+
+func TestRunAppDeploy_OutcomeUnknownMentionsKey(t *testing.T) {
+	plane := &fakeAppPlane{
+		deployKey: "key-abc",
+		deployErr: &remote.OutcomeUnknownError{Method: "POST", Path: "/apps/blog/deploy", Err: errors.New("boom")},
+	}
+	err := runAppDeploy(context.Background(), plane, "blog", "", "", &bytes.Buffer{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outcome-unknown")
+	assert.Contains(t, err.Error(), "key-abc")
+	assert.Contains(t, err.Error(), "by-key")
+}
+
+func TestRenderAppDeployResponse_SortedServices(t *testing.T) {
+	resp := &dto.AppDeployResponse{
+		Op: "op-1", App: "blog", Outcome: "partial",
+		Services: map[string]dto.AppServiceResultDTO{
+			"web": {Result: "deployed", EffectiveRevision: "rev-b"},
+			"db":  {Result: "failed", EffectiveRevision: "rev-a", Error: "nope", RestartUnsafe: true},
+		},
+		CleanupWarnings: []dto.AppCleanupWarningDTO{{Service: "web", Leftover: "ctr-old", Detail: "retire failed"}},
+		Effective:       dto.AppEffectiveDTO{Services: map[string]string{"web": "rev-b", "db": "rev-a"}},
+		Retained:        dto.AppRetainedDTO{Volumes: []string{"blog-db"}},
+	}
+	var out bytes.Buffer
+	require.NoError(t, renderAppDeployResponse(&out, resp))
+	text := out.String()
+	assert.Less(t, strings.Index(text, "db:"), strings.Index(text, "web:"))
+	assert.Contains(t, text, "restart_unsafe")
+	assert.Contains(t, text, "cleanup:")
+	assert.Contains(t, text, "blog-db")
+}
+
+func TestAppLogRef_Selection(t *testing.T) {
+	multi := &dto.AppShowResponse{App: "blog", Active: dto.AppActiveDTO{Services: map[string]dto.AppActiveServiceDTO{
+		"web": {Container: "ctr-web"},
+		"db":  {Container: "ctr-db"},
+	}}}
+	_, err := appLogRef(multi, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--service")
+
+	ref, err := appLogRef(multi, "db")
+	require.NoError(t, err)
+	assert.Equal(t, "ctr-db", ref)
+
+	_, err = appLogRef(multi, "missing")
+	require.Error(t, err)
+
+	single := &dto.AppShowResponse{App: "solo", Active: dto.AppActiveDTO{Services: map[string]dto.AppActiveServiceDTO{
+		"web": {Container: "ctr-solo"},
+	}}}
+	ref, err = appLogRef(single, "")
+	require.NoError(t, err)
+	assert.Equal(t, "ctr-solo", ref)
+
+	empty := &dto.AppShowResponse{App: "new", Active: dto.AppActiveDTO{Services: map[string]dto.AppActiveServiceDTO{
+		"web": {},
+	}}}
+	_, err = appLogRef(empty, "web")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no recorded container")
+}
+
+func TestResolveAppControlPlane_FailsWithoutDaemon(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("GORDON_REMOTE", "")
+	t.Setenv("GORDON_TOKEN", "")
+	origRemote, origToken, origInsecure := remoteFlag, tokenFlag, insecureTLSFlag
+	t.Cleanup(func() { remoteFlag, tokenFlag, insecureTLSFlag = origRemote, origToken, origInsecure })
+	remoteFlag, tokenFlag, insecureTLSFlag = "", "", false
+
+	_, err := resolveAppControlPlane()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon-unavailable")
+}
+
+// TestAppCommandSurface pins the frozen CLI surface (05-api-cli.md §5):
+// every command exists with its frozen Use string and flags. The commands
+// stay unregistered until cutover; this test is what keeps them referenced.
+func TestAppCommandSurface(t *testing.T) {
+	root := newAppsCmd()
+	require.Equal(t, "apps", root.Use)
+	subs := map[string]bool{}
+	for _, sub := range root.Commands() {
+		subs[sub.Name()] = true
+	}
+	for _, name := range []string{"apply", "list", "show", "diff", "secrets"} {
+		assert.True(t, subs[name], "apps subcommand %s", name)
+	}
+
+	secrets := newAppsSecretsCmd()
+	secretSubs := map[string]bool{}
+	for _, sub := range secrets.Commands() {
+		secretSubs[sub.Name()] = true
+	}
+	assert.True(t, secretSubs["set"])
+	assert.True(t, secretSubs["delete"])
+
+	flagged := map[*cobra.Command][]string{
+		newAppsApplyCmd():         {"file", "dry-run", "deploy", "json"},
+		newAppsListCmd():          {"json"},
+		newAppsShowCmd():          {"json"},
+		newAppsDiffCmd():          {"json"},
+		newAppsSecretsSetCmd():    {"service", "stdin", "json"},
+		newAppsSecretsDeleteCmd(): {"service", "json"},
+		newAppDeployCmd():         {"revision", "service", "json"},
+		newAppRestartCmd():        {"service", "json"},
+		newAppStopCmd():           {"json"},
+		newAppStartCmd():          {"json"},
+		newAppRemoveCmd():         {"json"},
+		newAppStatusCmd():         {"json"},
+		newAppLogsCmd():           {"service", "follow", "tail", "json"},
+	}
+	for cmd, flags := range flagged {
+		for _, flag := range flags {
+			assert.NotNil(t, cmd.Flags().Lookup(flag), "%s must define --%s", cmd.Use, flag)
+		}
+	}
+
+	assert.Equal(t, "deploy APP", newAppDeployCmd().Use)
+	assert.Equal(t, "restart APP", newAppRestartCmd().Use)
+	assert.Equal(t, "stop APP", newAppStopCmd().Use)
+	assert.Equal(t, "start APP", newAppStartCmd().Use)
+	assert.Equal(t, "remove APP", newAppRemoveCmd().Use)
+	assert.Equal(t, "status APP", newAppStatusCmd().Use)
+	assert.Equal(t, "logs APP", newAppLogsCmd().Use)
+}
+
+func TestRunAppsDiff_TextAndJSON(t *testing.T) {
+	plane := &fakeAppPlane{diffResp: &dto.AppDiffResponse{
+		App:  "blog",
+		Diff: dto.AppDiffSection{Added: []string{"b"}, Removed: []string{"a"}, Changed: []string{"c"}},
+	}}
+	var out bytes.Buffer
+	require.NoError(t, runAppsDiff(context.Background(), plane, "blog", &out, false))
+	text := out.String()
+	assert.Contains(t, text, "added:")
+	assert.Contains(t, text, "removed:")
+	assert.Contains(t, text, "changed:")
+
+	out.Reset()
+	require.NoError(t, runAppsDiff(context.Background(), plane, "blog", &out, true))
+	var got dto.AppDiffResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, *plane.diffResp, got)
+
+	plane.diffResp = &dto.AppDiffResponse{App: "blog"}
+	out.Reset()
+	require.NoError(t, runAppsDiff(context.Background(), plane, "blog", &out, false))
+	assert.Contains(t, out.String(), "No differences")
+}
+
+func TestRunAppsSecretsDelete(t *testing.T) {
+	plane := &fakeAppPlane{}
+	var out bytes.Buffer
+	require.NoError(t, runAppsSecretsDelete(context.Background(), plane, &out, "blog", "password", "web", false))
+	assert.Contains(t, out.String(), "password")
+
+	out.Reset()
+	require.NoError(t, runAppsSecretsDelete(context.Background(), plane, &out, "blog", "password", "web", true))
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "password", got["deleted"])
+
+	err := runAppsSecretsDelete(context.Background(), plane, &bytes.Buffer{}, "blog", "password", "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--service")
+}
+
+func TestRunAppRestart_AndLifecycle(t *testing.T) {
+	resp := &dto.AppDeployResponse{Op: "op-2", App: "blog", Revision: "rev-b", Outcome: "success"}
+	plane := &fakeAppPlane{
+		deployResp: resp,
+		lifecycleFn: func(_ context.Context, app string) (*dto.AppDeployResponse, string, error) {
+			assert.Equal(t, "blog", app)
+			return resp, "key-lc", nil
+		},
+	}
+	var out bytes.Buffer
+	require.NoError(t, runAppRestart(context.Background(), plane, "blog", "", &out, false))
+	assert.Contains(t, out.String(), "success")
+
+	out.Reset()
+	require.NoError(t, runAppRestart(context.Background(), plane, "blog", "", &out, true))
+	var got dto.AppDeployResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, *resp, got)
+
+	for _, fn := range []appLifecycleFunc{plane.StopApp, plane.StartApp, plane.RemoveApp} {
+		out.Reset()
+		require.NoError(t, runAppLifecycle(context.Background(), fn, "stop", "blog", &out, false))
+		assert.Contains(t, out.String(), "op-2")
+	}
+
+	unknown := &fakeAppPlane{
+		lifecycleFn: func(_ context.Context, _ string) (*dto.AppDeployResponse, string, error) {
+			return nil, "key-x", &remote.OutcomeUnknownError{Method: "POST", Path: "/x", Err: errors.New("boom")}
+		},
+	}
+	err := runAppLifecycle(context.Background(), unknown.StopApp, "stop", "blog", &bytes.Buffer{}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key-x")
+}
+
+func TestRunAppStatus_Observed(t *testing.T) {
+	plane := &fakeAppPlane{showResp: &dto.AppShowResponse{
+		App: "blog",
+		Active: dto.AppActiveDTO{Converged: true, Services: map[string]dto.AppActiveServiceDTO{
+			"web": {EffectiveRevision: "rev-b", Container: "ctr-b"},
+		}},
+	}}
+	var out bytes.Buffer
+	require.NoError(t, runAppStatus(context.Background(), plane, "blog", &out, false))
+	assert.Contains(t, out.String(), "ctr-b")
+
+	out.Reset()
+	require.NoError(t, runAppStatus(context.Background(), plane, "blog", &out, true))
+	var got dto.AppShowResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, *plane.showResp, got)
+}
+
+// fakeAppLogReader scripts container log reads for app log tests.
+type fakeAppLogReader struct {
+	lines  []string
+	stream []string
+}
+
+func (f *fakeAppLogReader) GetContainerLogs(_ context.Context, _ string, _ int) ([]string, error) {
+	return f.lines, nil
+}
+
+func (f *fakeAppLogReader) StreamContainerLogs(_ context.Context, _ string, _ int) (<-chan string, error) {
+	ch := make(chan string, len(f.stream))
+	for _, line := range f.stream {
+		ch <- line
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunAppLogs_TextJSONFollow(t *testing.T) {
+	show := &dto.AppShowResponse{App: "blog", Active: dto.AppActiveDTO{Services: map[string]dto.AppActiveServiceDTO{
+		"web": {Container: "ctr-web"},
+	}}}
+	plane := &fakeAppPlane{showResp: show}
+	reader := &fakeAppLogReader{lines: []string{"l1", "l2"}, stream: []string{"s1"}}
+
+	var out bytes.Buffer
+	require.NoError(t, runAppLogs(context.Background(), plane, reader, "blog", "", false, 50, &out, false))
+	assert.Equal(t, "l1\nl2\n", out.String())
+
+	out.Reset()
+	require.NoError(t, runAppLogs(context.Background(), plane, reader, "blog", "web", false, 50, &out, true))
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "blog", got["app"])
+
+	out.Reset()
+	require.NoError(t, runAppLogs(context.Background(), plane, reader, "blog", "web", true, 50, &out, false))
+	assert.Equal(t, "s1\n", out.String())
+}

--- a/internal/adapters/in/cli/remote/apps.go
+++ b/internal/adapters/in/cli/remote/apps.go
@@ -1,0 +1,235 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+)
+
+// Apps API: daemon-owned app mutations through the existing V2
+// administration transport. Every mutation carries an Idempotency-Key
+// header (client-generated ULID); the daemon persists the claim before
+// effects and replays recorded results. On ambiguous transport outcome
+// the caller gets OutcomeUnknownError and must re-query by key — never
+// blindly retry.
+
+// newIdempotencyKey allocates a time-ordered key (uuid v7).
+func newIdempotencyKey() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		id = uuid.New()
+	}
+	var buf [32]byte
+	hex.Encode(buf[:], id[:])
+	return string(buf[:])
+}
+
+// mutationPost sends a POST mutation with an idempotency key.
+func (c *Client) mutationPost(ctx context.Context, path string, key string, body any) (*http.Response, error) {
+	var jsonBody []byte
+	if body != nil {
+		var err error
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+	}
+	return c.doMutation(ctx, http.MethodPost, path, key, jsonBody)
+}
+
+// doMutation executes one mutation request with the idempotency header.
+// Transport ambiguity surfaces as OutcomeUnknownError: the caller must
+// re-query GET …/operations/by-key/{key} before any retry, and retries
+// reuse the SAME key.
+func (c *Client) doMutation(ctx context.Context, method, path, key string, jsonBody []byte) (*http.Response, error) {
+	reqURL := c.baseURL + "/admin" + path
+
+	var bodyReader io.Reader
+	if jsonBody != nil {
+		bodyReader = bytes.NewReader(jsonBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Idempotency-Key", key)
+
+	bearer, err := c.bearerToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, &OutcomeUnknownError{Method: method, Path: path, Err: err}
+	}
+	if isRetryableStatus(resp.StatusCode) {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		_ = resp.Body.Close()
+		return nil, &OutcomeUnknownError{
+			Method: method,
+			Path:   path,
+			Err:    parseErrorResponse(resp, body),
+		}
+	}
+	return resp, nil
+}
+
+// ApplyApp validates and persists desired state (or dry-runs).
+func (c *Client) ApplyApp(ctx context.Context, req dto.AppApplyRequest) (*dto.AppApplyResponse, error) {
+	resp, err := c.mutationPost(ctx, "/apps/apply", newIdempotencyKey(), req)
+	if err != nil {
+		return nil, err
+	}
+	var result dto.AppApplyResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, fmt.Errorf("apply app: %w", err)
+	}
+	return &result, nil
+}
+
+// ListApps returns desired+active summaries.
+func (c *Client) ListApps(ctx context.Context) ([]dto.AppSummaryDTO, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/apps", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result []dto.AppSummaryDTO
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, fmt.Errorf("list apps: %w", err)
+	}
+	return result, nil
+}
+
+// ShowApp inspects desired + active + intent + op ref.
+func (c *Client) ShowApp(ctx context.Context, app string) (*dto.AppShowResponse, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/apps/"+url.PathEscape(app), nil)
+	if err != nil {
+		return nil, err
+	}
+	var result dto.AppShowResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, fmt.Errorf("show app %s: %w", app, err)
+	}
+	return &result, nil
+}
+
+// DiffApp returns the normalized desired-vs-active diff.
+func (c *Client) DiffApp(ctx context.Context, app string) (*dto.AppDiffResponse, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/apps/"+url.PathEscape(app)+"/diff", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result dto.AppDiffResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, fmt.Errorf("diff app %s: %w", app, err)
+	}
+	return &result, nil
+}
+
+// DeployApp activates a captured revision. It returns the key used so
+// ambiguous outcomes can be recovered via OperationByKey.
+func (c *Client) DeployApp(ctx context.Context, app string, req dto.AppDeployRequest) (*dto.AppDeployResponse, string, error) {
+	key := newIdempotencyKey()
+	resp, err := c.mutationPost(ctx, "/apps/"+url.PathEscape(app)+"/deploy", key, req)
+	if err != nil {
+		return nil, key, err
+	}
+	var result dto.AppDeployResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, key, fmt.Errorf("deploy app %s: %w", app, err)
+	}
+	return &result, key, nil
+}
+
+// StopApp persists durable stopped intent and stops exact containers.
+func (c *Client) StopApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return c.lifecyclePost(ctx, app, "stop")
+}
+
+// StartApp clears stopped intent and ensures running from active.
+func (c *Client) StartApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return c.lifecyclePost(ctx, app, "start")
+}
+
+// RestartApp restarts from pinned digests (no re-resolution).
+func (c *Client) RestartApp(ctx context.Context, app, service string) (*dto.AppDeployResponse, string, error) {
+	key := newIdempotencyKey()
+	path := "/apps/" + url.PathEscape(app) + "/restart"
+	if service != "" {
+		path += "?service=" + url.QueryEscape(service)
+	}
+	resp, err := c.doMutation(ctx, http.MethodPost, path, key, nil)
+	if err != nil {
+		return nil, key, err
+	}
+	var result dto.AppDeployResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, key, fmt.Errorf("restart app %s: %w", app, err)
+	}
+	return &result, key, nil
+}
+
+// RemoveApp withdraws workloads; volumes and secrets are retained.
+func (c *Client) RemoveApp(ctx context.Context, app string) (*dto.AppDeployResponse, string, error) {
+	return c.lifecyclePost(ctx, app, "remove")
+}
+
+// lifecyclePost posts a body-less lifecycle mutation.
+func (c *Client) lifecyclePost(ctx context.Context, app, action string) (*dto.AppDeployResponse, string, error) {
+	key := newIdempotencyKey()
+	resp, err := c.doMutation(ctx, http.MethodPost, "/apps/"+url.PathEscape(app)+"/"+action, key, nil)
+	if err != nil {
+		return nil, key, err
+	}
+	var result dto.AppDeployResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, key, fmt.Errorf("%s app %s: %w", action, app, err)
+	}
+	return &result, key, nil
+}
+
+// OperationByKey recovers an ambiguous mutation outcome by idempotency key.
+func (c *Client) OperationByKey(ctx context.Context, app, key string) (*dto.AppDeployResponse, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/apps/"+url.PathEscape(app)+"/operations/by-key/"+url.PathEscape(key), nil)
+	if err != nil {
+		return nil, err
+	}
+	var result dto.AppDeployResponse
+	if err := parseResponse(resp, &result); err != nil {
+		return nil, fmt.Errorf("operation by key: %w", err)
+	}
+	return &result, nil
+}
+
+// SetAppSecrets writes secret values for pre-registered names.
+func (c *Client) SetAppSecrets(ctx context.Context, app string, req dto.AppSecretSetRequest) error {
+	resp, err := c.mutationPost(ctx, "/apps/"+url.PathEscape(app)+"/secrets/set", newIdempotencyKey(), req)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}
+
+// DeleteAppSecret removes one secret value (refused when referenced).
+func (c *Client) DeleteAppSecret(ctx context.Context, app string, req dto.AppSecretDeleteRequest) error {
+	resp, err := c.mutationPost(ctx, "/apps/"+url.PathEscape(app)+"/secrets/delete", newIdempotencyKey(), req)
+	if err != nil {
+		return err
+	}
+	return parseResponse(resp, nil)
+}

--- a/internal/adapters/in/cli/remote/apps_test.go
+++ b/internal/adapters/in/cli/remote/apps_test.go
@@ -1,0 +1,106 @@
+package remote
+
+// Tests for the v2.50 app mutation transport (apps.go): every mutation
+// carries a client-generated Idempotency-Key, retryable gateway statuses
+// surface OutcomeUnknownError without replaying the mutation, and
+// ambiguous outcomes recover via the by-key endpoint.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/adapters/dto"
+)
+
+func TestClientApplyApp_SendsIdempotencyKey(t *testing.T) {
+	var gotKey string
+	var gotBody dto.AppApplyRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/admin/apps/apply", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		gotKey = r.Header.Get("Idempotency-Key")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(dto.AppApplyResponse{
+			App: "blog", ResultingRevision: "rev-b", Pending: true, Intent: "apply-1",
+		})
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL).ApplyApp(context.Background(), dto.AppApplyRequest{ManifestTOML: "x"})
+	require.NoError(t, err)
+	assert.Equal(t, "blog", resp.App)
+	assert.NotEmpty(t, gotKey, "mutations must carry an Idempotency-Key")
+	assert.Equal(t, "x", gotBody.ManifestTOML)
+}
+
+func TestClientDeployApp_GatewayErrorIsOutcomeUnknownWithoutReplay(t *testing.T) {
+	var mutations int32
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/admin/apps/blog/deploy", r.URL.Path)
+		atomic.AddInt32(&mutations, 1)
+		gotKey = r.Header.Get("Idempotency-Key")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"upstream unavailable"}`))
+	}))
+	defer srv.Close()
+
+	resp, key, err := NewClient(srv.URL).DeployApp(context.Background(), "blog", dto.AppDeployRequest{})
+	require.Nil(t, resp)
+	require.Error(t, err)
+	var unknown *OutcomeUnknownError
+	require.ErrorAs(t, err, &unknown)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&mutations), "mutations must never replay on ambiguity")
+	assert.NotEmpty(t, key)
+	assert.Equal(t, gotKey, key, "recovery re-queries with the SAME key")
+}
+
+func TestClientOperationByKey_RecoveryPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(dto.AppDeployResponse{
+			Op: "op-1", App: "blog", Revision: "rev-b", Outcome: "success",
+		})
+	}))
+	defer srv.Close()
+
+	resp, err := NewClient(srv.URL).OperationByKey(context.Background(), "blog", "key-abc")
+	require.NoError(t, err)
+	assert.Equal(t, "op-1", resp.Op)
+	assert.Equal(t, "/admin/apps/blog/operations/by-key/key-abc", gotPath)
+}
+
+func TestClientLifecycle_MutationsCarryKeys(t *testing.T) {
+	var keys []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		keys = append(keys, r.Header.Get("Idempotency-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(dto.AppDeployResponse{Op: "op-x", Outcome: "success"})
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	ctx := context.Background()
+	_, _, err := client.StopApp(ctx, "blog")
+	require.NoError(t, err)
+	_, _, err = client.StartApp(ctx, "blog")
+	require.NoError(t, err)
+	_, _, err = client.RemoveApp(ctx, "blog")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+	for _, key := range keys {
+		assert.NotEmpty(t, key)
+	}
+	assert.NotEqual(t, keys[0], keys[1], "each mutation gets a fresh key")
+}

--- a/internal/boundaries/in/apps.go
+++ b/internal/boundaries/in/apps.go
@@ -1,0 +1,119 @@
+package in
+
+import (
+	"context"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// AppService is the driving port for the v2.50 app lifecycle.
+// Frozen operation set by docs/plans/v2.50.0/05-api-cli.md §2/§5:
+// apply + reads (list/show/diff), lifecycle verbs
+// (deploy/stop/start/restart/remove), op recovery by idempotency key,
+// and service-scoped secret value writes.
+//
+// The port owns its view structs and speaks domain types only — never
+// adapter DTOs. Secret VALUES cross SetSecrets by necessity (that is the
+// write path); every other method carries names, digests, and ids only.
+//
+// This is preparation: the interface is frozen here, unreachable.
+// The admin handler and the service implementation wire in at cutover;
+// until then no caller exists.
+type AppService interface {
+	// Apply validates a manifest spec and persists it as desired state,
+	// or validates without persistence when dryRun is set. source is the
+	// raw manifest bytes (hashed for audit, never re-read).
+	Apply(ctx context.Context, spec domain.AppSpec, source []byte, sourceName string, dryRun bool) (*AppApplyResult, *AppDryRunResult, error)
+
+	// List returns one summary per known app.
+	List(ctx context.Context) ([]AppSummary, error)
+
+	// Show inspects desired + active + intent + last op for one app.
+	Show(ctx context.Context, app string) (*AppDetail, error)
+
+	// Diff returns the normalized desired-vs-active diff for one app.
+	Diff(ctx context.Context, app string) (domain.AppDiff, error)
+
+	// Deploy activates a captured revision (empty revision means the
+	// desired head; empty service means all services).
+	Deploy(ctx context.Context, app, revision, service string) (*domain.AppOperation, error)
+
+	// Stop persists the durable stopped intent and stops exact containers.
+	Stop(ctx context.Context, app string) (*domain.AppOperation, error)
+
+	// Start clears the stopped intent and ensures running from active.
+	Start(ctx context.Context, app string) (*domain.AppOperation, error)
+
+	// Restart restarts from pinned digests without re-resolution.
+	// Empty service means all services.
+	Restart(ctx context.Context, app, service string) (*domain.AppOperation, error)
+
+	// Remove withdraws workloads; volumes and secrets are retained as
+	// owned orphans and the name stays reserved.
+	Remove(ctx context.Context, app string) (*domain.AppOperation, error)
+
+	// OperationByKey recovers an ambiguous mutation outcome by the
+	// client-supplied idempotency key.
+	OperationByKey(ctx context.Context, app, key string) (*domain.AppOperation, error)
+
+	// SetSecrets writes secret values for pre-registered names in one
+	// service. service is required; every key must already exist in
+	// desired or active state.
+	SetSecrets(ctx context.Context, app, service string, values map[string]string) error
+
+	// DeleteSecret removes one secret value. Refused when referenced.
+	DeleteSecret(ctx context.Context, app, service, key string) error
+}
+
+// AppApplyResult describes one accepted (or no-op) apply.
+type AppApplyResult struct {
+	App               string
+	FormerRevision    string
+	ResultingRevision string
+	Noop              bool
+	Pending           bool
+	Diff              domain.AppDiff
+	Warnings          []string
+	IntentID          string
+}
+
+// AppDryRunResult describes validation without persistence.
+// The resulting revision is a preview only and is never stored.
+type AppDryRunResult struct {
+	App      string
+	Valid    bool
+	Diff     domain.AppDiff
+	Warnings []string
+	Occupied []string
+}
+
+// AppSummary is one row of the app list: names and revisions only.
+type AppSummary struct {
+	App       string
+	Desired   string
+	Active    string
+	Converged bool
+	Stopped   bool
+}
+
+// AppServiceView is one service's effective state for inspection.
+// Digest and container are ids, never secret values.
+type AppServiceView struct {
+	EffectiveRevision string
+	Digest            string
+	Container         string
+	RestartUnsafe     bool
+}
+
+// AppDetail inspects desired + active + intent + last op for one app.
+type AppDetail struct {
+	App               string
+	DesiredRevision   string
+	DesiredStatus     string
+	Converged         bool
+	ConvergedRevision string
+	Services          map[string]AppServiceView
+	Stopped           bool
+	LastOp            string
+	LastOutcome       string
+}

--- a/internal/domain/auth.go
+++ b/internal/domain/auth.go
@@ -82,7 +82,11 @@ const (
 	AdminResourceStatus  = "status"
 	AdminResourceLogs    = "logs"
 	AdminResourceVolumes = "volumes"
-	AdminResourceAll     = "*"
+	// AdminResourceApps gates the v2.50 app surface
+	// (docs/plans/v2.50.0/05-api-cli.md §4). Enforcement sites land
+	// at cutover with the admin handlers; the constant is frozen here.
+	AdminResourceApps = "apps"
+	AdminResourceAll  = "*"
 )
 
 // Admin scope action constants.
@@ -308,6 +312,11 @@ func AdminScopeLogs(actions ...string) string {
 // AdminScopeVolumes creates an admin scope for volumes with the given actions.
 func AdminScopeVolumes(actions ...string) string {
 	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceVolumes, strings.Join(actions, ","))
+}
+
+// AdminScopeApps creates an admin scope for apps with the given actions.
+func AdminScopeApps(actions ...string) string {
+	return fmt.Sprintf("%s:%s:%s", ScopeTypeAdmin, AdminResourceApps, strings.Join(actions, ","))
 }
 
 // AuthStatus represents status of an authentication session.


### PR DESCRIPTION
Preparation slice for the frozen 05-api-cli contract. Unreachable by construction: no handler wiring, no root.go registration, no deletions, no local writes.

- DTOs with frozen field names + versioned AppError envelope (legacy tolerated)
- Remote mutation client: Idempotency-Key on every mutation, OutcomeUnknown without replay, by-key recovery
- in.AppService driving port (domain types only); mock registered in .mockery.yaml for cutover generation
- AdminResourceApps scope constant + helper (no enforcement sites yet)
- Unregistered CLI: apps apply/list/show/diff/secrets, deploy/restart/stop/start/remove, logs, status; --json parity, sorted output, no secret values in output, daemon-unavailable without a daemon

Gate: go build + go vet + full go test suite green, golangci-lint clean on touched packages, race on touched packages.

Cutover owns: admin handlers + auth enforcement, local proxy plane, root.go registration, retired-command deletion, AppService mock generation.