### PR TITLE
feat(apps): ownership-aware prune guards and backup identity

### DIFF
--- a/internal/domain/backup.go
+++ b/internal/domain/backup.go
@@ -51,9 +51,15 @@ const (
 
 // DBInfo holds detected database information from an attachment container.
 type DBInfo struct {
-	Type        DBType
-	Version     string
-	Domain      string
+	Type    DBType
+	Version string
+	Domain  string
+	// App and Service carry the v2.50 app identity for backup targets
+	// resolved from the active record (attachment-free detection).
+	// Empty for domain-keyed (V2 attachment) detection; the backup
+	// naming/scheduling rewiring that prefers them lands at cutover.
+	App         string
+	Service     string
 	Name        string
 	Host        string
 	Port        int

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -76,6 +76,10 @@ var (
 	ErrAppImageUnresolvable       = errors.New("image reference unresolvable")
 	ErrAppSecretMissing           = errors.New("required app secret missing")
 	ErrAppUnmanagedImageVolume    = errors.New("image declares unmanaged volume")
+	// ErrPruneDisabled is the prune-disabled wire code
+	// (05-api-cli.md §3): prune paths fail closed while app state
+	// exists and ownership-aware protection is not yet wired in.
+	ErrPruneDisabled = errors.New("pruning disabled while app state exists")
 
 	// Environment errors
 	ErrEnvFileNotFound             = errors.New("environment file not found")

--- a/internal/domain/labels.go
+++ b/internal/domain/labels.go
@@ -15,6 +15,17 @@ const (
 	// exposing secret values.
 	LabelEnvHash = "gordon.env-hash"
 
+	// App ownership labels are stamped by the v2.50 deploy engine on every
+	// container and volume it creates (03-deployment.md §4A/B, frozen here
+	// so prune/backup guards can consume them before the engine activates).
+	// The engine wiring that stamps them lands at cutover; until then no
+	// live resource carries them and guards treat their absence on a
+	// managed resource as legacy/unknown provenance (never prune-eligible
+	// once app state exists).
+	LabelApp         = "gordon.app"
+	LabelAppService  = "gordon.app.service"
+	LabelAppRevision = "gordon.app.revision"
+
 	// Standalone service labels identify Gordon-managed L4 service containers.
 	LabelService                       = "gordon.service"
 	LabelServiceName                   = "gordon.service.name"

--- a/internal/usecase/backup/app_identity.go
+++ b/internal/usecase/backup/app_identity.go
@@ -1,0 +1,87 @@
+package backup
+
+// App-identity backup targets (04-network.md §8.3 preparation).
+//
+// The live DetectDatabases path resolves targets through domain-keyed
+// attachments (containerSvc.ListAttachments). That coupling dies at
+// cutover with the attachments family; backups must already resolve the
+// same databases from the app ACTIVE record instead. This file is that
+// adaptation, preparation form: pure detection over service descriptors
+// plus app identity on the resulting DBInfo.
+//
+// Unwired until cutover: the service method that enumerates ACTIVE
+// services per app and the backup naming/scheduling rewiring that
+// prefers (app, service) over domain land with the handlers. The
+// detection RULES are shared with the attachment path (same helpers),
+// so parity is structural, not coincidental.
+
+import (
+	"strings"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// AppDatabaseSource describes one running service from the app ACTIVE
+// record: the fields backup detection needs, without attachments.
+type AppDatabaseSource struct {
+	App         string
+	Service     string
+	Name        string
+	Image       string
+	ContainerID string
+	Ports       []int
+}
+
+// DetectAppDatabases inspects app service descriptors and returns the
+// detected databases. Rules mirror detectDatabaseFromAttachment; the
+// resulting DBInfo carries App/Service identity and leaves Domain empty
+// (domain-keyed callers are untouched until the cutover rewiring).
+func DetectAppDatabases(sources []AppDatabaseSource) []domain.DBInfo {
+	dbs := make([]domain.DBInfo, 0, len(sources))
+	for _, source := range sources {
+		if db, ok := detectDatabaseFromAppSource(source); ok {
+			dbs = append(dbs, db)
+		}
+	}
+	return dbs
+}
+
+func detectDatabaseFromAppSource(source AppDatabaseSource) (domain.DBInfo, bool) {
+	image := strings.ToLower(source.Image)
+	name := strings.ToLower(source.Name)
+
+	switch {
+	case looksLikePostgres(image) || looksLikePostgres(name):
+		return buildAppPostgresInfo(source), true
+	case hasPort(source.Ports, 5432):
+		// Port 5432 fallback: likely PostgreSQL even with non-standard naming.
+		return buildAppPostgresInfo(source), true
+	default:
+		return domain.DBInfo{}, false
+	}
+}
+
+func buildAppPostgresInfo(source AppDatabaseSource) domain.DBInfo {
+	port := 5432
+	for _, p := range source.Ports {
+		if p == 5432 {
+			port = 5432
+			break
+		}
+		if p > 0 && port == 5432 {
+			port = p
+		}
+	}
+
+	return domain.DBInfo{
+		Type:        domain.DBTypePostgreSQL,
+		Version:     postgresVersionFromImage(source.Image),
+		App:         source.App,
+		Service:     source.Service,
+		Name:        source.Name,
+		Host:        source.Name,
+		Port:        port,
+		ContainerID: source.ContainerID,
+		ImageName:   source.Image,
+	}
+}

--- a/internal/usecase/backup/app_identity_test.go
+++ b/internal/usecase/backup/app_identity_test.go
@@ -1,0 +1,61 @@
+package backup
+
+// Tests for attachment-free (app-identity) database detection: the same
+// fixtures must resolve through the ACTIVE-record path and the legacy
+// attachment path with identical database fields, differing only in
+// identity (App/Service vs Domain).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestDetectAppDatabases_ParityWithAttachmentPath(t *testing.T) {
+	attachments := []domain.Attachment{
+		{Name: "db", Image: "postgres:16", ContainerID: "ctr-db", Ports: []int{5432}},
+		{Name: "cache", Image: "redis:7", ContainerID: "ctr-cache", Ports: []int{6379}},
+		{Name: "legacy", Image: "myregistry/custom:1", ContainerID: "ctr-legacy", Ports: []int{5432}},
+	}
+	sources := []AppDatabaseSource{
+		{App: "blog", Service: "db", Name: "db", Image: "postgres:16", ContainerID: "ctr-db", Ports: []int{5432}},
+		{App: "blog", Service: "cache", Name: "cache", Image: "redis:7", ContainerID: "ctr-cache", Ports: []int{6379}},
+		{App: "blog", Service: "legacy", Name: "legacy", Image: "myregistry/custom:1", ContainerID: "ctr-legacy", Ports: []int{5432}},
+	}
+
+	var viaAttachments []domain.DBInfo
+	for _, a := range attachments {
+		if db, ok := detectDatabaseFromAttachment("blog.example.com", a); ok {
+			viaAttachments = append(viaAttachments, db)
+		}
+	}
+	viaApps := DetectAppDatabases(sources)
+
+	require.Len(t, viaAttachments, 2)
+	require.Len(t, viaApps, 2, "same rules, no attachments involved")
+	for i := range viaApps {
+		assert.Equal(t, viaAttachments[i].Type, viaApps[i].Type)
+		assert.Equal(t, viaAttachments[i].Version, viaApps[i].Version)
+		assert.Equal(t, viaAttachments[i].Name, viaApps[i].Name)
+		assert.Equal(t, viaAttachments[i].Host, viaApps[i].Host)
+		assert.Equal(t, viaAttachments[i].Port, viaApps[i].Port)
+		assert.Equal(t, viaAttachments[i].ContainerID, viaApps[i].ContainerID)
+		assert.Equal(t, viaAttachments[i].ImageName, viaApps[i].ImageName)
+	}
+
+	assert.Equal(t, "blog", viaApps[0].App)
+	assert.Equal(t, "db", viaApps[0].Service)
+	assert.Empty(t, viaApps[0].Domain, "domain stays empty until the cutover rewiring")
+	assert.Equal(t, "16", viaApps[0].Version)
+	assert.Equal(t, "legacy", viaApps[1].Service, "5432 fallback works without attachments")
+}
+
+func TestDetectAppDatabases_Empty(t *testing.T) {
+	assert.Empty(t, DetectAppDatabases(nil))
+	assert.Empty(t, DetectAppDatabases([]AppDatabaseSource{
+		{App: "blog", Service: "web", Name: "web", Image: "blog:latest"},
+	}))
+}

--- a/internal/usecase/pruneguard/guard.go
+++ b/internal/usecase/pruneguard/guard.go
@@ -1,0 +1,144 @@
+// Package pruneguard holds the ownership-aware prune decisions frozen by
+// docs/plans/v2.50.0/04-network.md §8 and 03-deployment.md §9.
+//
+// PREPARATION: every function here is pure — inputs in, verdicts out, no
+// store reads, no runtime calls. The live wiring (volumes Service,
+// images Service, prune scheduler consulting AppState; handlers mapping
+// ErrPruneDisabled to 409 + {"error":"prune-disabled"}) lands at cutover.
+// Until then these decisions are exercised by tests only, which is what
+// keeps them referenced.
+//
+// Fail-closed order: in-use and unmanaged resources are never eligible;
+// app-owned resources are never eligible (the engine never deletes
+// volumes; remove retains them as orphans); legacy managed-label
+// resources (unknown / old-V2 provenance) are never eligible once ANY
+// app state exists; image prune fails closed on pinned or unknown
+// content and on any candidate the protected set covers.
+package pruneguard
+
+import (
+	"fmt"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+// VolumesPruneAllowed is the operation-level gate for PruneVolumes: while
+// ANY app state exists the operation disables itself with the frozen
+// prune-disabled code instead of guessing provenance.
+func VolumesPruneAllowed(appStateExists bool) error {
+	if appStateExists {
+		return fmt.Errorf("%w: volume prune refuses to run while app state exists", domain.ErrPruneDisabled)
+	}
+	return nil
+}
+
+// ImagePruneSchedulerAllowed is the operation-level gate for the image
+// prune scheduler: disabled while ANY app state exists.
+func ImagePruneSchedulerAllowed(appStateExists bool) error {
+	if appStateExists {
+		return fmt.Errorf("%w: image prune scheduler refuses to run while app state exists", domain.ErrPruneDisabled)
+	}
+	return nil
+}
+
+// VolumeProvenance classifies one volume's label set.
+type VolumeProvenance int
+
+const (
+	// ProvenanceUnmanaged is not Gordon-managed (or no labels at all).
+	ProvenanceUnmanaged VolumeProvenance = iota
+	// ProvenanceLegacyManaged carries the managed label but no app
+	// ownership labels: the unknown / old-V2 class. Never implicitly
+	// eligible once app state exists.
+	ProvenanceLegacyManaged
+	// ProvenanceAppOwned carries engine-stamped app ownership labels.
+	// Never prune-eligible: volumes are never deleted.
+	ProvenanceAppOwned
+)
+
+// ClassifyVolume maps a volume label set to its provenance.
+func ClassifyVolume(labels map[string]string) VolumeProvenance {
+	if labels == nil || labels[domain.LabelManaged] != "true" {
+		return ProvenanceUnmanaged
+	}
+	if labels[domain.LabelApp] != "" {
+		return ProvenanceAppOwned
+	}
+	return ProvenanceLegacyManaged
+}
+
+// VolumePruneEligible renders the per-volume verdict. inUse and runtime
+// state arrive as arguments so the decision stays pure; callers pass the
+// live values at cutover.
+func VolumePruneEligible(provenance VolumeProvenance, inUse, appStateExists bool) (bool, string) {
+	if inUse {
+		return false, "in-use"
+	}
+	switch provenance {
+	case ProvenanceAppOwned:
+		return false, "app-owned: volumes are never deleted"
+	case ProvenanceLegacyManaged:
+		if appStateExists {
+			return false, "prune-disabled: legacy managed volume while app state exists"
+		}
+		return true, "legacy-managed with no app state"
+	default:
+		return false, "not gordon-managed"
+	}
+}
+
+// ImageCandidate is one prune candidate described by identity only.
+type ImageCandidate struct {
+	// Digest is the content digest (sha256:…); empty means unknown.
+	Digest string
+	Tags   []string
+	// Pinned marks registry pinned indexes/manifests and any content
+	// the operator pinned: never eligible.
+	Pinned bool
+}
+
+// ProtectedImageSet unions the digest sets prune must never touch:
+// active definitions of running and stopped apps, in-flight op digests,
+// and registry pinned indexes/manifests plus their referenced content.
+// Callers build each set from AppState/registry state at cutover.
+func ProtectedImageSet(sets ...[]string) map[string]struct{} {
+	protected := make(map[string]struct{})
+	for _, set := range sets {
+		for _, digest := range set {
+			if digest != "" {
+				protected[digest] = struct{}{}
+			}
+		}
+	}
+	return protected
+}
+
+// PartitionImageCandidates splits candidates into safe-to-prune and
+// blocked. Blocked covers pinned content, unknown (digest-less)
+// content, and anything the protected set covers.
+func PartitionImageCandidates(candidates []ImageCandidate, protected map[string]struct{}) (safe, blocked []ImageCandidate) {
+	for _, c := range candidates {
+		if c.Pinned || c.Digest == "" {
+			blocked = append(blocked, c)
+			continue
+		}
+		if _, ok := protected[c.Digest]; ok {
+			blocked = append(blocked, c)
+			continue
+		}
+		safe = append(safe, c)
+	}
+	return safe, blocked
+}
+
+// CheckManualImagePrune fails the whole manual prune closed when ANY
+// candidate is blocked: pinned/unknown/protected content refuses the
+// operation instead of pruning around it.
+func CheckManualImagePrune(candidates []ImageCandidate, protected map[string]struct{}) error {
+	_, blocked := PartitionImageCandidates(candidates, protected)
+	if len(blocked) > 0 {
+		return fmt.Errorf("%w: %d image candidate(s) are pinned, unknown, or protected",
+			domain.ErrPruneDisabled, len(blocked))
+	}
+	return nil
+}

--- a/internal/usecase/pruneguard/guard_test.go
+++ b/internal/usecase/pruneguard/guard_test.go
@@ -1,0 +1,109 @@
+package pruneguard
+
+// Tests for the §8 prune gates: operation-level disable while app state
+// exists, per-volume provenance verdicts, and fail-closed image pruning
+// over pinned/unknown/protected content.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bnema/gordon/internal/domain"
+)
+
+func TestVolumesPruneAllowed(t *testing.T) {
+	require.NoError(t, VolumesPruneAllowed(false))
+
+	err := VolumesPruneAllowed(true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrPruneDisabled)
+}
+
+func TestImagePruneSchedulerAllowed(t *testing.T) {
+	require.NoError(t, ImagePruneSchedulerAllowed(false))
+
+	err := ImagePruneSchedulerAllowed(true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrPruneDisabled)
+}
+
+func TestClassifyVolume(t *testing.T) {
+	assert.Equal(t, ProvenanceUnmanaged, ClassifyVolume(nil))
+	assert.Equal(t, ProvenanceUnmanaged, ClassifyVolume(map[string]string{}))
+	assert.Equal(t, ProvenanceUnmanaged, ClassifyVolume(map[string]string{domain.LabelManaged: "false"}))
+	assert.Equal(t, ProvenanceLegacyManaged, ClassifyVolume(map[string]string{domain.LabelManaged: "true"}))
+	assert.Equal(t, ProvenanceAppOwned, ClassifyVolume(map[string]string{
+		domain.LabelManaged: "true",
+		domain.LabelApp:     "blog",
+	}))
+}
+
+func TestVolumePruneEligible(t *testing.T) {
+	eligible, _ := VolumePruneEligible(ProvenanceLegacyManaged, true, false)
+	assert.False(t, eligible, "in-use volumes are never eligible")
+
+	eligible, _ = VolumePruneEligible(ProvenanceUnmanaged, false, false)
+	assert.False(t, eligible, "unmanaged volumes are never eligible")
+
+	eligible, reason := VolumePruneEligible(ProvenanceAppOwned, false, false)
+	assert.False(t, eligible, "app-owned volumes are never eligible")
+	assert.Contains(t, reason, "never deleted")
+
+	eligible, _ = VolumePruneEligible(ProvenanceLegacyManaged, false, true)
+	assert.False(t, eligible, "legacy managed volumes are never eligible while app state exists")
+
+	eligible, _ = VolumePruneEligible(ProvenanceLegacyManaged, false, false)
+	assert.True(t, eligible, "legacy behavior preserved only with no app state")
+
+	// App-owned stays ineligible even with no app state: volumes are
+	// never deleted, only retained as orphans.
+	eligible, _ = VolumePruneEligible(ProvenanceAppOwned, false, true)
+	assert.False(t, eligible)
+}
+
+func TestProtectedImageSet(t *testing.T) {
+	protected := ProtectedImageSet(
+		[]string{"sha256:active", "sha256:stopped"},
+		[]string{"sha256:inflight"},
+		[]string{"sha256:pinned", ""},
+	)
+	for _, digest := range []string{"sha256:active", "sha256:stopped", "sha256:inflight", "sha256:pinned"} {
+		assert.Contains(t, protected, digest)
+	}
+	assert.NotContains(t, protected, "")
+}
+
+func TestPartitionImageCandidates(t *testing.T) {
+	protected := ProtectedImageSet([]string{"sha256:active"})
+	candidates := []ImageCandidate{
+		{Digest: "sha256:stale", Tags: []string{"blog:old"}},
+		{Digest: "sha256:active", Tags: []string{"blog:current"}},
+		{Digest: "sha256:pinned-manifest", Pinned: true},
+		{Digest: ""},
+	}
+	safe, blocked := PartitionImageCandidates(candidates, protected)
+	require.Len(t, safe, 1)
+	assert.Equal(t, "sha256:stale", safe[0].Digest)
+	require.Len(t, blocked, 3, "protected, pinned, and unknown content all block")
+}
+
+func TestCheckManualImagePrune_FailsClosed(t *testing.T) {
+	require.NoError(t, CheckManualImagePrune(
+		[]ImageCandidate{{Digest: "sha256:stale"}},
+		ProtectedImageSet([]string{"sha256:active"}),
+	))
+
+	for _, candidates := range [][]ImageCandidate{
+		{{Digest: "sha256:active"}},
+		{{Digest: "sha256:x", Pinned: true}},
+		{{Digest: ""}},
+		{{Digest: "sha256:stale"}, {Digest: "sha256:active"}},
+	} {
+		err := CheckManualImagePrune(candidates, ProtectedImageSet([]string{"sha256:active"}))
+		require.Error(t, err, "candidates %v", candidates)
+		assert.True(t, errors.Is(err, domain.ErrPruneDisabled), "manual prune fails closed, never prunes around")
+	}
+}


### PR DESCRIPTION
Preparation slice for the frozen 04-network.md section 8 prerequisites. Pure and unwired: no service, scheduler, or handler changes.

- Frozen gordon.app / gordon.app.service / gordon.app.revision ownership labels (engine stamps them at cutover)
- prune-disabled sentinel (frozen wire code)
- pruneguard: operation gates (volumes prune + image scheduler disable while app state exists), volume provenance classification with per-volume verdicts, protected image-digest sets with fail-closed manual prune
- Backup identity: attachment-free DetectAppDatabases over ACTIVE-record descriptors with parity tests against the attachment path; App/Service fields on DBInfo (Domain untouched)

Gate: go build + vet + full suite (58 pkgs) green, race on touched packages, golangci-lint clean.

Cutover owns: consulting AppState in volumes/images services + scheduler, backup service enumeration + naming rewiring, 409 prune-disabled handler mapping.